### PR TITLE
Add deploy-rs for ongoing NixOS config deploys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ surface.
 - `nix run .#write-terragrunt` — regenerate `tf-stacks/prd/network/**/terragrunt.hcl` from Nix. Run after editing any `"terragrunt-stacks"` aspect content or a device's `terragruntInputs`.
 - `nix run .#write-manifests` — regenerate `manifests/prd/**` from nixidy. Run after editing any `k8s-manifests` aspect content.
 - `nix run .#nixos-anywhere-install <host> <ssh-target>` — kexec-based remote NixOS install straight onto real hardware for a `den.hosts` entry (e.g. `nixos-anywhere-install node1 root@10.0.10.10`).
+- `deploy .#node1` — ongoing config push to an already-installed `den.hosts` entry over SSH (host must first exist via `nixos-anywhere-install`). Hosts opt in via `fleet.deploy-rs.targets.<name>` (not every `den.hosts` entry — `test-vm` isn't). `deploy .#node1 --dry-activate` previews the activation without switching; magic-rollback (on by default) auto-reverts if the host becomes unreachable after activation.
 - `treefmt` — formats everything (`nixfmt`, `deadnix`, `statix`, `hclfmt`, `terraform` for `*.tofu`/`*.tfvars`/`*.tftest.hcl`, `yamlfmt`, `just`). `*.sops.*` and `manifests/**` are excluded. Runs automatically pre-commit via git-hooks-nix; the full `nix flake check` runs pre-push instead (kept off pre-commit for speed).
 - `.pre-commit-config.yaml` is a generated symlink into the Nix store — never hand-edit it.
 - Terragrunt `plan`/`apply` happen by hand, from inside `tf-stacks/prd/network/<device>[/<stack>]/`, only after `write-terragrunt` + human review of the diff. Never automate an apply.
@@ -50,6 +51,7 @@ Known gotchas in this system, worth knowing before you hit them again:
 - NixOS content aspects needing `{ host, user }` context (e.g. `modules/den/aspects/users/{define-user,ssh-keys}.nix`) must be wired via `den.schema.user.includes`, **not** a host's own `den.aspects.<host>.includes` — the host's own aspect chain only has `{ host }` bound, so a function requiring `user` silently never fires there. If a registry user's NixOS account renders empty, check this first.
 - `den.schema.user.classes` needs a default (`lib.mkDefault [ ]`, set in `modules/den/schema/users.nix`) — several of den's own built-in batteries read `user.classes` unconditionally and crash if it's unset.
 - Files named `_foo.nix` (e.g. `modules/network/_ros-lib.nix`, `modules/terragrunt/_render-lib.nix`) are plain `import`ed libs, not modules — the leading underscore makes `import-tree` skip them. Don't drop the underscore, or they'll be auto-imported as broken flake-parts modules.
+- `modules/flake/deploy-rs.nix` derives deploy targets from `config.flake.nixosConfigurations` — don't hand-list a host's NixOS modules a second time there; opt a host in via `fleet.deploy-rs.targets.<name>` on its own file instead.
 
 ## RouterOS / Terragrunt
 
@@ -63,4 +65,4 @@ Known gotchas in this system, worth knowing before you hit them again:
 
 - `modules/clusters/prd.nix`'s `den.aspects.prd.includes` lists which app aspects apply to the `prd` k3s cluster (currently `cilium`, `cilium-bgp`, `cilium-hubble-tls`, `cert-manager`, `coredns`, `argocd`). Each app aspect (`modules/kubernetes/<app>/default.nix`) contributes `k8s-manifests` content — nixidy-flavored NixOS-module options, not raw YAML.
 - Rendered to `manifests/prd/**`, applied once by `modules/den/aspects/services/k3s/bootstrap.nix`, after which ArgoCD (itself one of the app aspects) takes over syncing the rest of the app set from git.
-- The cluster runs on `modules/hosts/node1.nix` — a bare-metal box installed via `nixos-anywhere`, doubling as k3s node, Incus VM host, and NFS storage.
+- The cluster runs on `modules/hosts/node1.nix` — a bare-metal box installed via `nixos-anywhere`, doubling as k3s node, Incus VM host, and NFS storage, and kept up to date via `deploy-rs` after initial install.

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,26 @@
         "type": "github"
       }
     },
