### PR TITLE
feat(clonarr): add app to media stack

### DIFF
--- a/kubernetes/apps/media/clonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/clonarr/app/helmrelease.yaml
@@ -1,0 +1,92 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: clonarr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: clonarr
+  interval: 1h
+  values:
+    controllers:
+      clonarr:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/prophetse7en/clonarr
+              tag: v2.5.9@sha256:7541c15ad2400553e03ed2897ac79affb20bb622e9d2d8c296581c8ff0bd729b
+            command:
+              - /usr/local/bin/clonarr
+            env:
+              PORT: &port 6060
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  periodSeconds: 30
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 5
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *port
+                  failureThreshold: 30
+                  periodSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - clonarr.${APP_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network-system
+    persistence:
+      config:
+        existingClaim: clonarr
+        globalMounts:
+          - path: /config
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/media/clonarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/clonarr/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/media/clonarr/app/ocirepository.yaml
+++ b/kubernetes/apps/media/clonarr/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: clonarr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/media/clonarr/ks.yaml
+++ b/kubernetes/apps/media/clonarr/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: clonarr
+spec:
+  dependsOn:
+    - name: volsync
+      namespace: storage-system
+  interval: 1h
+  path: ./kubernetes/apps/media/clonarr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: media
+  wait: false
+  components:
+    - ../../../../components/volsync/
+  postBuild:
+    substitute:
+      APP: clonarr
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_PUID: "1000"
+      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -10,6 +10,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./clonarr/ks.yaml
   - ./sonarr/ks.yaml
   - ./radarr/ks.yaml
   - ./prowlarr/ks.yaml


### PR DESCRIPTION
## Summary
- add Clonarr under `kubernetes/apps/media/clonarr`
- expose it at `clonarr.${APP_DOMAIN}` via `envoy-internal`
- provision persistent config storage using the existing VolSync component

## Notes
- runs `clonarr` directly instead of the upstream entrypoint so the pod can stay non-root
- uses `/api/health` for startup, readiness, and liveness probes

## Validation
- `kustomize build kubernetes/apps/media`
- `helm template` against `ghcr.io/bjw-s-labs/helm/app-template:5.0.1`