### PR TITLE
feat(observability): expand Alloy to Kubernetes pod logs

### DIFF
--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -201,7 +201,8 @@ data:
     }
 
     otelcol.processor.k8sattributes "kubernetes" {
-      auth_type = "serviceAccount"
+      auth_type         = "serviceAccount"
+      wait_for_metadata = true
 
       extract {
         metadata = [

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -205,6 +205,8 @@ data:
           "k8s.pod.ip",
           "k8s.node.name",
         ]
+
+        otel_annotations = true
       }
 
       pod_association {

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -177,6 +177,8 @@ data:
           "k8s.statefulset.name",
           "k8s.job.name",
           "k8s.cronjob.name",
+          "service.name",
+          "service.namespace",
         ]
 
         otel_annotations = true

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -159,42 +159,6 @@ data:
         action = "upsert"
       }
 
-      action {
-        key            = "alloy.k8s.pod.uid"
-        from_attribute = "pod_uid"
-        action         = "upsert"
-      }
-
-      action {
-        key    = "pod_name"
-        action = "delete"
-      }
-
-      action {
-        key    = "pod_namespace"
-        action = "delete"
-      }
-
-      action {
-        key    = "container_name"
-        action = "delete"
-      }
-
-      action {
-        key    = "pod_uid"
-        action = "delete"
-      }
-
-      action {
-        key    = "restart_count"
-        action = "delete"
-      }
-
-      action {
-        key    = "log.file.path"
-        action = "delete"
-      }
-
       output {
         logs = [otelcol.processor.k8sattributes.kubernetes.input]
       }
@@ -223,8 +187,8 @@ data:
 
       pod_association {
         source {
-          from = "resource_attribute"
-          name = "alloy.k8s.pod.uid"
+          from = "attribute"
+          name = "pod_uid"
         }
       }
 
@@ -239,7 +203,12 @@ data:
       log_statements {
         context = "log"
         statements = [
-          "delete_key(attributes, \"alloy.k8s.pod.uid\")",
+          "delete_key(attributes, \"pod_name\")",
+          "delete_key(attributes, \"pod_namespace\")",
+          "delete_key(attributes, \"container_name\")",
+          "delete_key(attributes, \"pod_uid\")",
+          "delete_key(attributes, \"restart_count\")",
+          "delete_key(attributes, \"log.file.path\")",
           "delete_key(attributes, \"k8s.pod.uid\")",
         ]
       }
