### PR TITLE
chore(renovate): ignore manifests/prd/** in renovate config

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -16,6 +16,10 @@
   ],
   ignorePaths: [
     '**/resources/**',
+    // nixidy-generated, regenerated from modules/kubernetes/**/*.nix via
+    // `nix run .#write-manifests` — never hand-edit, and a version bump
+    // here alone would just get overwritten on the next regen.
+    'manifests/prd/**',
   ],
   suppressNotifications: [
     "prEditedNotification",


### PR DESCRIPTION
## Summary
- \`.renovaterc.json5\`'s \`kubernetes\`/\`helm-values\`/\`flux\` managers all match any \`*.yaml\` in the repo, so Renovate started proposing direct edits to nixidy-generated manifests under \`manifests/prd/**\` (e.g. #215-#221, bumping openebs's CSI sidecar image tags).
- That directory is machine-generated (\`nix run .#write-manifests\`) and drift-checked by \`nix flake check\` — merging one of those PRs would get silently reverted on the next regen and would fail CI in the meantime.
- Added \`manifests/prd/**\` to \`ignorePaths\`. Version bumps for anything rendered there need to happen in the Nix source (chart version bump or explicit Helm \`values\` override) instead.

## Test plan
- [x] \`nix flake check --print-build-logs\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CezjyaVpC3FVPTUECp7cMR