### PR TITLE
Add actions-runner-controller

### DIFF
--- a/.github/workflows/dagger-checks.yaml
+++ b/.github/workflows/dagger-checks.yaml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   checks:
-    runs-on: ubuntu-latest
+    runs-on: home-ops
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -51,7 +51,9 @@ jobs:
   diff:
     name: Flux Diff - ${{ matrix.cluster }} / ${{ matrix.kind }}
     needs: prepare
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - home-ops
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -51,9 +51,7 @@ jobs:
   diff:
     name: Flux Diff - ${{ matrix.cluster }} / ${{ matrix.kind }}
     needs: prepare
-    runs-on:
-      - self-hosted
-      - home-ops
+    runs-on: home-ops
     permissions:
       contents: read
       pull-requests: write

--- a/clusters/dev/apps/kustomization.yaml
+++ b/clusters/dev/apps/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - ../../../kubernetes/apps/actions-runner-system/
   - ../../../kubernetes/apps/external-secrets/
   - ../../../kubernetes/apps/flux-system/
   - ../../../kubernetes/apps/kube-system/

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/helmrelease.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: actions-runner-controller
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: actions-runner-controller
+  interval: 1h
+  values:
+    flags:
+      logLevel: info
+      logFormat: json

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: actions-runner-controller
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.1
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set-controller

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: actions-runner-controller
+spec:
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: actions-runner-controller
+      namespace: actions-runner-system
+  interval: 1h
+  path: ./kubernetes/apps/actions-runner-system/actions-runner-controller/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: actions-runner-system
+  wait: true

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-ops-runner-auth
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: ${ONEPASSWORD_STORE}
+  target:
+    name: home-ops-runner-auth-secret
+    template:
+      data:
+        github_token: "{{ .FLUX_GITHUB_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: flux

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/externalsecret.yaml
@@ -12,7 +12,7 @@ spec:
     name: home-ops-runner-auth-secret
     template:
       data:
-        github_token: "{{ .FLUX_GITHUB_TOKEN }}"
+        github_token: "{{ .credential }}"
   dataFrom:
     - extract:
-        key: flux
+        key: "github-runner - ${CLUSTER_NAME}"

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: home-ops-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: home-ops-runner
+  interval: 1h
+  values:
+    githubConfigUrl: https://github.com/kid/home-ops
+    githubConfigSecret: home-ops-runner-auth-secret
+    runnerScaleSetName: home-ops
+    minRunners: 0
+    maxRunners: 2
+    scaleSetLabels:
+      - home-ops
+      - kubernetes
+    controllerServiceAccount:
+      namespace: actions-runner-system
+      name: actions-runner-controller-gha-rs-controller
+    containerMode:
+      type: dind
+    listenerTemplate:
+      spec:
+        tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoSchedule
+    template:
+      spec:
+        tolerations:
+          - key: node-role.kubernetes.io/control-plane
+            operator: Exists
+            effect: NoSchedule

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
@@ -14,7 +14,7 @@ spec:
     githubConfigSecret: home-ops-runner-auth-secret
     runnerScaleSetName: home-ops
     minRunners: 0
-    maxRunners: 2
+    maxRunners: 3
     scaleSetLabels:
       - home-ops
       - kubernetes

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
@@ -23,12 +23,6 @@ spec:
       name: actions-runner-controller-gha-rs-controller
     containerMode:
       type: dind
-    listenerTemplate:
-      spec:
-        tolerations:
-          - key: node-role.kubernetes.io/control-plane
-            operator: Exists
-            effect: NoSchedule
     template:
       spec:
         tolerations:

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: home-ops-runner
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.14.1
+  url: oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: home-ops-runner
+spec:
+  dependsOn:
+    - name: actions-runner-controller
+    - name: external-secrets
+      namespace: external-secrets
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: home-ops-runner
+      namespace: actions-runner-system
+  interval: 1h
+  path: ./kubernetes/apps/actions-runner-system/home-ops-runner/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: actions-runner-system
+  wait: true

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -11,3 +11,4 @@ components:
 resources:
   - ./namespace.yaml
   - ./actions-runner-controller/ks.yaml
+  - ./home-ops-runner/ks.yaml

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: actions-runner-system
+
+components:
+  - ../../components/cluster-values
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./actions-runner-controller/ks.yaml

--- a/kubernetes/apps/actions-runner-system/namespace.yaml
+++ b/kubernetes/apps/actions-runner-system/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/actions-runner-system/namespace.yaml
+++ b/kubernetes/apps/actions-runner-system/namespace.yaml
@@ -3,5 +3,9 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: _
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary
- add a new `actions-runner-system` app set for the dev cluster
- install the `gha-runner-scale-set-controller` chart via Flux
- include the app in `clusters/dev/apps/kustomization.yaml`

## Validation
- direnv exec . dagger call flux-local build --path clusters/dev --kind all export --path /tmp/dev.yaml
- direnv exec . dagger call flux-local test-build

## Notes
- controller only; no runner scale set yet
- PR created only, not deployed to the cluster