### PR TITLE
chore(observability): disable VolSync for Victoria data

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
       retentionPeriod: 30d
       persistentVolume:
         enabled: true
-        existingClaim: ${VOLSYNC_PVC}
+        existingClaim: victoria-logs
         mountPath: /storage
       route:
         enabled: true

--- a/kubernetes/apps/observability/victoria-logs/ks.app.yaml
+++ b/kubernetes/apps/observability/victoria-logs/ks.app.yaml
@@ -10,8 +10,6 @@ spec:
       namespace: external-secrets
     - name: piraeus-operator
       namespace: storage-system
-    - name: volsync
-      namespace: storage-system
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-logs/app
   prune: true
@@ -21,12 +19,3 @@ spec:
     namespace: flux-system
   targetNamespace: observability
   wait: true
-  components:
-    - ../../../../components/volsync/
-  postBuild:
-    substitute:
-      APP: victoria-logs
-      VOLSYNC_PVC: victoria-logs
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_PUID: "1000"
-      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -376,10 +376,6 @@ spec:
         storage:
           accessModes:
             - ReadWriteOnce
-          dataSourceRef:
-            apiGroup: volsync.backube
-            kind: ReplicationDestination
-            name: victoria-metrics-dst
           resources:
             requests:
               storage: 10Gi

--- a/kubernetes/apps/observability/victoria-metrics/ks.app.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/ks.app.yaml
@@ -14,8 +14,6 @@ spec:
     - name: prometheus-operator-crds
     - name: piraeus-operator
       namespace: storage-system
-    - name: volsync
-      namespace: storage-system
   interval: 1h
   path: ./kubernetes/apps/observability/victoria-metrics/app
   prune: true
@@ -25,12 +23,3 @@ spec:
     namespace: flux-system
   targetNamespace: observability
   wait: true
-  components:
-    - ../../../../components/volsync-nopvc/
-  postBuild:
-    substitute:
-      APP: victoria-metrics
-      VOLSYNC_PVC: vmsingle-victoria-metrics
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_PUID: "0"
-      VOLSYNC_PGID: "0"


### PR DESCRIPTION
## Summary
- disable VolSync wiring for `victoria-metrics`
- disable VolSync wiring for `victoria-logs`
- stop bootstrapping Victoria PVCs from VolSync destinations

## Why
`victoria-metrics` and `victoria-logs` are carrying too much data for the current VolSync backup approach, causing long-running syncs and out-of-sync alert noise.

## Notes
- `victoria-logs` is pinned to the existing `victoria-logs` PVC
- the shared VolSync PVC template already had `kustomize.toolkit.fluxcd.io/prune: disabled`, so removing the component should not prune the live PVC