### PR TITLE
fix(ci): restrict Flux diff workflow triggers

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - clusters/**
+      - kubernetes/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
@@ -19,28 +22,12 @@ jobs:
     name: Flux Diff - Prepare
     runs-on: ubuntu-latest
     outputs:
-      changed: ${{ steps.filter.outputs.changed }}
       clusters: ${{ steps.clusters.outputs.clusters }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-
-      - name: Check for relevant changes
-        id: filter
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          base_sha="${{ github.event.pull_request.base.sha }}"
-          head_sha="${{ github.event.pull_request.head.sha }}"
-
-          if git diff --name-only "$base_sha" "$head_sha" | grep -Eq '^(clusters/|kubernetes/|dagger/flux-local/|dagger.json|\.github/workflows/flux-diff\.yaml$)'; then
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-          fi
 
       - name: Discover clusters
         id: clusters
@@ -64,7 +51,6 @@ jobs:
   diff:
     name: Flux Diff - ${{ matrix.cluster }} / ${{ matrix.kind }}
     needs: prepare
-    if: ${{ needs.prepare.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- trigger the Flux diff workflow only for changes under `clusters/**` and `kubernetes/**`
- remove the now-redundant changed-files filter logic
- keep dynamic cluster discovery and the existing diff comment behavior

## Testing
- validated workflow YAML parses successfully