@@ -247,7 +216,6 @@ data:
       log_statements {
         context = "resource"
         statements = [
-          "delete_key(attributes, \"alloy.k8s.pod.uid\")",
           "delete_key(attributes, \"k8s.pod.uid\")",
         ]
       }

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -133,7 +133,7 @@ data:
       log_statements {
         context = "log"
         statements = [
-          "merge_maps(attributes, ParseJSON(body), \"upsert\") where IsMatch(body, \"^\\s*\\{\")",
+          "merge_maps(attributes, ParseJSON(body), \"upsert\") where Substring(body, 0, 1) == \"{\"",
           "set(body, attributes[\"message\"]) where attributes[\"message\"] != nil",
           "set(body, attributes[\"msg\"]) where attributes[\"message\"] == nil and attributes[\"msg\"] != nil",
           "set(body, attributes[\"log\"]) where attributes[\"message\"] == nil and attributes[\"msg\"] == nil and attributes[\"log\"] != nil",

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -190,39 +190,9 @@ data:
       }
 
       action {
-        key            = "k8s.namespace.name"
-        from_attribute = "pod_namespace"
-        action         = "upsert"
-      }
-
-      action {
-        key            = "k8s.pod.name"
-        from_attribute = "pod_name"
-        action         = "upsert"
-      }
-
-      action {
         key            = "k8s.pod.uid"
         from_attribute = "pod_uid"
         action         = "upsert"
-      }
-
-      action {
-        key            = "k8s.container.name"
-        from_attribute = "container_name"
-        action         = "upsert"
-      }
-
-      action {
-        key    = "k8s.node.name"
-        value  = sys.env("ALLOY_NODE_NAME")
-        action = "upsert"
-      }
-
-      action {
-        key    = "k8s.cluster.name"
-        value  = "${CLUSTER_NAME}"
-        action = "upsert"
       }
 
       action {
@@ -271,12 +241,6 @@ data:
           "k8s.pod.ip",
           "k8s.node.name",
         ]
-
-        label {
-          from      = "pod"
-          key_regex = "(.*)"
-          tag_name  = "kubernetes.pod_labels.$1"
-        }
       }
 
       pod_association {
@@ -299,6 +263,52 @@ data:
         statements = [
           "set(attributes[\"kubernetes.pod_ip\"], resource.attributes[\"k8s.pod.ip\"]) where resource.attributes[\"k8s.pod.ip\"] != nil",
         ]
+      }
+
+      output {
+        logs = [otelcol.processor.attributes.kubernetes_cleanup.input]
+      }
+    }
+
+    otelcol.processor.attributes "kubernetes_cleanup" {
+      action {
+        key    = "k8s.namespace.name"
+        action = "delete"
+      }
+
+      action {
+        key    = "k8s.pod.name"
+        action = "delete"
+      }
+
+      action {
+        key    = "k8s.pod.uid"
+        action = "delete"
+      }
+
+      action {
+        key    = "k8s.pod.ip"
+        action = "delete"
+      }
+
+      action {
+        key    = "k8s.node.name"
+        action = "delete"
+      }
+
+      action {
+        key    = "k8s.cluster.name"
+        action = "delete"
+      }
+
+      action {
+        key    = "k8s.container.name"
+        action = "delete"
+      }
+
+      action {
+        key    = "k8s.container.restart_count"
+        action = "delete"
       }
 
       output {

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -142,24 +142,6 @@ data:
       }
 
       output {
-        logs = [otelcol.processor.attributes.kubernetes_logs.input]
-      }
-    }
-
-    otelcol.processor.attributes "kubernetes_logs" {
-      action {
-        key    = "k8s.cluster.name"
-        value  = "${CLUSTER_NAME}"
-        action = "upsert"
-      }
-
-      action {
-        key    = "log.source"
-        value  = "kubernetes"
-        action = "upsert"
-      }
-
-      output {
         logs = [otelcol.processor.k8sattributes.kubernetes.input]
       }
     }
