### PR TITLE
chore(skills): add VictoriaMetrics skill locks

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,6 +1,12 @@
 {
   "version": 1,
   "skills": {
+    "alertmanager-query": {
+      "source": "VictoriaMetrics/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/query/skills/alertmanager-query/SKILL.md",
+      "computedHash": "b5a7ad3ebf428aacbc481c47ec323896384ad9c0298794f7ab12e1d43b021345"
+    },
     "gitops-cluster-debug": {
       "source": "fluxcd/agent-skills",
       "sourceType": "github",
@@ -18,6 +24,48 @@
       "sourceType": "github",
       "skillPath": "skills/gitops-repo-audit/SKILL.md",
       "computedHash": "993332d18e70d52d438d0d44a8039427e7b44f2a43099e31efeeda788de26743"
+    },
+    "investigating-with-observability": {
+      "source": "VictoriaMetrics/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/diagnostics/skills/investigating-with-observability/SKILL.md",
+      "computedHash": "8b754801e3ad4c275849d90823e1dbcc3d5e6b3d096e50de6848452b6f4a0cf9"
+    },
+    "victorialogs-query": {
+      "source": "VictoriaMetrics/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/query/skills/victorialogs-query/SKILL.md",
+      "computedHash": "eb7115c1213aba9df1e55c993da63dbc3b934c3423a3895e1a441671823a40fc"
+    },
+    "victoriametrics-cardinality-analysis": {
+      "source": "VictoriaMetrics/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/diagnostics/skills/victoriametrics-cardinality-analysis/SKILL.md",
+      "computedHash": "0c2fc27ee18be14a63b0da82304bef162af2830334c2dfadc2cb52be6cd38410"
+    },
+    "victoriametrics-query": {
+      "source": "VictoriaMetrics/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/query/skills/victoriametrics-query/SKILL.md",
+      "computedHash": "d4cd5148fcc310d46158fb96f3b578ba46530711f2f490e678b74f0d589d883c"
+    },
+    "victoriametrics-unused-metrics-analysis": {
+      "source": "VictoriaMetrics/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/diagnostics/skills/victoriametrics-unused-metrics-analysis/SKILL.md",
+      "computedHash": "499b1a5dd2822c86aadc79f3975f34fd98f5d9d2d35199944f837fbafc3113d3"
+    },
+    "victoriatraces-query": {
+      "source": "VictoriaMetrics/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/query/skills/victoriatraces-query/SKILL.md",
+      "computedHash": "ac2fe50db0404e5fd4f019df1c67d9e4a69357932529a28abc52ea83fe6797a2"
+    },
+    "vm-trace-analyzer": {
+      "source": "VictoriaMetrics/skills",
+      "sourceType": "github",
+      "skillPath": "plugins/diagnostics/skills/vm-trace-analyzer/SKILL.md",
+      "computedHash": "c887db6fde4e89945d4de928592743235d68b95c11dea06a885bacdc3d1aa967"
     }
   }
 }


### PR DESCRIPTION
## Summary
- add the VictoriaMetrics query and diagnostics entries to `skills-lock.json`
- keep the repo's skill lock metadata in sync with the installed skills

## Verification
- lockfile update only