### PR TITLE
fix(observability): increase VictoriaMetrics PVC in dev

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -382,7 +382,7 @@ spec:
             name: victoria-metrics-dst
           resources:
             requests:
-              storage: 5Gi
+              storage: 10Gi
           storageClassName: ${APP_STORAGECLASS}
     vmagent:
       spec:


### PR DESCRIPTION
## Summary
- increase the dev VictoriaMetrics vmsingle PVC request from 5Gi to 10Gi
- keep retention at 14d

## Why
- `FluxInstanceAbsent` was a symptom of observability ingestion failing, not Flux being down
- VictoriaMetrics entered read-only mode because the vmsingle volume was nearly full
- increasing the PVC should restore remote write ingestion and allow the stale alerts to clear after reconciliation

## Validation
- confirmed `flux_instance_info` exists on the `flux-operator` metrics endpoint
- confirmed vmagent was scraping `flux-operator` successfully
- confirmed `vmsingle` reported `vm_storage_is_read_only=1` with free space below `storage.minFreeDiskSpaceBytes`