@@ -203,6 +185,7 @@ data:
       log_statements {
         context = "log"
         statements = [
+          "set(attributes[\"log.source\"], \"kubernetes\")",
           "delete_key(attributes, \"pod_name\")",
           "delete_key(attributes, \"pod_namespace\")",
           "delete_key(attributes, \"container_name\")",
@@ -216,6 +199,7 @@ data:
       log_statements {
         context = "resource"
         statements = [
+          "set(attributes[\"k8s.cluster.name\"], \"${CLUSTER_NAME}\")",
           "delete_key(attributes, \"k8s.pod.uid\")",
         ]
       }

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -152,7 +152,7 @@ data:
       log_statements {
         context = "log"
         statements = [
-          "set(resource.attributes[\"alloy.k8s.pod.uid\"], attributes[\"pod_uid\"]) where attributes[\"pod_uid\"] != nil",
+          "set(resource.attributes[\"k8s.pod.uid\"], attributes[\"pod_uid\"]) where attributes[\"pod_uid\"] != nil",
         ]
       }
 
@@ -185,7 +185,7 @@ data:
       pod_association {
         source {
           from = "resource_attribute"
-          name = "alloy.k8s.pod.uid"
+          name = "k8s.pod.uid"
         }
       }
 
@@ -215,7 +215,6 @@ data:
         context = "resource"
         statements = [
           "set(attributes[\"k8s.cluster.name\"], \"${CLUSTER_NAME}\")",
-          "delete_key(attributes, \"alloy.k8s.pod.uid\")",
           "delete_key(attributes, \"k8s.pod.uid\")",
         ]
       }

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -223,6 +223,13 @@ data:
       error_mode = "ignore"
 
       log_statements {
+        context = "log"
+        statements = [
+          "delete_key(attributes, \"alloy.k8s.pod.uid\")",
+        ]
+      }
+
+      log_statements {
         context = "resource"
         statements = [
           "delete_key(attributes, \"alloy.k8s.pod.uid\")",

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -256,6 +256,49 @@ data:
       }
 
       output {
+        logs = [otelcol.processor.k8sattributes.kubernetes.input]
+      }
+    }
+
+    otelcol.processor.k8sattributes "kubernetes" {
+      auth_type = "serviceAccount"
+
+      extract {
+        metadata = [
+          "k8s.namespace.name",
+          "k8s.pod.name",
+          "k8s.pod.uid",
+          "k8s.pod.ip",
+          "k8s.node.name",
+        ]
+
+        label {
+          from      = "pod"
+          key_regex = "(.*)"
+          tag_name  = "kubernetes.pod_labels.$1"
+        }
+      }
+
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.uid"
+        }
+      }
+
+      output {
+        logs = [otelcol.processor.attributes.kubernetes_metadata.input]
+      }
+    }
+
+    otelcol.processor.attributes "kubernetes_metadata" {
+      action {
+        key            = "kubernetes.pod_ip"
+        from_attribute = "k8s.pod.ip"
+        action         = "upsert"
+      }
+
+      output {
         logs = [otelcol.processor.batch.logs.input]
       }
     }

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -262,6 +262,7 @@ data:
         context = "log"
         statements = [
           "set(attributes[\"kubernetes.pod_ip\"], resource.attributes[\"k8s.pod.ip\"]) where resource.attributes[\"k8s.pod.ip\"] != nil",
+          "delete_key(attributes, \"k8s.pod.uid\")",
         ]
       }
 

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -154,38 +154,8 @@ data:
       }
 
       action {
-        key    = "k8s.node.name"
-        value  = sys.env("ALLOY_NODE_NAME")
-        action = "upsert"
-      }
-
-      action {
-        key            = "k8s.namespace.name"
-        from_attribute = "pod_namespace"
-        action         = "upsert"
-      }
-
-      action {
-        key            = "k8s.pod.name"
-        from_attribute = "pod_name"
-        action         = "upsert"
-      }
-
-      action {
-        key            = "k8s.pod.uid"
+        key            = "alloy.k8s.pod.uid"
         from_attribute = "pod_uid"
-        action         = "upsert"
-      }
-
-      action {
-        key            = "k8s.container.name"
-        from_attribute = "container_name"
-        action         = "upsert"
-      }
-
-      action {
-        key            = "k8s.container.restart_count"
-        from_attribute = "restart_count"
         action         = "upsert"
       }
 
@@ -240,8 +210,23 @@ data:
       pod_association {
         source {
           from = "resource_attribute"
-          name = "k8s.pod.uid"
+          name = "alloy.k8s.pod.uid"
         }
+      }
+
+      output {
+        logs = [otelcol.processor.transform.kubernetes_cleanup.input]
+      }
+    }
+
+    otelcol.processor.transform "kubernetes_cleanup" {
+      error_mode = "ignore"
+
+      log_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"alloy.k8s.pod.uid\")",
+        ]
       }
 
       output {

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -133,7 +133,7 @@ data:
       log_statements {
         context = "log"
         statements = [
-          "merge_maps(attributes, ParseJSON(body), \"upsert\") where Substring(body, 0, 1) == \"{\"",
+          "merge_maps(attributes, ParseJSON(body), \"upsert\") where body != \"\" and Substring(body, 0, 1) == \"{\"",
           "set(body, attributes[\"message\"]) where attributes[\"message\"] != nil",
           "set(body, attributes[\"msg\"]) where attributes[\"message\"] == nil and attributes[\"msg\"] != nil",
           "set(body, attributes[\"log\"]) where attributes[\"message\"] == nil and attributes[\"msg\"] == nil and attributes[\"log\"] != nil",
@@ -287,15 +287,18 @@ data:
       }
 
       output {
-        logs = [otelcol.processor.attributes.kubernetes_metadata.input]
+        logs = [otelcol.processor.transform.kubernetes_metadata.input]
       }
     }
 
-    otelcol.processor.attributes "kubernetes_metadata" {
-      action {
-        key            = "kubernetes.pod_ip"
-        from_attribute = "k8s.pod.ip"
-        action         = "upsert"
+    otelcol.processor.transform "kubernetes_metadata" {
+      error_mode = "ignore"
+
+      log_statements {
+        context = "log"
+        statements = [
+          "set(attributes[\"kubernetes.pod_ip\"], resource.attributes[\"k8s.pod.ip\"]) where resource.attributes[\"k8s.pod.ip\"] != nil",
+        ]
       }
 
       output {

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -154,6 +154,12 @@ data:
       }
 
       action {
+        key    = "log.source"
+        value  = "kubernetes"
+        action = "upsert"
+      }
+
+      action {
         key            = "alloy.k8s.pod.uid"
         from_attribute = "pod_uid"
         action         = "upsert"

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -240,6 +240,7 @@ data:
         context = "log"
         statements = [
           "delete_key(attributes, \"alloy.k8s.pod.uid\")",
+          "delete_key(attributes, \"k8s.pod.uid\")",
         ]
       }
 
@@ -247,6 +248,7 @@ data:
         context = "resource"
         statements = [
           "delete_key(attributes, \"alloy.k8s.pod.uid\")",
+          "delete_key(attributes, \"k8s.pod.uid\")",
         ]
       }
 

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -204,6 +204,11 @@ data:
           "k8s.pod.uid",
           "k8s.pod.ip",
           "k8s.node.name",
+          "k8s.deployment.name",
+          "k8s.replicaset.name",
+          "k8s.statefulset.name",
+          "k8s.job.name",
+          "k8s.cronjob.name",
         ]
 
         otel_annotations = true

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -265,50 +265,18 @@ data:
         ]
       }
 
