### PR TITLE
feat(observability): back up victoria-metrics with volsync

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -104,17 +104,20 @@ spec:
             - targetLabel: job
               replacement: kubelet
     vmsingle:
-      enabled: true
       spec:
         replicaCount: 1
         retentionPeriod: 14d
         storage:
           accessModes:
             - ReadWriteOnce
+          dataSourceRef:
+            apiGroup: volsync.backube
+            kind: ReplicationDestination
+            name: victoria-metrics-dst
           resources:
             requests:
-              storage: 10Gi
-          storageClassName: linstor-zfs-ssd-replicated
+              storage: 5Gi
+          storageClassName: ${APP_STORAGECLASS}
     vmagent:
       spec:
         resources:

--- a/kubernetes/apps/observability/victoria-metrics/ks.app.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/ks.app.yaml
@@ -8,8 +8,12 @@ spec:
   dependsOn:
     - name: cert-manager
       namespace: network-system
+    - name: external-secrets
+      namespace: external-secrets
     - name: grafana-operator
     - name: piraeus-operator
+      namespace: storage-system
+    - name: volsync
       namespace: storage-system
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-metrics/app
@@ -20,3 +24,12 @@ spec:
     namespace: flux-system
   targetNamespace: observability
   wait: true
+  components:
+    - ../../../../components/volsync-nopvc/
+  postBuild:
+    substitute:
+      APP: victoria-metrics
+      VOLSYNC_PVC: vmsingle-victoria-metrics
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_PUID: "0"
+      VOLSYNC_PGID: "0"

--- a/kubernetes/components/volsync-nopvc/kustomization.yaml
+++ b/kubernetes/components/volsync-nopvc/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+resources:
+  - ../volsync/external-secret.yaml
+  - ../volsync/replication-source.yaml
+  - ../volsync/replication-destination.yaml

--- a/kubernetes/components/volsync/kustomization.yaml
+++ b/kubernetes/components/volsync/kustomization.yaml
@@ -2,8 +2,8 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 
+components:
+  - ../volsync-nopvc
+
 resources:
-  - external-secret.yaml
-  - replication-source.yaml
-  - replication-destination.yaml
   - pvc.yaml


### PR DESCRIPTION
## Summary
- configure VictoriaMetrics to use a VolSync replication destination as the restore source for `VMSingle` storage
- add a `volsync-nopvc` component so workloads with existing PVCs can reuse the shared VolSync secret/source/destination resources without creating a managed restore PVC
- keep the manual VictoriaMetrics migration bootstrap outside Flux ownership; the initial backup has already been created successfully on-cluster