### PR TITLE
feat(observability): collect Talos logs with victoria logs collector

### DIFF
--- a/kubernetes/apps/observability/victoria-logs-collector/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs-collector/app/helmrelease.yaml
@@ -17,12 +17,24 @@ spec:
     fullnameOverride: vl-collector
     extraArgs:
       tmpDataPath: /var/lib/vl-collector
+      fileCollector.glob:
+        - /var/log/*.log
+        - /var/log/audit/kube/*.log
+      fileCollector.extraFields:
+        - '{"log.source":"talos","node":"%{NODE_NAME}"}'
+        - '{"log.source":"talos-audit","node":"%{NODE_NAME}"}'
+      fileCollector.streamFields: file,node
     collector:
       excludeFilter: kubernetes.pod_name:=%{HOSTNAME}
       includePodLabels: true
       includePodAnnotations: false
       includeNodeLabels: false
       includeNodeAnnotations: false
+    env:
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
     tolerations:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists


### PR DESCRIPTION
## Summary
- collect Talos host log files with `victoria-logs-collector`
- tag Talos log lines with `log.source`
- include the node name on forwarded Talos log lines

## Details
This extends `kubernetes/apps/observability/victoria-logs-collector/app/helmrelease.yaml` to collect:
- `/var/log/*.log`
- `/var/log/audit/kube/*.log`

and forwards them with:
- `log.source=talos` for top-level Talos logs
- `log.source=talos-audit` for kube audit logs
- `node=%{NODE_NAME}` via a downward API env var

The existing Kubernetes pod log collection remains in place.

## Validation
- rendered the cluster successfully via `direnv exec . dagger call flux-local build --path clusters/dev --kind all export ...` from a non-worktree copy
- verified rendered `vlagent` args include the expected `fileCollector.*` flags and `NODE_NAME` env var
