### PR TITLE
Disable OpenEBS in the dev cluster

### DIFF
--- a/clusters/dev/apps/storage-system/kustomization.yaml
+++ b/clusters/dev/apps/storage-system/kustomization.yaml
@@ -6,17 +6,31 @@ kind: Kustomization
 resources:
   - ../../../../kubernetes/apps/storage-system/
 
-# patches:
-#   - target:
-#       group: kustomize.toolkit.fluxcd.io
-#       version: v1
-#       kind: Kustomization
-#       name: piraeus-operator
-#       namespace: storage-system
-#     patch: |-
-#       $patch: delete
-#       apiVersion: kustomize.toolkit.fluxcd.io/v1
-#       kind: Kustomization
-#       metadata:
-#         name: piraeus-operator
-#         namespace: storage-system
+patches:
+  - target:
+      group: kustomize.toolkit.fluxcd.io
+      version: v1
+      kind: Kustomization
+      name: openebs
+      namespace: storage-system
+    patch: |-
+      $patch: delete
+      apiVersion: kustomize.toolkit.fluxcd.io/v1
+      kind: Kustomization
+      metadata:
+        name: openebs
+        namespace: storage-system
+
+#  - target:
+#      group: kustomize.toolkit.fluxcd.io
+#      version: v1
+#      kind: Kustomization
+#      name: piraeus-operator
+#      namespace: storage-system
+#    patch: |-
+#      $patch: delete
+#      apiVersion: kustomize.toolkit.fluxcd.io/v1
+#      kind: Kustomization
+#      metadata:
+#        name: piraeus-operator
+#        namespace: storage-system

--- a/clusters/dev/talos/nodes/talos1.yaml
+++ b/clusters/dev/talos/nodes/talos1.yaml
@@ -17,15 +17,6 @@ apiVersion: v1alpha1
 kind: VolumeConfig
 name: EPHEMERAL
 provisioning:
-  minSize: 10GiB
-  maxSize: 10GiB
-  grow: false
----
-apiVersion: v1alpha1
-kind: UserVolumeConfig
-name: local-storage
-provisioning:
-  diskSelector:
-    match: "system_disk"
-  minSize: 10GB
-  maxSize: 100GB
+  minSize: 50GiB
+  maxSize: 100GiB
+  grow: true

--- a/clusters/dev/talos/nodes/talos2.yaml
+++ b/clusters/dev/talos/nodes/talos2.yaml
@@ -17,15 +17,6 @@ apiVersion: v1alpha1
 kind: VolumeConfig
 name: EPHEMERAL
 provisioning:
-  minSize: 10GiB
-  maxSize: 10GiB
-  grow: false
----
-apiVersion: v1alpha1
-kind: UserVolumeConfig
-name: local-storage
-provisioning:
-  diskSelector:
-    match: "system_disk"
-  minSize: 10GB
-  maxSize: 100GB
+  minSize: 50GiB
+  maxSize: 100GiB
+  grow: true

--- a/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/home-ops-runner/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
       kubernetesModeWorkVolumeClaim:
         accessModes:
           - ReadWriteOnce
-        storageClassName: openebs-hostpath
+        storageClassName: linstor-zfs-ssd-replicated
         resources:
           requests:
             storage: 10Gi

--- a/kubernetes/apps/storage-system/piraeus-operator/app/linstor-cluster-helmrelease.yaml
+++ b/kubernetes/apps/storage-system/piraeus-operator/app/linstor-cluster-helmrelease.yaml
@@ -48,11 +48,26 @@ spec:
                   operator: NotIn
                   values:
                     - talos0
+                    - talos1
                     - talos2
         storagePools:
           - name: ssd
             zfsPool:
               zPool: piraeus-ssd
+            properties:
+              - name: StorDriver/ZfscreateOptions
+                value: -o volblocksize=4K
+            source:
+              hostDevices:
+                - /dev/vdb
+
+      - name: zfs-pool-talos1
+        nodeSelector:
+          kubernetes.io/hostname: talos1
+        storagePools:
+          - name: ssd
+            zfsPool:
+              zPool: ssd
             properties:
               - name: StorDriver/ZfscreateOptions
                 value: -o volblocksize=4K

--- a/kubernetes/apps/storage-system/piraeus-operator/app/linstor-cluster-helmrelease.yaml
+++ b/kubernetes/apps/storage-system/piraeus-operator/app/linstor-cluster-helmrelease.yaml
@@ -48,10 +48,25 @@ spec:
                   operator: NotIn
                   values:
                     - talos0
+                    - talos2
         storagePools:
           - name: ssd
             zfsPool:
               zPool: piraeus-ssd
+            properties:
+              - name: StorDriver/ZfscreateOptions
+                value: -o volblocksize=4K
+            source:
+              hostDevices:
+                - /dev/vdb
+
+      - name: zfs-pool-talos2
+        nodeSelector:
+          kubernetes.io/hostname: talos2
+        storagePools:
+          - name: ssd
+            zfsPool:
+              zPool: ssd
             properties:
               - name: StorDriver/ZfscreateOptions
                 value: -o volblocksize=4K

