### PR TITLE
chore(renovate): track version pins in modules/kubernetes/**/*.nix and nixhelm

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -30,4 +30,43 @@
   kubernetes: {
     managerFilePatterns: ["/\\.yaml(?:\\.j2)?$/"],
   },
+  // Tracks version pins hand-written directly in modules/kubernetes/**/*.nix
+  // (Helm values, fetchFromGitHub revs) that the yaml-only managers above
+  // can't see. Each pin needs a `# renovate: datasource=... depName=...`
+  // comment on the line above it — see those files for examples. Pins
+  // paired with a Nix `hash` (fetchFromGitHub) will still need that hash
+  // updated by hand after Renovate bumps `rev`: the hosted app can't run
+  // postUpgradeTasks to recompute it, so `nix flake check` will fail with
+  // a hash mismatch until it's fixed.
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^modules/kubernetes/.*\\.nix$/"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>[a-z-]+?)(?: depName=(?<depName>.+?))?\\s+\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\";",
+      ],
+    },
+  ],
+  // Beta: lets Renovate propose a bump PR for individual flake.lock inputs.
+  // Scoped to nixhelm only for now — that's the only lever available for
+  // keeping charts.<repo>.<chart> versions (cilium, cert-manager, coredns,
+  // openebs's own driver) current, since none of those are literal
+  // strings anywhere in this repo. A nixhelm bump changes every chart it
+  // packages at once and, like the customManagers pins above, will fail
+  // checks.manifests until `nix run .#write-manifests` is re-run and
+  // committed alongside it.
+  nix: {
+    enabled: true,
+  },
+  packageRules: [
+    {
+      matchManagers: ["nix"],
+      enabled: false,
+    },
+    {
+      matchManagers: ["nix"],
+      matchDepNames: ["nixhelm"],
+      enabled: true,
+    },
+  ],
 }

--- a/modules/kubernetes/argocd/default.nix
+++ b/modules/kubernetes/argocd/default.nix
@@ -43,6 +43,7 @@ in
                 src = pkgs.fetchFromGitHub {
                   owner = "argoproj";
                   repo = "argo-cd";
+                  # renovate: datasource=github-releases depName=argoproj/argo-cd
                   rev = "v3.4.4";
                   hash = "sha256-I3udVhmPpOA2Lf1mkJqG+d+mGpfM16HIKBkEnTiAw0c=";
                 };

--- a/modules/kubernetes/cilium/gateway-api-crds.nix
+++ b/modules/kubernetes/cilium/gateway-api-crds.nix
@@ -5,6 +5,10 @@
 # v1.4.1 matches what Cilium 1.19.6 (nixhelm's charts.cilium.cilium)
 # requires. `config/crd`, not `config/crd/standard`: the latter has no
 # kustomization.yaml of its own.
+#
+# The Renovate annotation below tracks this independently of Cilium's own
+# version — check the Cilium release notes for its required Gateway API
+# CRD version before merging a bump here, don't take it on trust.
 _: {
   den.aspects.gateway-api-crds.k8s-manifests =
     { pkgs, ... }:
@@ -13,6 +17,7 @@ _: {
         src = pkgs.fetchFromGitHub {
           owner = "kubernetes-sigs";
           repo = "gateway-api";
+          # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
           rev = "v1.4.1";
           hash = "sha256-/GHyikcC2QGDN0ndpY6/xvSEEnpSsLrNU+lFElCKBs8=";
         };

--- a/modules/kubernetes/openebs/default.nix
+++ b/modules/kubernetes/openebs/default.nix
@@ -23,11 +23,16 @@ _: {
           values = {
             analytics.enabled = false;
 
+            # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-node-driver-registrar
             zfsNode.driverRegistrar.image.tag = "v2.17.0";
             zfsController = {
+              # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-resizer
               resizer.image.tag = "v1.14.0";
+              # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-provisioner
               provisioner.image.tag = "v5.3.0";
+              # renovate: datasource=docker depName=registry.k8s.io/sig-storage/csi-snapshotter
               snapshotter.image.tag = "v8.6.0";
+              # renovate: datasource=docker depName=registry.k8s.io/sig-storage/snapshot-controller
               snapshotController.image.tag = "v8.6.0";
             };
           };


### PR DESCRIPTION
## Summary
- Stacked on #223 — this PR annotates the exact CSI sidecar tag lines that PR adds, so it needs to land first (or be merged along with it).
- `manifests/prd/**` is now Renovate-ignored (#222), which means Renovate has no visibility into version pins for the new dendritic k8s app set at all — not just the openebs CSI sidecars, but every `.nix`-embedded version string.
- Adds a `customManagers` regex entry tracking any `# renovate: datasource=... depName=...`-annotated pin under `modules/kubernetes/**`, and annotates the 7 that exist today: the 5 openebs CSI sidecar tags (#223), plus `argocd`'s and `gateway-api-crds`' `fetchFromGitHub` revs.
  - Renovate PRs bumping a `rev` still need the paired Nix `hash` fixed by hand afterward — the hosted app can't run `postUpgradeTasks` to recompute it, so `nix flake check` will fail loudly with the correct hash until that's done.
  - `gateway-api-crds`' rev is coupled to whatever Cilium's chart requires (documented in the file) — a Renovate PR there needs a manual cross-check against Cilium's release notes before merging, not a blind bump.
- Enables Renovate's (beta) `nix` manager, scoped to just the `nixhelm` flake input via `packageRules` — the only lever available for keeping nixhelm-sourced chart versions (cilium, cert-manager, coredns, openebs's driver) moving, since none of those are literal strings anywhere in this repo. Deliberately not opened up to other flake inputs (`nixpkgs` especially) given how much unrelated surface those could touch.

## Test plan
- [x] Validated `.renovaterc.json5` JSON5 syntax with the `json5` CLI (parses cleanly)
- [x] Tested the `customManagers` regex against all 3 annotated files — correctly extracts `datasource`/`depName`/`currentValue` for all 7 pins
- [x] `nix run .#write-manifests` — zero manifest drift (comment-only Nix changes)
- [x] `nix flake check --print-build-logs` passes
- [ ] Real end-to-end confirmation only happens on Renovate's next scan after merge — not testable locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CezjyaVpC3FVPTUECp7cMR