### PR TITLE
fix: restore kubevirt for VM cleanup

### DIFF
--- a/clusters/dev/apps/kustomization.yaml
+++ b/clusters/dev/apps/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ../../../kubernetes/apps/kube-system/
   - ../../../kubernetes/apps/network-system/
   - ../../../kubernetes/apps/observability/
+  - ../../../kubernetes/apps/virtualization/
   - ./storage-system/

--- a/kubernetes/apps/virtualization/kubevirt/ks.yaml
+++ b/kubernetes/apps/virtualization/kubevirt/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubevirt
+spec:
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: virtualmachines.kubevirt.io
+  interval: 1h
+  path: ./deploy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubevirt-upstream
+    namespace: virtualization
+  targetNamespace: virtualization
+  wait: true

--- a/kubernetes/apps/virtualization/kubevirt/source.yaml
+++ b/kubernetes/apps/virtualization/kubevirt/source.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/gitrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: kubevirt-upstream
+spec:
+  interval: 1h
+  timeout: 2m
+  url: https://github.com/JJGadgets/kubevirt-flux
+  ref:
+    branch: v1.8.1

--- a/kubernetes/apps/virtualization/kustomization.yaml
+++ b/kubernetes/apps/virtualization/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: virtualization
+
+components:
+  - ../../components/cluster-values
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./kubevirt/source.yaml
+  - ./kubevirt/ks.yaml

--- a/kubernetes/apps/virtualization/namespace.yaml
+++ b/kubernetes/apps/virtualization/namespace.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary
- restore the dev virtualization app group with the minimal kubevirt source and Flux kustomization
- intentionally avoid reintroducing the NAS VM and CDI so kubevirt can come back just long enough to clean up the stuck VM
- keep this branch focused on live cleanup so the cluster can be pointed at it for temporary reconciliation