### PR TITLE
Add in-cluster Dagger engine for ARC runners

### DIFF
--- a/.github/workflows/dagger-checks.yaml
+++ b/.github/workflows/dagger-checks.yaml
@@ -1,3 +1,4 @@
+---
 name: Dagger Checks
 
 on:
@@ -15,6 +16,51 @@ jobs:
 
       - name: Prepare CI env file
         run: cp .env.gha .env
+
+      - name: Configure Dagger cluster runner
+        shell: bash
+        env:
+          DAGGER_NAMESPACE: actions-runner-system
+          DAGGER_ENGINE_LABEL_SELECTOR: name%3Ddagger-dagger-helm-engine
+        run: |
+          set -euo pipefail
+
+          token_file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          ca_file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+          if [[ ! -r "$token_file" ]]; then
+            echo "missing service account token at $token_file" >&2
+            exit 1
+          fi
+
+          api_server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS:-443}"
+          pods_json="$({
+            curl --fail --silent --show-error \
+              --cacert "$ca_file" \
+              -H "Authorization: Bearer $(< "$token_file")" \
+              "$api_server/api/v1/namespaces/$DAGGER_NAMESPACE/pods?labelSelector=$DAGGER_ENGINE_LABEL_SELECTOR"
+          })"
+
+          pod_name="$({
+            printf '%s' "$pods_json" | node -e '
+              let input = "";
+              process.stdin.on("data", (chunk) => (input += chunk));
+              process.stdin.on("end", () => {
+                const data = JSON.parse(input);
+                const pod =
+                  (data.items || []).find((item) => item.status?.phase === "Running") ||
+                  (data.items || [])[0];
+                if (!pod?.metadata?.name) {
+                  console.error("no dagger engine pod found");
+                  process.exit(1);
+                }
+                process.stdout.write(pod.metadata.name);
+              });
+            '
+          })"
+
+          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=kube-pod://$pod_name?namespace=$DAGGER_NAMESPACE" >> "$GITHUB_ENV"
+          echo "Using Dagger engine pod $pod_name in $DAGGER_NAMESPACE"
 
       - name: Run Dagger checks
         uses: dagger/checks@64525befa1c36dd55577dae083df5c8968d9325a # v1.1.0

--- a/.github/workflows/dagger-checks.yaml
+++ b/.github/workflows/dagger-checks.yaml
@@ -10,8 +10,6 @@ permissions:
 jobs:
   checks:
     runs-on: home-ops
-    container:
-      image: ghcr.io/actions/actions-runner:latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/dagger-checks.yaml
+++ b/.github/workflows/dagger-checks.yaml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   checks:
     runs-on: home-ops
+    container:
+      image: ghcr.io/actions/actions-runner:latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -19,48 +21,9 @@ jobs:
 
       - name: Configure Dagger cluster runner
         shell: bash
-        env:
-          DAGGER_NAMESPACE: actions-runner-system
-          DAGGER_ENGINE_LABEL_SELECTOR: name%3Ddagger-dagger-helm-engine
         run: |
-          set -euo pipefail
-
-          token_file=/var/run/secrets/kubernetes.io/serviceaccount/token
-          ca_file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-
-          if [[ ! -r "$token_file" ]]; then
-            echo "missing service account token at $token_file" >&2
-            exit 1
-          fi
-
-          api_server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS:-443}"
-          pods_json="$({
-            curl --fail --silent --show-error \
-              --cacert "$ca_file" \
-              -H "Authorization: Bearer $(< "$token_file")" \
-              "$api_server/api/v1/namespaces/$DAGGER_NAMESPACE/pods?labelSelector=$DAGGER_ENGINE_LABEL_SELECTOR"
-          })"
-
-          pod_name="$({
-            printf '%s' "$pods_json" | node -e '
-              let input = "";
-              process.stdin.on("data", (chunk) => (input += chunk));
-              process.stdin.on("end", () => {
-                const data = JSON.parse(input);
-                const pod =
-                  (data.items || []).find((item) => item.status?.phase === "Running") ||
-                  (data.items || [])[0];
-                if (!pod?.metadata?.name) {
-                  console.error("no dagger engine pod found");
-                  process.exit(1);
-                }
-                process.stdout.write(pod.metadata.name);
-              });
-            '
-          })"
-
-          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=kube-pod://$pod_name?namespace=$DAGGER_NAMESPACE" >> "$GITHUB_ENV"
-          echo "Using Dagger engine pod $pod_name in $DAGGER_NAMESPACE"
+          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=kube-pod://dagger-dagger-helm-engine-0?namespace=actions-runner-system" >> "$GITHUB_ENV"
+          echo "Using Dagger engine pod dagger-dagger-helm-engine-0 in actions-runner-system"
 
       - name: Run Dagger checks
         uses: dagger/checks@64525befa1c36dd55577dae083df5c8968d9325a # v1.1.0

