### PR TITLE
fix(storage): harden nfs server availability

### DIFF
--- a/kubernetes/apps/storage-system/nfs/app/deployment.yaml
+++ b/kubernetes/apps/storage-system/nfs/app/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app.kubernetes.io/name: nfs
     spec:
+      priorityClassName: nfs-storage-critical
       nodeSelector:
         kubernetes.io/hostname: talos0
       containers:
@@ -31,6 +32,20 @@ spec:
             - name: nfs
               containerPort: 2049
               protocol: TCP
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - showmount -e 127.0.0.1 2>/dev/null | grep -qE '^/nfsshare([[:space:]]|$)'
+          readinessProbe: &probe
+            tcpSocket:
+              port: nfs
+            periodSeconds: 5
+            timeoutSeconds: 1
+            failureThreshold: 2
+            successThreshold: 1
+          livenessProbe: *probe
           securityContext:
             privileged: true
           volumeMounts:

--- a/kubernetes/apps/storage-system/nfs/app/kustomization.yaml
+++ b/kubernetes/apps/storage-system/nfs/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./priority-class.yaml
   - ./deployment.yaml
   - ./service.yaml

--- a/kubernetes/apps/storage-system/nfs/app/priority-class.yaml
+++ b/kubernetes/apps/storage-system/nfs/app/priority-class.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: nfs-storage-critical
+value: 1000000
+globalDefault: false
+description: Prioritize the NFS server so it is evicted after normal workloads.


### PR DESCRIPTION
## Summary
- add a dedicated PriorityClass for the NFS server so it is evicted after normal workloads
- add startup, readiness, and liveness probes for the NFS pod
- make startup verify `/nfsshare` is actually exported before the pod is considered started

## Testing
- direnv exec . dagger call flux-local test
- direnv exec . dagger call flux-local test-build