### PR TITLE
feat(observability): add KEDA

### DIFF
--- a/kubernetes/apps/observability/keda/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/keda/app/grafanadashboard.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: keda
+spec:
+  allowCrossNamespaceImport: true
+  folder: keda
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  datasources:
+    - datasourceName: VictoriaMetrics
+      inputName: datasource
+  url: https://raw.githubusercontent.com/kedacore/keda/refs/heads/main/config/grafana/keda-dashboard.json

--- a/kubernetes/apps/observability/keda/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/keda/app/helmrelease.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: keda
+spec:
+  releaseName: keda
+  chartRef:
+    kind: OCIRepository
+    name: keda
+  interval: 1h
+  targetNamespace: observability
+  values:
+    prometheus:
+      operator:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+        prometheusRules:
+          enabled: true
+      metricServer:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+      webhooks:
+        enabled: true
+        serviceMonitor:
+          enabled: true

--- a/kubernetes/apps/observability/keda/app/kustomization.yaml
+++ b/kubernetes/apps/observability/keda/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/observability/keda/app/kustomization.yaml
+++ b/kubernetes/apps/observability/keda/app/kustomization.yaml
@@ -5,3 +5,4 @@ kind: Kustomization
 resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
+  - ./grafanadashboard.yaml

--- a/kubernetes/apps/observability/keda/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/keda/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: keda
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.19.0
+  url: oci://ghcr.io/home-operations/charts-mirror/keda

--- a/kubernetes/apps/observability/keda/ks.yaml
+++ b/kubernetes/apps/observability/keda/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: keda
+spec:
+  dependsOn:
+    - name: prometheus-operator-crds
+  interval: 1h
+  path: ./kubernetes/apps/observability/keda/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: observability
+  wait: true

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./alertmanager-config/ks.app.yaml
   - ./grafana-operator/ks.yaml
   - ./grafana/ks.yaml
+  - ./keda/ks.yaml
   - ./mikrotik-exporter/ks.app.yaml
   - ./prometheus-operator-crds/ks.yaml
   - ./silence-operator/ks.app.yaml


### PR DESCRIPTION
## Summary
- add KEDA to the observability stack
- source the chart from ghcr.io/home-operations/charts-mirror/keda
- enable Prometheus ServiceMonitors and PrometheusRule for KEDA

## Validation
- kustomize build kubernetes/apps/observability/keda/app
- kustomize build kubernetes/apps/observability
- helm template oci://ghcr.io/home-operations/charts-mirror/keda --version 2.19.0