+    "deploy-rs": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1786361680,
+        "narHash": "sha256-IxaZkb9rCGEZ+yGndxKXONeIEcKMzoFUsvLTB5G/caw=",
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "rev": "16901271e5b30b591e56f7a84f25f186fb20f3e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "deploy-rs",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -87,6 +107,22 @@
     "flake-compat": {
       "flake": false,
       "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
         "lastModified": 1767039857,
         "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "NixOS",
@@ -137,7 +173,7 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -155,7 +191,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -173,7 +209,7 @@
     },
     "git-hooks-nix": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -238,7 +274,7 @@
     "impermanence": {
       "inputs": {
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1769548169,
@@ -374,7 +410,7 @@
         "nix-vm-test": "nix-vm-test",
         "nixos-images": "nixos-images",
         "nixos-stable": "nixos-stable",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -434,6 +470,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1743014863,
+        "narHash": "sha256-jAIUqsiN2r3hCuHji80U7NNEafpIMBXiwKlSrjWMlpg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bd3bac8bfb542dbde7ffffb6987a1a1f9d41699f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1768564909,
         "narHash": "sha256-Kell/SpJYVkHWMvnhqJz/8DqQg2b6PguxVWOuadbHCc=",
         "owner": "nixos",
@@ -448,7 +500,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1782860505,
         "narHash": "sha256-7beKprxZK6AT2aNMCLFUBew5g18GfWZYAbWIuxK7R3c=",
@@ -464,7 +516,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1784796856,
         "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
@@ -533,6 +585,7 @@
     "root": {
       "inputs": {
         "den": "den",
+        "deploy-rs": "deploy-rs",
         "disko": "disko",
         "disko-zfs": "disko-zfs",
         "flake-file": "flake-file",
@@ -543,7 +596,7 @@
         "nixhelm": "nixhelm",
         "nixidy": "nixidy",
         "nixos-anywhere": "nixos-anywhere",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "treefmt-nix": "treefmt-nix_2"
       }
     },
@@ -563,6 +616,21 @@
       }
     },
     "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -615,6 +683,24 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
 
   inputs = {
     den.url = "github:denful/den";
+    deploy-rs.url = "github:serokell/deploy-rs";
     disko = {
       url = "github:AlexLov/disko/6747342da148f6cb28c8405a70fe00455a0ba027";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/flake/deploy-rs.nix
+++ b/modules/flake/deploy-rs.nix
@@ -1,0 +1,67 @@
+# Ongoing config pushes to already-installed hosts (deploy .#<host>), NOT
+# initial install — that's nixos-anywhere-install
+# (modules/flake/nixos-anywhere.nix). CLI lives in the devshell
+# (modules/flake/devshell.nix); invoked by hand, never automated.
+#
+# Nodes are built straight from config.flake.nixosConfigurations.<name> —
+# the same standard, already-evaluated NixOS system den produces from
+# den.hosts. No den internals needed, unlike colmena (which would re-eval
+# each host itself and need den's undocumented `mainModule` option).
+#
+# Hosts opt in via fleet.deploy-rs.targets.<name> on their own file (e.g.
+# modules/hosts/node1.nix). test-vm is a throwaway QEMU box and is
+# deliberately never added.
+{
+  inputs,
+  lib,
+  config,
+  ...
+}:
+{
+  config.flake-file.inputs.deploy-rs.url = "github:serokell/deploy-rs";
+
+  options.fleet.deploy-rs.targets = lib.mkOption {
+    type = lib.types.attrsOf (
+      lib.types.submodule {
+        options = {
+          hostname = lib.mkOption {
+            type = lib.types.str;
+            description = "SSH target host/IP for `deploy`";
+          };
+          sshUser = lib.mkOption {
+            type = lib.types.str;
+            default = "root";
+          };
+          remoteBuild = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Permanent per-host default; prefer the `deploy --remote-build` CLI flag for one-off overrides.";
+          };
+        };
+      }
+    );
+    default = { };
+    description = "Hosts opted into deploy-rs for ongoing config deploys";
+  };
+
+  config.flake.deploy.nodes = lib.mapAttrs (name: target: {
+    inherit (target) hostname sshUser remoteBuild;
+    profiles.system = {
+      user = "root";
+      path = inputs.deploy-rs.lib.x86_64-linux.activate.nixos config.flake.nixosConfigurations.${name};
+    };
+  }) config.fleet.deploy-rs.targets;
+
+  config.perSystem =
+    { system, ... }:
+    {
+      # deploy-rs's `lib` output isn't one of flake-parts' standard
+      # per-system categories, so inputs' (which only projects
+      # packages/checks/devShells/etc.) doesn't cover it here.
+      #
+      # deployChecks returns an attrset of checks (deploy-activate,
+      # deploy-schema), not a single derivation — merge it straight into
+      # `checks` rather than nesting it under one name.
+      checks = inputs.deploy-rs.lib.${system}.deployChecks config.flake.deploy;
+    };
+}

--- a/modules/flake/devshell.nix
+++ b/modules/flake/devshell.nix
@@ -2,43 +2,51 @@
 # lives in modules/flake/formatter.nix, git hooks in modules/flake/git-hooks.nix.
 _: {
   perSystem =
-    { config, pkgs, ... }:
+    {
+      config,
+      inputs',
+      pkgs,
+      ...
+    }:
     {
       devShells.default = pkgs.mkShell {
-        packages = with pkgs; [
-          watch
-          just
-          yq
-          gum
-          expect
-          age
-          sops
-          opentofu
-          tofu-ls
-          terragrunt
+        packages =
+          with pkgs;
+          [
+            watch
+            just
+            yq
+            gum
+            expect
+            age
+            sops
+            opentofu
+            tofu-ls
+            terragrunt
 
-          go
-          gotestsum
+            go
+            gotestsum
 
-          talhelper
-          talosctl
-          kubectl
-          kubernetes-helm
-          cilium-cli
-          kustomize
-          kustomize-sops
-          kubectx
-          fluxcd
-          fluxcd-operator
-          fluxcd-operator-mcp
-          mcp-grafana
-          helmfile
-          kubevirt
-          nodejs
+            talhelper
+            talosctl
+            kubectl
+            kubernetes-helm
+            cilium-cli
+            kustomize
+            kustomize-sops
+            kubectx
+            fluxcd
+            fluxcd-operator
+            fluxcd-operator-mcp
+            mcp-grafana
+            helmfile
+            kubevirt
+            nodejs
 
-          nil
-          nixd
-        ];
+            nil
+            nixd
+          ]
+          ++ [ inputs'.deploy-rs.packages.deploy-rs ];
 
         inputsFrom = [
           config.treefmt.build.devShell

--- a/modules/hosts/node1.nix
+++ b/modules/hosts/node1.nix
@@ -1,7 +1,7 @@
 # node1 — bare-metal box for the `prd` cluster: k3s node, Incus VM host, and
 # NFS storage. Installs directly onto real hardware via nixos-anywhere
 # (`nix run .#nixos-anywhere-install`, modules/flake/nixos-anywhere.nix).
-{ den, ... }:
+{ den, config, ... }:
 {
   den.hosts.x86_64-linux.node1 = {
     k3s.clusterName = "prd";
@@ -109,4 +109,13 @@
   # Grants kid's "admin" access-policy group (modules/users/kid.nix) onto
   # this host — see modules/den/policies/users.nix for how this resolves.
   fleet.user-access.by-host.node1.groups = [ "admin" ];
+
+  # Opts node1 into deploy-rs (modules/flake/deploy-rs.nix) for ongoing
+  # `deploy` config pushes. SSH in as kid (wheel + passwordless sudo via
+  # modules/den/aspects/base/security.nix) rather than root directly;
+  # deploy-rs sudos to root itself for the profile activation.
+  fleet.deploy-rs.targets.node1 = {
+    hostname = config.den.devices.node1.address;
+    sshUser = "kid";
+  };
 }


### PR DESCRIPTION
## Summary
- Adds `deploy-rs` (chosen over `colmena` after comparing both) for pushing config updates to already-installed NixOS hosts — `nixos-anywhere` only ever handled initial install.
- `modules/flake/deploy-rs.nix`: pins the input, adds an opt-in `fleet.deploy-rs.targets.<name>` allowlist, derives `flake.deploy.nodes` straight from `config.flake.nixosConfigurations` (no `den` internals needed), wires `deployChecks` into `nix flake check`.
- `node1` opts in, connecting as `kid` (existing `wheel` + passwordless sudo) rather than `root` directly — `deploy-rs` sudos to `root` only for the profile activation.
- `test-vm` (throwaway QEMU box) is deliberately not opted in.
- Adds the `deploy-rs` CLI to the devshell and documents the new `deploy .#node1` / `--dry-activate` workflow in `AGENTS.md`.

## Test plan
- [x] `nix eval .#deploy.nodes` → `["node1"]` only
- [x] `nix eval .#deploy.nodes.node1.{hostname,sshUser}` → `10.0.10.10` / `kid`
- [x] `nix build .#deploy.nodes.node1.profiles.system.path` builds locally, no network activity against node1
- [x] `nix flake check --print-build-logs` passes in full (includes new `deploy-activate`/`deploy-schema` checks)
- [x] `deploy .#node1 --dry-activate` then `deploy .#node1` — run by hand against the real host, not automated here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CezjyaVpC3FVPTUECp7cMR