--- a/.github/workflows/dagger-checks.yaml
+++ b/.github/workflows/dagger-checks.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Configure Dagger cluster runner
         shell: bash
         run: |
-          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=kube-pod://dagger-dagger-helm-engine-0?namespace=actions-runner-system" >> "$GITHUB_ENV"
-          echo "Using Dagger engine pod dagger-dagger-helm-engine-0 in actions-runner-system"
+          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=tcp://dagger.actions-runner-system.svc.cluster.local:1234" >> "$GITHUB_ENV"
+          echo "Using Dagger engine service dagger.actions-runner-system.svc.cluster.local:1234"
 
       - name: Run Dagger checks
         uses: dagger/checks@64525befa1c36dd55577dae083df5c8968d9325a # v1.1.0

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -52,8 +52,6 @@ jobs:
     name: Flux Diff - ${{ matrix.cluster }} / ${{ matrix.kind }}
     needs: prepare
     runs-on: home-ops
-    container:
-      image: ghcr.io/actions/actions-runner:latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -71,6 +71,51 @@ jobs:
       - name: Prepare CI env file
         run: cp .env.gha .env
 
+      - name: Configure Dagger cluster runner
+        shell: bash
+        env:
+          DAGGER_NAMESPACE: actions-runner-system
+          DAGGER_ENGINE_LABEL_SELECTOR: name%3Ddagger-dagger-helm-engine
+        run: |
+          set -euo pipefail
+
+          token_file=/var/run/secrets/kubernetes.io/serviceaccount/token
+          ca_file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+          if [[ ! -r "$token_file" ]]; then
+            echo "missing service account token at $token_file" >&2
+            exit 1
+          fi
+
+          api_server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS:-443}"
+          pods_json="$({
+            curl --fail --silent --show-error \
+              --cacert "$ca_file" \
+              -H "Authorization: Bearer $(< "$token_file")" \
+              "$api_server/api/v1/namespaces/$DAGGER_NAMESPACE/pods?labelSelector=$DAGGER_ENGINE_LABEL_SELECTOR"
+          })"
+
+          pod_name="$({
+            printf '%s' "$pods_json" | node -e '
+              let input = "";
+              process.stdin.on("data", (chunk) => (input += chunk));
+              process.stdin.on("end", () => {
+                const data = JSON.parse(input);
+                const pod =
+                  (data.items || []).find((item) => item.status?.phase === "Running") ||
+                  (data.items || [])[0];
+                if (!pod?.metadata?.name) {
+                  console.error("no dagger engine pod found");
+                  process.exit(1);
+                }
+                process.stdout.write(pod.metadata.name);
+              });
+            '
+          })"
+
+          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=kube-pod://$pod_name?namespace=$DAGGER_NAMESPACE" >> "$GITHUB_ENV"
+          echo "Using Dagger engine pod $pod_name in $DAGGER_NAMESPACE"
+
       - name: Install Dagger
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1
         with:

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -76,8 +76,8 @@ jobs:
       - name: Configure Dagger cluster runner
         shell: bash
         run: |
-          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=kube-pod://dagger-dagger-helm-engine-0?namespace=actions-runner-system" >> "$GITHUB_ENV"
-          echo "Using Dagger engine pod dagger-dagger-helm-engine-0 in actions-runner-system"
+          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=tcp://dagger.actions-runner-system.svc.cluster.local:1234" >> "$GITHUB_ENV"
+          echo "Using Dagger engine service dagger.actions-runner-system.svc.cluster.local:1234"
 
       - name: Install Dagger
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1

--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -52,6 +52,8 @@ jobs:
     name: Flux Diff - ${{ matrix.cluster }} / ${{ matrix.kind }}
     needs: prepare
     runs-on: home-ops