--- a/secrets/cloudflare.sops.yaml
+++ b/secrets/cloudflare.sops.yaml
@@ -1,5 +1,5 @@
-r2_access_key: ENC[AES256_GCM,data:26ZcMBQYCZAnzx6eBGfOtjjF8Wzqes5smFZQ3aVWYJY=,iv:sgA7vH7VDCc+K3J54GUSBlnmQHeoUTi28E34q8VtQhw=,tag:jwYheKXha82S51PqgwYhog==,type:str]
-r2_secret_key: ENC[AES256_GCM,data:jY4TXVnf8jR/0Gq9Ad2IkfW2gi+80sHJCYV4aZGYmyJ15VW+nk/hv2aSQCwpOxBQ6egIMBquMKjW0Z0ikcOoqA==,iv:FyYdyahhB48WMuLVWFfzt4VkecsJAOhLp2pWudl4VCs=,tag:lVwjma8E99yb7t6T85wfGw==,type:str]
+r2_access_key: ENC[AES256_GCM,data:fRlOBT/GyU5jYpDYHQGUY3FCIOv9SOBJBOFxj6WV1Yg=,iv:6RG15uVpJ1KGjvpFbXFy5J4AELwwIY12pm8gaGFtugU=,tag:3x5hWDNOTpzjr8UaGpgD7w==,type:str]
+r2_secret_key: ENC[AES256_GCM,data:tEremeqlmLdGCQz1/6aRBBgfwSIQ3ycKoKMAxjngLNct4ftC4Fjm/il0zBhMtwhSgVxgVe132EGn1hVtr6deBw==,iv:O0uo4W8dcmk6F80qvlypaHVV1xe6BXI33iVK9tGk5MU=,tag:vPTUMclAWy/Pt4o02Gsxvg==,type:str]
 r2_endpoint: ENC[AES256_GCM,data:xEoXZg0SgTk21eEi9uSEKFFkoUr0m6o01UJnhwe+IfrxMoPooqw0Cl31tXfFCAxtUrSoBXcXfZY7WNUjC+SLCdLR58w=,iv:h1+f05ekX0qgMdlHzLQYw3L1DIX+Vt6Sxkr8FKEc37I=,tag:WIN2573iGO5Dgyobs5DyiQ==,type:str]
 sops:
   age:
@@ -23,7 +23,7 @@ sops:
         5AugNhX4+m5D/0CE0821NC6XAaE2fMMeKDuVhU+FjVTKmFY0D9wdelA1WJ3zOCUa
         HliJ5A==
         -----END AGE ENCRYPTED FILE-----
-  lastmodified: "2025-12-06T09:13:48Z"
-  mac: ENC[AES256_GCM,data:iqfhIQnzPAMmhOTxV47zzyMPjqpO+z/4BhtSKOfe3hLiaPl3P/Mdcy/ZlC8DWihJFkKEkV2E3F2CSCjfYu7WsMYumNACL/rx7x0T+TkyS1wF6FiQpm9ejzKqyCUVu3bCgt+AUMDq6pQxcpdY2NbbHfBf7gHdo8x8Nrw5ATqG79k=,iv:my350X0+EQ4+/2jJKiC6v72cPerXE65kZvuY8zFTSA4=,tag:vfeRJMfPnXLU5JxkDXZOTA==,type:str]
+  lastmodified: "2026-05-31T11:39:32Z"
+  mac: ENC[AES256_GCM,data:CHJ4x5KS30XlQXJ+VoKGNsLLA8eEsQZFn03bl4cTTyWU3VmrAZs5kcMzU5R8ZektH2crpSpdnEiSNPnWFZYvMAqoLySRS69MSLVQi2dR45AVViTQeXCF4zZpTqOvfI/qLx4c83//klZqvB8KrmSix8fPbDSJ1aO+PUMAmw8Ut3Q=,iv:C3O78edLb4sUNwrNSjgcONwoRJQSHgdOcpBfXGydK/k=,tag:B8Fz2RjsWf9RSKy/UnNiEQ==,type:str]
   unencrypted_suffix: _unencrypted
-  version: 3.11.0
+  version: 3.12.2

--- a/tf-stacks/prd/talos-dev/terragrunt.stack.hcl
+++ b/tf-stacks/prd/talos-dev/terragrunt.stack.hcl
@@ -1,6 +1,6 @@
 locals {
-  infra_module_version = "talos-infra-v1.4.0"
-  bgp_module_version   = "talos-bgp-v1.1.0"
+  infra_module_version = "main"
+  bgp_module_version   = "main"
 
   config = yamldecode(file("${get_repo_root()}/clusters/dev/talos/config.yaml"))
 
@@ -39,8 +39,7 @@ unit "infra" {
         memory     = 8192
         disk_size  = 100
         additional_disks = [
-          { size = 100 },
-          { size = 32 },
+          { size = 256 },
         ]
       } if lookup(node, "target", local.config.target) != "metal"
     }


### PR DESCRIPTION
## Summary
- disable the OpenEBS kustomization in the dev cluster overlay
- switch the home-ops runner work volume claim away from `openebs-hostpath` to `linstor-zfs-ssd-replicated`

## Verification
- `direnv exec . dagger call flux-local build --path clusters/dev --kind all export --path /tmp/dev-cluster.yaml`
- confirmed `/tmp/dev-cluster.yaml` no longer contains OpenEBS resources or `openebs-hostpath`
