### PR TITLE
fix: disable out of space alerts for tank on dev cluster

### DIFF
--- a/clusters/dev/apps/kustomization.yaml
+++ b/clusters/dev/apps/kustomization.yaml
@@ -5,10 +5,10 @@ kind: Kustomization
 
 resources:
   - ./storage-system/
+  - ./observability/
   - ../../../kubernetes/apps/actions-runner-system/
   - ../../../kubernetes/apps/external-secrets/
   - ../../../kubernetes/apps/flux-system/
   - ../../../kubernetes/apps/kube-system/
   - ../../../kubernetes/apps/network-system/
-  - ../../../kubernetes/apps/observability/
   - ../../../kubernetes/apps/media/

--- a/clusters/dev/apps/observability/kustomization.yaml
+++ b/clusters/dev/apps/observability/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../../../kubernetes/apps/observability/
+  - ./silences.yaml

--- a/clusters/dev/apps/observability/silences.yaml
+++ b/clusters/dev/apps/observability/silences.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: observability.giantswarm.io/v1alpha2
+kind: Silence
+metadata:
+  name: node-exporter-out-of-space
+  namespace: observability
+spec:
+  matchers:
+    - name: alertname
+      value: NodeFilesystemAlmostOutOfSpace
+    - name: device
+      value: tank.*
+      matchType: =~


### PR DESCRIPTION
## Summary
- add a dev-cluster-only overlay under `clusters/dev/apps/observability/`
- silence the tank out-of-space alerts there

## Notes
- extracted from #141 so the VolSync change can stay focused