+    container:
+      image: ghcr.io/actions/actions-runner:latest
     permissions:
       contents: read
       pull-requests: write
@@ -73,48 +75,9 @@ jobs:
 
       - name: Configure Dagger cluster runner
         shell: bash
-        env:
-          DAGGER_NAMESPACE: actions-runner-system
-          DAGGER_ENGINE_LABEL_SELECTOR: name%3Ddagger-dagger-helm-engine
         run: |
-          set -euo pipefail
-
-          token_file=/var/run/secrets/kubernetes.io/serviceaccount/token
-          ca_file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-
-          if [[ ! -r "$token_file" ]]; then
-            echo "missing service account token at $token_file" >&2
-            exit 1
-          fi
-
-          api_server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS:-443}"
-          pods_json="$({
-            curl --fail --silent --show-error \
-              --cacert "$ca_file" \
-              -H "Authorization: Bearer $(< "$token_file")" \
-              "$api_server/api/v1/namespaces/$DAGGER_NAMESPACE/pods?labelSelector=$DAGGER_ENGINE_LABEL_SELECTOR"
-          })"
-
-          pod_name="$({
-            printf '%s' "$pods_json" | node -e '
-              let input = "";
-              process.stdin.on("data", (chunk) => (input += chunk));
-              process.stdin.on("end", () => {
-                const data = JSON.parse(input);
-                const pod =
-                  (data.items || []).find((item) => item.status?.phase === "Running") ||
-                  (data.items || [])[0];
-                if (!pod?.metadata?.name) {
-                  console.error("no dagger engine pod found");
-                  process.exit(1);
-                }
-                process.stdout.write(pod.metadata.name);
-              });
-            '
-          })"
-
-          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=kube-pod://$pod_name?namespace=$DAGGER_NAMESPACE" >> "$GITHUB_ENV"
-          echo "Using Dagger engine pod $pod_name in $DAGGER_NAMESPACE"
+          echo "_EXPERIMENTAL_DAGGER_RUNNER_HOST=kube-pod://dagger-dagger-helm-engine-0?namespace=actions-runner-system" >> "$GITHUB_ENV"
+          echo "Using Dagger engine pod dagger-dagger-helm-engine-0 in actions-runner-system"
 
       - name: Install Dagger
         uses: dagger/dagger-for-github@27b130bf0f79a7f6fbbbe0fbca6760dc9bb40a77 # v8.4.1

--- a/kubernetes/apps/actions-runner-system/dagger/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/dagger/app/helmrelease.yaml
@@ -14,6 +14,20 @@ spec:
       kind: StatefulSet
       newServiceAccount:
         create: true
+      statefulSet:
+        persistentVolumeClaim:
+          enabled: true
+          storageClassName: ${APP_STORAGECLASS}
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 20Gi
+      hostPath:
+        dataVolume:
+          enabled: false
+        runVolume:
+          enabled: false
       tolerations:
         - key: node-role.kubernetes.io/control-plane
           operator: Exists

--- a/kubernetes/apps/actions-runner-system/dagger/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/dagger/app/helmrelease.yaml
@@ -12,6 +12,7 @@ spec:
   values:
     engine:
       kind: StatefulSet
+      port: 1234
       newServiceAccount:
         create: true
       statefulSet:

--- a/kubernetes/apps/actions-runner-system/dagger/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/dagger/app/helmrelease.yaml
@@ -11,6 +11,7 @@ spec:
   interval: 1h
   values:
     engine:
+      kind: StatefulSet
       newServiceAccount:
         create: true
       tolerations:

--- a/kubernetes/apps/actions-runner-system/dagger/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/dagger/app/helmrelease.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dagger
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: dagger
+  interval: 1h
+  values:
+    engine:
+      newServiceAccount:
+        create: true
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      resources:
+        requests:
+          cpu: 250m
+          memory: 512Mi

--- a/kubernetes/apps/actions-runner-system/dagger/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/dagger/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/actions-runner-system/dagger/app/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/dagger/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
+  - ./service.yaml

--- a/kubernetes/apps/actions-runner-system/dagger/app/ocirepository.yaml
+++ b/kubernetes/apps/actions-runner-system/dagger/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dagger
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.20.8
+  url: oci://registry.dagger.io/dagger-helm

