### PR TITLE
feat(media): scale down Sonarr and Radarr when NFS is down

### DIFF
--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -23,6 +23,7 @@ spec:
   wait: false
   components:
     - ../../../../components/volsync/
+    - ../../../../components/nfs/
   postBuild:
     substitute:
       APP: radarr

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -23,6 +23,7 @@ spec:
   wait: false
   components:
     - ../../../../components/volsync/
+    - ../../../../components/nfs/
   postBuild:
     substitute:
       APP: sonarr

--- a/kubernetes/components/nfs/kustomization.yaml
+++ b/kubernetes/components/nfs/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./scaledobject.yaml

--- a/kubernetes/components/nfs/scaledobject.yaml
+++ b/kubernetes/components/nfs/scaledobject.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://k8s-versioned-schemas.pages.dev/keda/2.19.0/scaledobject_v1alpha1.json
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: ${APP}
+spec:
+  advanced:
+    restoreToOriginalReplicaCount: true
+  pollingInterval: 10
+  cooldownPeriod: 0
+  idleReplicaCount: 0
+  minReplicaCount: ${REPLICAS:=1}
+  maxReplicaCount: ${REPLICAS:=1}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: ${APP}
+  triggers:
+    - type: prometheus
+      metadata:
+        serverAddress: http://vmsingle-victoria-metrics.observability.svc:8428/prometheus
+        query: max(kube_deployment_status_replicas_available{namespace="${NFS_NAMESPACE:=storage-system}",deployment="${NFS_DEPLOYMENT:=nfs}"}) OR on() vector(0)
+        threshold: "1"


### PR DESCRIPTION
## Summary
- add a reusable `kubernetes/components/nfs` Kustomize component
- add KEDA ScaledObjects for Sonarr and Radarr through that component
- scale both apps to 0 when the `storage-system/nfs` deployment is unavailable

## Details
- uses the in-cluster VictoriaMetrics endpoint for the KEDA Prometheus scaler
- checks `kube_deployment_status_replicas_available{namespace="storage-system",deployment="nfs"}`
- restores original replica count when NFS becomes available again

## Validation
- flux build kustomization sonarr --namespace media --path ./kubernetes/apps/media/sonarr/app --kustomization-file ./kubernetes/apps/media/sonarr/ks.yaml
- flux build kustomization radarr --namespace media --path ./kubernetes/apps/media/radarr/app --kustomization-file ./kubernetes/apps/media/radarr/ks.yaml