### PR TITLE
Pin containerd's runc runtime snapshotter to zfs

### DIFF
--- a/modules/den/aspects/services/k3s/containerd.nix
+++ b/modules/den/aspects/services/k3s/containerd.nix
@@ -68,6 +68,18 @@
               snapshotter = "zfs";
             }
           ];
+          # containerd's implicit default "runc" runtime entry carries its
+          # own snapshotter (defaulting to "overlayfs") independently of the
+          # top-level CRI snapshotter above. kubelet's image pulls go through
+          # that per-runtime entry and silently pull with overlayfs unless
+          # it's pinned here too — fails with "no unpack platforms defined"
+          # since only a zfs unpack_config is declared. `ctr images pull
+          # --snapshotter zfs` (this file's original verification) bypasses
+          # the per-runtime lookup entirely, so it didn't catch this.
+          "io.containerd.grpc.v1.cri".containerd.runtimes.runc = {
+            runtime_type = "io.containerd.runc.v2";
+            snapshotter = "zfs";
+          };
         };
       };
     };


### PR DESCRIPTION
## Summary
- Fixes pod sandboxes failing to start on node1 with `unable to initialize unpacker: no unpack platforms defined` whenever a restart evicts running pods (e.g. a NixOS activation touching kubelet's persist mounts).
- Root cause: containerd's implicit default `runc` runtime entry carries its own snapshotter (defaults to `overlayfs`) independently of the top-level CRI `snapshotter = "zfs"` setting. kubelet's image pulls go through that per-runtime entry, so they silently pull with `overlayfs` and fail, since only a `zfs` unpack_config is declared. `ctr images pull --snapshotter zfs` (this file's original verification comment) bypasses the per-runtime lookup entirely, so it never caught this.
- Pins `containerd.runtimes.runc.snapshotter = "zfs"` explicitly to close the gap.

## Test plan
- [x] `nix flake check` passes
- [x] Verified live on node1: after applying this, Cilium's DaemonSet came back to `1/1` ready, all `kube-system` pods `Running`/`Completed`, and all `k3s-bootstrap-*` units succeeded (`active (exited)`).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01CezjyaVpC3FVPTUECp7cMR