--- a/kubernetes/apps/actions-runner-system/dagger/app/service.yaml
+++ b/kubernetes/apps/actions-runner-system/dagger/app/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dagger
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: dagger.${INTERNAL_DOMAIN}
+spec:
+  type: LoadBalancer
+  selector:
+    name: dagger-dagger-helm-engine
+  ports:
+    - name: dagger
+      port: 1234
+      targetPort: 1234
+      protocol: TCP

--- a/kubernetes/apps/actions-runner-system/dagger/ks.yaml
+++ b/kubernetes/apps/actions-runner-system/dagger/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dagger
+spec:
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: dagger
+      namespace: actions-runner-system
+  interval: 1h
+  path: ./kubernetes/apps/actions-runner-system/dagger/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: actions-runner-system
+  wait: true

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
       kubernetesModeWorkVolumeClaim:
         accessModes:
           - ReadWriteOnce
-        storageClassName: ${APP_STORAGECLASS}
+        storageClassName: openebs-hostpath
         resources:
           requests:
             storage: 10Gi
@@ -41,21 +41,17 @@ spec:
             - get
     template:
       spec:
+        containers:
+          - name: runner
+            image: ghcr.io/home-operations/actions-runner:2.334.0@sha256:95d91d7f8d241e319ef2f4fec08f417aa1606b96fbb327643f75c303acd30002
+            command:
+              - /home/runner/run.sh
+            env:
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
         securityContext:
           fsGroup: 1001
           fsGroupChangePolicy: OnRootMismatch
-        initContainers:
-          - name: init-workdir-perms
-            image: busybox:1.36
-            command:
-              - sh
-              - -lc
-              - mkdir -p /home/runner/_work/_tool && chown -R 1001:1001 /home/runner/_work
-            securityContext:
-              runAsUser: 0
-            volumeMounts:
-              - name: work
-                mountPath: /home/runner/_work
         tolerations:
           - key: node-role.kubernetes.io/control-plane
             operator: Exists

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
@@ -41,6 +41,21 @@ spec:
             - get
     template:
       spec:
+        securityContext:
+          fsGroup: 1001
+          fsGroupChangePolicy: OnRootMismatch
+        initContainers:
+          - name: init-workdir-perms
+            image: busybox:1.36
+            command:
+              - sh
+              - -lc
+              - mkdir -p /home/runner/_work/_tool && chown -R 1001:1001 /home/runner/_work
+            securityContext:
+              runAsUser: 0
+            volumeMounts:
+              - name: work
+                mountPath: /home/runner/_work
         tolerations:
           - key: node-role.kubernetes.io/control-plane
             operator: Exists

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
@@ -30,15 +30,6 @@ spec:
         resources:
           requests:
             storage: 10Gi
-      kubernetesModeAdditionalRoleRules:
-        - apiGroups:
-            - ""
-          resources:
-            - pods/attach
-            - pods/portforward
-          verbs:
-            - create
-            - get
     template:
       spec:
         containers:

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
@@ -22,7 +22,23 @@ spec:
       namespace: actions-runner-system
       name: actions-runner-controller-gha-rs-controller
     containerMode:
-      type: dind
+      type: kubernetes
+      kubernetesModeWorkVolumeClaim:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: ${APP_STORAGECLASS}
+        resources:
+          requests:
+            storage: 10Gi
+      kubernetesModeAdditionalRoleRules:
+        - apiGroups:
+            - ""
+          resources:
+            - pods/attach
+            - pods/portforward
+          verbs:
+            - create
+            - get
     template:
       spec:
         tolerations:

--- a/kubernetes/apps/actions-runner-system/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/kustomization.yaml
@@ -11,4 +11,5 @@ components:
 resources:
   - ./namespace.yaml
   - ./actions-runner-controller/ks.yaml
+  - ./dagger/ks.yaml
   - ./home-ops-runner/ks.yaml


### PR DESCRIPTION
## Summary
- deploy the Dagger Helm chart in `actions-runner-system`
- switch the ARC runner scale set to Kubernetes container mode
- point the GitHub Actions workflows at the in-cluster Dagger engine pod

## Validation
- `direnv exec . dagger call flux-local build --path clusters/dev --kind all export --path /tmp/dev-cluster.yaml`