-      output {
-        logs = [otelcol.processor.attributes.kubernetes_cleanup.input]
-      }
-    }
-
-    otelcol.processor.attributes "kubernetes_cleanup" {
-      action {
-        key    = "k8s.namespace.name"
-        action = "delete"
-      }
-
-      action {
-        key    = "k8s.pod.name"
-        action = "delete"
-      }
-
-      action {
-        key    = "k8s.pod.uid"
-        action = "delete"
-      }
-
-      action {
-        key    = "k8s.pod.ip"
-        action = "delete"
-      }
-
-      action {
-        key    = "k8s.node.name"
-        action = "delete"
-      }
-
-      action {
-        key    = "k8s.cluster.name"
-        action = "delete"
-      }
-
-      action {
-        key    = "k8s.container.name"
-        action = "delete"
-      }
-
-      action {
-        key    = "k8s.container.restart_count"
-        action = "delete"
+      log_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"k8s.namespace.name\")",
+          "delete_key(attributes, \"k8s.pod.name\")",
+          "delete_key(attributes, \"k8s.pod.uid\")",
+          "delete_key(attributes, \"k8s.pod.ip\")",
+          "delete_key(attributes, \"k8s.node.name\")",
+          "delete_key(attributes, \"k8s.cluster.name\")",
+          "delete_key(attributes, \"k8s.container.name\")",
+          "delete_key(attributes, \"k8s.container.restart_count\")",
+        ]
       }
 
       output {

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -133,7 +133,7 @@ data:
       log_statements {
         context = "log"
         statements = [
-          "merge_maps(attributes, ParseJSON(body), \"upsert\")",
+          "merge_maps(attributes, ParseJSON(body), \"upsert\") where IsMatch(body, \"^\\s*\\{\")",
           "set(body, attributes[\"message\"]) where attributes[\"message\"] != nil",
           "set(body, attributes[\"msg\"]) where attributes[\"message\"] == nil and attributes[\"msg\"] != nil",
           "set(body, attributes[\"log\"]) where attributes[\"message\"] == nil and attributes[\"msg\"] == nil and attributes[\"log\"] != nil",
@@ -184,12 +184,6 @@ data:
       }
 
       action {
-        key            = "kubernetes.container_id"
-        from_attribute = "container_id"
-        action         = "upsert"
-      }
-
-      action {
         key    = "kubernetes.pod_node_name"
         value  = sys.env("ALLOY_NODE_NAME")
         action = "upsert"
@@ -204,6 +198,12 @@ data:
       action {
         key            = "k8s.pod.name"
         from_attribute = "pod_name"
+        action         = "upsert"
+      }
+
+      action {
+        key            = "k8s.pod.uid"
+        from_attribute = "pod_uid"
         action         = "upsert"
       }
 
@@ -241,7 +241,12 @@ data:
       }
 
       action {
-        key    = "container_id"
+        key    = "pod_uid"
+        action = "delete"
+      }
+
+      action {
+        key    = "restart_count"
         action = "delete"
       }
 
@@ -296,8 +301,10 @@ data:
     }
 
     otelcol.receiver.filelog "kubernetes" {
-      include           = ["/var/log/containers/*.log"]
-      exclude           = [string.format("/var/log/containers/%s_%s_*.log", sys.env("POD_NAME"), sys.env("POD_NAMESPACE"))]
+      include = ["/var/log/pods/*/*/*.log"]
+      exclude = [
+        string.format("/var/log/pods/%s_%s_*/alloy/*.log", sys.env("POD_NAMESPACE"), sys.env("POD_NAME")),
+      ]
       include_file_path = true
       start_at          = "end"
 
@@ -315,7 +322,7 @@ data:
         {
           type       = "regex_parser",
           parse_from = "attributes[\"log.file.path\"]",
-          regex      = "^/var/log/containers/(?P<pod_name>.+)_(?P<pod_namespace>[^_]+)_(?P<container_name>.+)-(?P<container_id>[a-f0-9]+)\\.log$",
+          regex      = "^/var/log/pods/(?P<pod_namespace>[^_]+)_(?P<pod_name>.+)_(?P<pod_uid>[0-9a-fA-F-]+)/(?P<container_name>[^/]+)/(?P<restart_count>[0-9]+)\\.log$",
         },
       ]
 

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -148,50 +148,44 @@ data:
 
     otelcol.processor.attributes "kubernetes_logs" {
       action {
-        key    = "cluster"
+        key    = "k8s.cluster.name"
         value  = "${CLUSTER_NAME}"
         action = "upsert"
       }
 
       action {
-        key    = "node"
+        key    = "k8s.node.name"
         value  = sys.env("ALLOY_NODE_NAME")
         action = "upsert"
       }
 
       action {
-        key    = "log.source"
-        value  = "kubernetes"
-        action = "upsert"
-      }
-
-      action {
-        key            = "kubernetes.pod_name"
-        from_attribute = "pod_name"
-        action         = "upsert"
-      }
-
-      action {
-        key            = "kubernetes.pod_namespace"
+        key            = "k8s.namespace.name"
         from_attribute = "pod_namespace"
         action         = "upsert"
       }
 
       action {
-        key            = "kubernetes.container_name"
-        from_attribute = "container_name"
+        key            = "k8s.pod.name"
+        from_attribute = "pod_name"
         action         = "upsert"
-      }
-
-      action {
-        key    = "kubernetes.pod_node_name"
-        value  = sys.env("ALLOY_NODE_NAME")
-        action = "upsert"
       }
 
       action {
         key            = "k8s.pod.uid"
         from_attribute = "pod_uid"
+        action         = "upsert"
+      }
+
+      action {
+        key            = "k8s.container.name"
+        from_attribute = "container_name"
+        action         = "upsert"
+      }
+
+      action {
+        key            = "k8s.container.restart_count"
+        from_attribute = "restart_count"
         action         = "upsert"
       }
 
@@ -248,36 +242,6 @@ data:
           from = "resource_attribute"
           name = "k8s.pod.uid"
         }
-      }
-
-      output {
-        logs = [otelcol.processor.transform.kubernetes_metadata.input]
-      }
-    }
-
-    otelcol.processor.transform "kubernetes_metadata" {
-      error_mode = "ignore"
-
-      log_statements {
-        context = "log"
-        statements = [
-          "set(attributes[\"kubernetes.pod_ip\"], resource.attributes[\"k8s.pod.ip\"]) where resource.attributes[\"k8s.pod.ip\"] != nil",
-          "delete_key(attributes, \"k8s.pod.uid\")",
-        ]
-      }
-
-      log_statements {
-        context = "resource"
-        statements = [
-          "delete_key(attributes, \"k8s.namespace.name\")",
-          "delete_key(attributes, \"k8s.pod.name\")",
-          "delete_key(attributes, \"k8s.pod.uid\")",
-          "delete_key(attributes, \"k8s.pod.ip\")",
-          "delete_key(attributes, \"k8s.node.name\")",
-          "delete_key(attributes, \"k8s.cluster.name\")",
-          "delete_key(attributes, \"k8s.container.name\")",
-          "delete_key(attributes, \"k8s.container.restart_count\")",
-        ]
       }
 
       output {

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -142,6 +142,21 @@ data:
       }
 
       output {
+        logs = [otelcol.processor.transform.kubernetes_association.input]
+      }
+    }
+
+    otelcol.processor.transform "kubernetes_association" {
+      error_mode = "ignore"
+
+      log_statements {
+        context = "log"
+        statements = [
+          "set(resource.attributes[\"alloy.k8s.pod.uid\"], attributes[\"pod_uid\"]) where attributes[\"pod_uid\"] != nil",
+        ]
+      }
+
+      output {
         logs = [otelcol.processor.k8sattributes.kubernetes.input]
       }
     }
