### PR TITLE
refactor: reuse Flux Kustomization components for media apps

### DIFF
--- a/kubernetes/apps/media/clonarr/ks.yaml
+++ b/kubernetes/apps/media/clonarr/ks.yaml
@@ -5,23 +5,8 @@ kind: Kustomization
 metadata:
   name: clonarr
 spec:
-  dependsOn:
-    - name: volsync
-      namespace: storage-system
-  interval: 1h
   path: ./kubernetes/apps/media/clonarr/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: media
-  wait: false
-  components:
-    - ../../../../components/volsync/
   postBuild:
     substitute:
       APP: clonarr
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_PUID: "1000"
-      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/media/clonarr/kustomization.yaml
+++ b/kubernetes/apps/media/clonarr/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ks.yaml
+components:
+  - ../../../components/ks-base
+  - ../../../components/ks-volsync

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -10,8 +10,8 @@ components:
 
 resources:
   - ./namespace.yaml
-  - ./clonarr/ks.yaml
-  - ./sonarr/ks.yaml
-  - ./radarr/ks.yaml
-  - ./prowlarr/ks.yaml
-  - ./sabnzbd/ks.yaml
+  - ./clonarr/
+  - ./sonarr/
+  - ./radarr/
+  - ./prowlarr/
+  - ./sabnzbd/

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -5,25 +5,8 @@ kind: Kustomization
 metadata:
   name: prowlarr
 spec:
-  dependsOn:
-    - name: external-secrets
-      namespace: external-secrets
-    - name: volsync
-      namespace: storage-system
-  interval: 1h
   path: ./kubernetes/apps/media/prowlarr/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: media
-  wait: false
-  components:
-    - ../../../../components/volsync/
   postBuild:
     substitute:
       APP: prowlarr
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_PUID: "1000"
-      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/media/prowlarr/kustomization.yaml
+++ b/kubernetes/apps/media/prowlarr/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ks.yaml
+components:
+  - ../../../components/ks-base
+  - ../../../components/ks-external-secrets
+  - ../../../components/ks-volsync

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -5,28 +5,8 @@ kind: Kustomization
 metadata:
   name: radarr
 spec:
-  dependsOn:
-    - name: external-secrets
-      namespace: external-secrets
-    - name: volsync
-      namespace: storage-system
-    - name: nfs
-      namespace: storage-system
-  interval: 1h
   path: ./kubernetes/apps/media/radarr/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: media
-  wait: false
-  components:
-    - ../../../../components/volsync/
-    - ../../../../components/nfs/
   postBuild:
     substitute:
       APP: radarr
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_PUID: "1000"
-      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/media/radarr/kustomization.yaml
+++ b/kubernetes/apps/media/radarr/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ks.yaml
+components:
+  - ../../../components/ks-base
+  - ../../../components/ks-external-secrets
+  - ../../../components/ks-volsync
+  - ../../../components/ks-nfs

--- a/kubernetes/apps/media/sabnzbd/ks.yaml
+++ b/kubernetes/apps/media/sabnzbd/ks.yaml
@@ -5,25 +5,8 @@ kind: Kustomization
 metadata:
   name: sabnzbd
 spec:
-  dependsOn:
-    - name: external-secrets
-      namespace: external-secrets
-    - name: volsync
-      namespace: storage-system
-  interval: 1h
   path: ./kubernetes/apps/media/sabnzbd/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: media
-  wait: false
-  components:
-    - ../../../../components/volsync/
   postBuild:
     substitute:
       APP: sabnzbd
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_PUID: "1000"
-      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/media/sabnzbd/kustomization.yaml
+++ b/kubernetes/apps/media/sabnzbd/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ks.yaml
+components:
+  - ../../../components/ks-base
+  - ../../../components/ks-external-secrets
+  - ../../../components/ks-volsync

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -5,28 +5,8 @@ kind: Kustomization
 metadata:
   name: sonarr
 spec:
-  dependsOn:
-    - name: external-secrets
-      namespace: external-secrets
-    - name: volsync
-      namespace: storage-system
-    - name: nfs
-      namespace: storage-system
-  interval: 1h
   path: ./kubernetes/apps/media/sonarr/app
-  prune: true
-  sourceRef:
-    kind: GitRepository
-    name: flux-system
-    namespace: flux-system
   targetNamespace: media
-  wait: false
-  components:
-    - ../../../../components/volsync/
-    - ../../../../components/nfs/
   postBuild:
     substitute:
       APP: sonarr
-      VOLSYNC_CAPACITY: 5Gi
-      VOLSYNC_PUID: "1000"
-      VOLSYNC_PGID: "1000"

--- a/kubernetes/apps/media/sonarr/kustomization.yaml
+++ b/kubernetes/apps/media/sonarr/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ks.yaml
+components:
+  - ../../../components/ks-base
+  - ../../../components/ks-external-secrets
+  - ../../../components/ks-volsync
+  - ../../../components/ks-nfs

--- a/kubernetes/components/ks-base/kustomization.yaml
+++ b/kubernetes/components/ks-base/kustomization.yaml
@@ -1,0 +1,30 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - patch: |
+      - op: add
+        path: /spec/dependsOn
+        value: []
+      - op: add
+        path: /spec/interval
+        value: 1h
+      - op: add
+        path: /spec/prune
+        value: true
+      - op: add
+        path: /spec/sourceRef
+        value:
+          kind: GitRepository
+          name: flux-system
+          namespace: flux-system
+      - op: add
+        path: /spec/wait
+        value: false
+      - op: add
+        path: /spec/components
+        value: []
+    target:
+      kind: Kustomization
+      group: kustomize.toolkit.fluxcd.io

--- a/kubernetes/components/ks-external-secrets/kustomization.yaml
+++ b/kubernetes/components/ks-external-secrets/kustomization.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - patch: |
+      - op: add
+        path: /spec/dependsOn/-
+        value:
+          name: external-secrets
+          namespace: external-secrets
+    target:
+      kind: Kustomization
+      group: kustomize.toolkit.fluxcd.io

--- a/kubernetes/components/ks-nfs/kustomization.yaml
+++ b/kubernetes/components/ks-nfs/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - patch: |
+      - op: add
+        path: /spec/dependsOn/-
+        value:
+          name: nfs
+          namespace: storage-system
+      - op: add
+        path: /spec/components/-
+        value: ../../../../components/nfs/
+    target:
+      kind: Kustomization
+      group: kustomize.toolkit.fluxcd.io

--- a/kubernetes/components/ks-volsync/kustomization.yaml
+++ b/kubernetes/components/ks-volsync/kustomization.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+patches:
+  - patch: |
+      - op: add
+        path: /spec/dependsOn/-
+        value:
+          name: volsync
+          namespace: storage-system
+      - op: add
+        path: /spec/components/-
+        value: ../../../../components/volsync/
+      - op: add
+        path: /spec/postBuild/substitute/VOLSYNC_CAPACITY
+        value: 5Gi
+      - op: add
+        path: /spec/postBuild/substitute/VOLSYNC_PUID
+        value: "1000"
+      - op: add
+        path: /spec/postBuild/substitute/VOLSYNC_PGID
+        value: "1000"
+    target:
+      kind: Kustomization
+      group: kustomize.toolkit.fluxcd.io


### PR DESCRIPTION
## Summary
- add reusable Kustomize components for common Flux Kustomization defaults and media app mixins
- refactor media apps to compose those components instead of repeating the same Flux spec blocks
- keep app-specific values in each app's `ks.yaml` while the directory `kustomization.yaml` applies the shared mixins

## Testing
- direnv exec . kustomize build kubernetes/apps/media
- direnv exec . dagger call flux-local build --path clusters/dev --kind all export --path /tmp/home-ops-dev.yaml
