### PR TITLE
Add PR workflow for Flux diffs

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -1,0 +1,148 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Flux Diff
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Flux Diff - Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+      clusters: ${{ steps.clusters.outputs.clusters }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for relevant changes
+        id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          head_sha="${{ github.event.pull_request.head.sha }}"
+
+          if git diff --name-only "$base_sha" "$head_sha" | grep -Eq '^(clusters/|kubernetes/|dagger/flux-local/|dagger.json|\.github/workflows/flux-diff\.yaml$)'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Discover clusters
+        id: clusters
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          import pathlib
+
+          clusters = sorted(
+              path.name
+              for path in pathlib.Path("clusters").iterdir()
+              if path.is_dir()
+          )
+
+          print(f"clusters={json.dumps(clusters)}")
+          PY
+
+  diff:
+    name: Flux Diff - ${{ matrix.cluster }} / ${{ matrix.kind }}
+    needs: prepare
+    if: ${{ needs.prepare.outputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        cluster: ${{ fromJson(needs.prepare.outputs.clusters) }}
+        kind:
+          - ks
+          - hr
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare CI env file
+        run: cp .env.gha .env
+
+      - name: Install Dagger
+        uses: dagger/dagger-for-github@v8.4.0
+        with:
+          version: latest
+          dagger-flags: --progress=logs
+          call: flux-local version
+
+      - name: Prepare PR comment
+        id: diff
+        shell: bash
+        env:
+          CLUSTER_PATH: clusters/${{ matrix.cluster }}
+          KIND: ${{ matrix.kind }}
+        run: |
+          set -euo pipefail
+
+          comment_file="$(mktemp)"
+          output_file="$(mktemp)"
+          dagger call flux-local diff --kind "$KIND" --path "$CLUSTER_PATH" stdout > "$output_file"
+
+          if [[ -z "$(tr -d '[:space:]' < "$output_file")" ]]; then
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+            echo "comment_file=$comment_file" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          max_bytes=60000
+          output_bytes="$(wc -c < "$output_file")"
+
+          {
+            echo "## Flux diff"
+            echo
+            echo "- Cluster: \`$CLUSTER_PATH\`"
+            echo "- Kind: \`$KIND\`"
+            echo
+            echo '```diff'
+            head -c "$max_bytes" "$output_file"
+            if [[ "$output_bytes" -gt "$max_bytes" ]]; then
+              printf '\n\n... diff truncated at %s bytes ...\n' "$max_bytes"
+            fi
+            echo
+            echo '```'
+          } > "$comment_file"
+
+          echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          echo "comment_file=$comment_file" >> "$GITHUB_OUTPUT"
+
+      - name: Update PR comment
+        if: ${{ steps.diff.outputs.has_diff == 'true' }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: flux-diff/${{ matrix.cluster }}/${{ matrix.kind }}
+          path: ${{ steps.diff.outputs.comment_file }}
+          skip_unchanged: true
+
+      - name: Delete stale PR comment
+        if: ${{ steps.diff.outputs.has_diff == 'false' }}
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: flux-diff/${{ matrix.cluster }}/${{ matrix.kind }}
+          delete: true


### PR DESCRIPTION
## Summary
- add a dedicated PR workflow for Flux diffs
- discover clusters dynamically from `clusters/*`
- run `flux-local diff` for both `ks` and `hr`
- post one sticky PR comment per cluster/kind and delete it when the diff becomes empty

## Testing
- validated workflow YAML parses successfully
