### PR TITLE
feat(observability): add OTel-style fields to victoria logs collector

### DIFF
--- a/kubernetes/apps/observability/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs-collector/app/helmrelease.yaml
@@ -23,6 +23,10 @@ spec:
       includePodAnnotations: false
       includeNodeLabels: false
       includeNodeAnnotations: false
+      # vlagent can't rename dynamic kubernetes.* metadata into OpenTelemetry k8s.* fields,
+      # but it can attach the static OTel-style fields that downstream queries expect.
+      extraFields: >-
+        {"cluster":"${CLUSTER_NAME}","k8s.cluster.name":"${CLUSTER_NAME}","log.source":"kubernetes"}
     tolerations:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists

--- a/kubernetes/apps/observability/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs-collector/app/helmrelease.yaml
@@ -24,9 +24,9 @@ spec:
       includeNodeLabels: false
       includeNodeAnnotations: false
       # vlagent can't rename dynamic kubernetes.* metadata into OpenTelemetry k8s.* fields,
-      # but it can attach the static OTel-style fields that downstream queries expect.
+      # but it can attach static OTel-style fields that downstream queries expect.
       extraFields: >-
-        {"cluster":"${CLUSTER_NAME}","k8s.cluster.name":"${CLUSTER_NAME}","log.source":"kubernetes"}
+        {"log.source":"kubernetes"}
     tolerations:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists


### PR DESCRIPTION
## Summary
- add a static OTel-style `log.source` field to `victoria-logs-collector`
- keep the PR based on `main` instead of the Alloy branch
- preserve the existing Victoria log collector deployment

## Details
This adds:
- `log.source=kubernetes`

via `collector.extraFields` in `kubernetes/apps/observability/victoria-logs-collector/app/helmrelease.yaml`.

## Notes
`vlagent` can attach static fields, but it cannot remap dynamic Kubernetes metadata from `kubernetes.*` names to OpenTelemetry `k8s.*` names. So this gives limited compatibility with the Alloy OTEL labels without adopting Alloy.

## Validation
- reviewed rendered flag change in the HelmRelease diff
- attempted repo render in a git worktree; `flux-local` failed because the worktree git metadata path was not recognized inside the container