@@ -169,8 +184,8 @@ data:
 
       pod_association {
         source {
-          from = "attribute"
-          name = "pod_uid"
+          from = "resource_attribute"
+          name = "alloy.k8s.pod.uid"
         }
       }
 
@@ -200,6 +215,7 @@ data:
         context = "resource"
         statements = [
           "set(attributes[\"k8s.cluster.name\"], \"${CLUSTER_NAME}\")",
+          "delete_key(attributes, \"alloy.k8s.pod.uid\")",
           "delete_key(attributes, \"k8s.pod.uid\")",
         ]
       }

--- a/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/configmap-logs.yaml
@@ -127,6 +127,134 @@ data:
       }
     }
 
+    otelcol.processor.transform "kubernetes_json" {
+      error_mode = "ignore"
+
+      log_statements {
+        context = "log"
+        statements = [
+          "merge_maps(attributes, ParseJSON(body), \"upsert\")",
+          "set(body, attributes[\"message\"]) where attributes[\"message\"] != nil",
+          "set(body, attributes[\"msg\"]) where attributes[\"message\"] == nil and attributes[\"msg\"] != nil",
+          "set(body, attributes[\"log\"]) where attributes[\"message\"] == nil and attributes[\"msg\"] == nil and attributes[\"log\"] != nil",
+          "set(body, attributes[\"log_message\"]) where attributes[\"message\"] == nil and attributes[\"msg\"] == nil and attributes[\"log\"] == nil and attributes[\"log_message\"] != nil",
+        ]
+      }
+
+      output {
+        logs = [otelcol.processor.attributes.kubernetes_logs.input]
+      }
+    }
+
+    otelcol.processor.attributes "kubernetes_logs" {
+      action {
+        key    = "cluster"
+        value  = "${CLUSTER_NAME}"
+        action = "upsert"
+      }
+
+      action {
+        key    = "node"
+        value  = sys.env("ALLOY_NODE_NAME")
+        action = "upsert"
+      }
+
+      action {
+        key    = "log.source"
+        value  = "kubernetes"
+        action = "upsert"
+      }
+
+      action {
+        key            = "kubernetes.pod_name"
+        from_attribute = "pod_name"
+        action         = "upsert"
+      }
+
+      action {
+        key            = "kubernetes.pod_namespace"
+        from_attribute = "pod_namespace"
+        action         = "upsert"
+      }
+
+      action {
+        key            = "kubernetes.container_name"
+        from_attribute = "container_name"
+        action         = "upsert"
+      }
+
+      action {
+        key            = "kubernetes.container_id"
+        from_attribute = "container_id"
+        action         = "upsert"
+      }
+
+      action {
+        key    = "kubernetes.pod_node_name"
+        value  = sys.env("ALLOY_NODE_NAME")
+        action = "upsert"
+      }
+
+      action {
+        key            = "k8s.namespace.name"
+        from_attribute = "pod_namespace"
+        action         = "upsert"
+      }
+
+      action {
+        key            = "k8s.pod.name"
+        from_attribute = "pod_name"
+        action         = "upsert"
+      }
+
+      action {
+        key            = "k8s.container.name"
+        from_attribute = "container_name"
+        action         = "upsert"
+      }
+
+      action {
+        key    = "k8s.node.name"
+        value  = sys.env("ALLOY_NODE_NAME")
+        action = "upsert"
+      }
+
+      action {
+        key    = "k8s.cluster.name"
+        value  = "${CLUSTER_NAME}"
+        action = "upsert"
+      }
+
+      action {
+        key    = "pod_name"
+        action = "delete"
+      }
+
+      action {
+        key    = "pod_namespace"
+        action = "delete"
+      }
+
+      action {
+        key    = "container_name"
+        action = "delete"
+      }
+
+      action {
+        key    = "container_id"
+        action = "delete"
+      }
+
+      action {
+        key    = "log.file.path"
+        action = "delete"
+      }
+
+      output {
+        logs = [otelcol.processor.batch.logs.input]
+      }
+    }
+
     otelcol.exporter.otlphttp "victorialogs" {
       client {
         endpoint    = "http://victoria-logs-vl-server.observability.svc.cluster.local:9428/insert/opentelemetry"
@@ -164,6 +292,35 @@ data:
 
       output {
         logs = [otelcol.processor.transform.talos_json.input]
+      }
+    }
+
+    otelcol.receiver.filelog "kubernetes" {
+      include           = ["/var/log/containers/*.log"]
+      exclude           = [string.format("/var/log/containers/%s_%s_*.log", sys.env("POD_NAME"), sys.env("POD_NAMESPACE"))]
+      include_file_path = true
+      start_at          = "end"
+
+      retry_on_failure {
+        enabled          = true
+        initial_interval = "1s"
+        max_interval     = "30s"
+        max_elapsed_time = "5m"
+      }
+
+      operators = [
+        {
+          type = "container",
+        },
+        {
+          type       = "regex_parser",
+          parse_from = "attributes[\"log.file.path\"]",
+          regex      = "^/var/log/containers/(?P<pod_name>.+)_(?P<pod_namespace>[^_]+)_(?P<container_name>.+)-(?P<container_id>[a-f0-9]+)\\.log$",
+        },
+      ]
+
+      output {
+        logs = [otelcol.processor.transform.kubernetes_json.input]
       }
     }
 

--- a/kubernetes/apps/observability/alloy/app/helmrelease-logs.yaml
+++ b/kubernetes/apps/observability/alloy/app/helmrelease-logs.yaml
@@ -14,6 +14,38 @@ spec:
     fullnameOverride: alloy-logs
     service:
       enabled: false
+    rbac:
+      rules:
+        - apiGroups: ["", "discovery.k8s.io", "networking.k8s.io"]
+          resources: ["endpoints", "endpointslices", "ingresses", "pods", "services"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["pods", "pods/log", "namespaces"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["monitoring.grafana.com"]
+          resources: ["podlogs"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["monitoring.coreos.com"]
+          resources: ["prometheusrules"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["monitoring.coreos.com"]
+          resources: ["alertmanagerconfigs"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["monitoring.coreos.com"]
+          resources: ["podmonitors", "servicemonitors", "probes", "scrapeconfigs"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["events"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["configmaps", "secrets"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["apps", "extensions"]
+          resources: ["replicasets", "deployments", "statefulsets", "daemonsets"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["batch"]
+          resources: ["jobs", "cronjobs"]
+          verbs: ["get", "list", "watch"]
     alloy:
       stabilityLevel: experimental
       extraEnv:

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -22,4 +22,3 @@ resources:
   - ./victoria-metrics/ks.app.yaml
   - ./victoria-metrics-rules/ks.app.yaml
   - ./victoria-logs/ks.app.yaml
-  - ./victoria-logs-collector/ks.app.yaml


### PR DESCRIPTION
## Summary
- start Phase 2 of the Alloy logging migration
- use `alloy-logs` to collect Kubernetes/container logs in addition to Phase 1 sources
- keep this PR based on #122 until Phase 1 merges

## Depends on
- #122

## Scope
- [ ] collect Kubernetes pod/container logs with Alloy
- [ ] preserve useful Kubernetes metadata and compatibility fields
- [ ] validate logs in VictoriaLogs
- [ ] decide when to retire `victoria-logs-collector` in a later step

## Notes
- This PR is intentionally opened against `feat/alloy-logs-phase1` as the base branch while Phase 1 is still under review.