### PR TITLE
Add external-secrets + 1Password + Terraform scaffold for prd secrets

### DIFF
--- a/manifests/prd/apps/Application-external-secrets.yaml
+++ b/manifests/prd/apps/Application-external-secrets.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: external-secrets
+  namespace: argocd
+spec:
+  destination:
+    namespace: external-secrets
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./manifests/prd/external-secrets
+    repoURL: https://github.com/kid/home-ops.git
+    targetRevision: main
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/manifests/prd/cert-manager/ExternalSecret-cloudflare-dns-api-token.yaml
+++ b/manifests/prd/cert-manager/ExternalSecret-cloudflare-dns-api-token.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudflare-dns-api-token
+  namespace: cert-manager
+spec:
+  data:
+    - remoteRef:
+        key: cloudflare-dns-api-token/fields/token
+      secretKey: token
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    creationPolicy: Owner

--- a/manifests/prd/external-secrets/ClusterRole-external-secrets-cert-controller.yaml
+++ b/manifests/prd/external-secrets/ClusterRole-external-secrets-cert-controller.yaml
@@ -1,0 +1,94 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-cert-controller
+  name: external-secrets-cert-controller
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apiextensions.k8s.io
+    resourceNames:
+      - externalsecrets.external-secrets.io
+      - secretstores.external-secrets.io
+      - clustersecretstores.external-secrets.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - list
+      - watch
+      - get
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resourceNames:
+      - secretstore-validate
+      - externalsecret-validate
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resourceNames:
+      - external-secrets-webhook
+    resources:
+      - secrets
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+      - patch

--- a/manifests/prd/external-secrets/ClusterRole-external-secrets-controller.yaml
+++ b/manifests/prd/external-secrets/ClusterRole-external-secrets-controller.yaml
@@ -1,0 +1,149 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+  name: external-secrets-controller
+rules:
+  - apiGroups:
+      - external-secrets.io
+    resources:
+      - secretstores
+      - clustersecretstores
+      - externalsecrets
+      - clusterexternalsecrets
+      - pushsecrets
+      - clusterpushsecrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - external-secrets.io
+    resources:
+      - externalsecrets
+      - externalsecrets/status
+      - externalsecrets/finalizers
+      - secretstores
+      - secretstores/status
+      - secretstores/finalizers
+      - clustersecretstores
+      - clustersecretstores/status
+      - clustersecretstores/finalizers
+      - clusterexternalsecrets
+      - clusterexternalsecrets/status
+      - clusterexternalsecrets/finalizers
+      - pushsecrets
+      - pushsecrets/status
+      - pushsecrets/finalizers
+      - clusterpushsecrets
+      - clusterpushsecrets/status
+      - clusterpushsecrets/finalizers
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - generators.external-secrets.io
+    resources:
+      - generatorstates
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+      - deletecollection
+  - apiGroups:
+      - generators.external-secrets.io
+    resources:
+      - acraccesstokens
+      - cloudsmithaccesstokens
+      - clustergenerators
+      - ecrauthorizationtokens
+      - fakes
+      - gcraccesstokens
+      - githubaccesstokens
+      - gitlabdeploytokens
+      - quayaccesstokens
+      - passwords
+      - sshkeys
+      - stssessiontokens
+      - uuids
+      - vaultdynamicsecrets
+      - webhooks
+      - grafanas
+      - mfas
+      - beyondtrustworkloadcredentialsdynamicsecrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts/token
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - external-secrets.io
+    resources:
+      - externalsecrets
+    verbs:
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - external-secrets.io
+    resources:
+      - pushsecrets
+    verbs:
+      - create
+      - update
+      - delete

--- a/manifests/prd/external-secrets/ClusterRole-external-secrets-edit.yaml
+++ b/manifests/prd/external-secrets/ClusterRole-external-secrets-edit.yaml
@@ -1,0 +1,51 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: external-secrets-edit
+rules:
+  - apiGroups:
+      - external-secrets.io
+    resources:
+      - externalsecrets
+      - secretstores
+      - clustersecretstores
+      - pushsecrets
+      - clusterpushsecrets
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+  - apiGroups:
+      - generators.external-secrets.io
+    resources:
+      - acraccesstokens
+      - cloudsmithaccesstokens
+      - clustergenerators
+      - ecrauthorizationtokens
+      - fakes
+      - gcraccesstokens
+      - githubaccesstokens
+      - gitlabdeploytokens
+      - quayaccesstokens
+      - passwords
+      - sshkeys
+      - vaultdynamicsecrets
+      - webhooks
+      - grafanas
+      - generatorstates
+      - mfas
+      - beyondtrustworkloadcredentialsdynamicsecrets
+      - uuids
+    verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update

--- a/manifests/prd/external-secrets/ClusterRole-external-secrets-servicebindings.yaml
+++ b/manifests/prd/external-secrets/ClusterRole-external-secrets-servicebindings.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+    servicebinding.io/controller: "true"
+  name: external-secrets-servicebindings
+rules:
+  - apiGroups:
+      - external-secrets.io
+    resources:
+      - externalsecrets
+      - pushsecrets
+    verbs:
+      - get
+      - list
+      - watch

--- a/manifests/prd/external-secrets/ClusterRole-external-secrets-view.yaml
+++ b/manifests/prd/external-secrets/ClusterRole-external-secrets-view.yaml
@@ -1,0 +1,48 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: external-secrets-view
+rules:
+  - apiGroups:
+      - external-secrets.io
+    resources:
+      - externalsecrets
+      - secretstores
+      - clustersecretstores
+      - pushsecrets
+      - clusterpushsecrets
+    verbs:
+      - get
+      - watch
+      - list
+  - apiGroups:
+      - generators.external-secrets.io
+    resources:
+      - acraccesstokens
+      - beyondtrustworkloadcredentialsdynamicsecrets
+      - cloudsmithaccesstokens
+      - clustergenerators
+      - ecrauthorizationtokens
+      - fakes
+      - gcraccesstokens
+      - githubaccesstokens
+      - gitlabdeploytokens
+      - quayaccesstokens
+      - passwords
+      - sshkeys
+      - vaultdynamicsecrets
+      - webhooks
+      - grafanas
+      - generatorstates
+      - mfas
+      - uuids
+    verbs:
+      - get
+      - watch
+      - list

--- a/manifests/prd/external-secrets/ClusterRoleBinding-external-secrets-cert-controller.yaml
+++ b/manifests/prd/external-secrets/ClusterRoleBinding-external-secrets-cert-controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-cert-controller
+  name: external-secrets-cert-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-cert-controller
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets-cert-controller
+    namespace: external-secrets

--- a/manifests/prd/external-secrets/ClusterRoleBinding-external-secrets-controller.yaml
+++ b/manifests/prd/external-secrets/ClusterRoleBinding-external-secrets-controller.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+  name: external-secrets-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-controller
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets

--- a/manifests/prd/external-secrets/ClusterSecretStore-onepassword.yaml
+++ b/manifests/prd/external-secrets/ClusterSecretStore-onepassword.yaml
@@ -1,0 +1,13 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: onepassword
+spec:
+  provider:
+    onepasswordSDK:
+      auth:
+        serviceAccountSecretRef:
+          key: token
+          name: onepassword-service-account-token
+          namespace: external-secrets
+      vault: home-ops

--- a/manifests/prd/external-secrets/CustomResourceDefinition-acraccesstokens-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-acraccesstokens-generators-external-secrets-io.yaml
@@ -1,0 +1,208 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: acraccesstokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: ACRAccessToken
+    listKind: ACRAccessTokenList
+    plural: acraccesstokens
+    singular: acraccesstoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ACRAccessToken returns an Azure Container Registry token
+            that can be used for pushing/pulling images.
+            Note: by default it will return an ACR Refresh Token with full access
+            (depending on the identity).
+            This can be scoped down to the repository level using .spec.scope.
+            In case scope is defined it will return an ACR Access Token.
+
+            See docs: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                ACRAccessTokenSpec defines how to generate the access token
+                e.g. how to authenticate and which registry to use.
+                see: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#overview
+              properties:
+                auth:
+                  description: ACRAuth defines the authentication methods for Azure Container Registry.
+                  properties:
+                    managedIdentity:
+                      description: ManagedIdentity uses Azure Managed Identity to authenticate with Azure.
+                      properties:
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                      type: object
+                    servicePrincipal:
+                      description: ServicePrincipal uses Azure Service Principal credentials to authenticate with Azure.
+                      properties:
+                        secretRef:
+                          description: |-
+                            AzureACRServicePrincipalAuthSecretRef defines the secret references for Azure Service Principal authentication.
+                            It uses static credentials stored in a Kind=Secret.
+                          properties:
+                            clientId:
+                              description: The Azure clientId of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - secretRef
+                      type: object
+                    workloadIdentity:
+                      description: WorkloadIdentity uses Azure Workload Identity to authenticate with Azure.
+                      properties:
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                  type: object
+                environmentType:
+                  default: PublicCloud
+                  description: |-
+                    EnvironmentType specifies the Azure cloud environment endpoints to use for
+                    connecting and authenticating with Azure. By default, it points to the public cloud AAD endpoint.
+                    The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                    PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud
+                  enum:
+                    - PublicCloud
+                    - USGovernmentCloud
+                    - ChinaCloud
+                    - GermanCloud
+                    - AzureStackCloud
+                  type: string
+                registry:
+                  description: |-
+                    the domain name of the ACR registry
+                    e.g. foobarexample.azurecr.io
+                  type: string
+                scope:
+                  description: |-
+                    Define the scope for the access token, e.g. pull/push access for a repository.
+                    if not provided it will return a refresh token that has full scope.
+                    Note: you need to pin it down to the repository level, there is no wildcard available.
+
+                    examples:
+                    repository:my-repository:pull,push
+                    repository:my-repository:pull
+
+                    see docs for details: https://docs.docker.com/registry/spec/auth/scope/
+                  type: string
+                tenantId:
+                  description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                  type: string
+              required:
+                - auth
+                - registry
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-beyondtrustworkloadcredentialsdynamicsecrets-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-beyondtrustworkloadcredentialsdynamicsecrets-generators-external-secrets-io.yaml
@@ -1,0 +1,212 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: beyondtrustworkloadcredentialsdynamicsecrets.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: BeyondtrustWorkloadCredentialsDynamicSecret
+    listKind: BeyondtrustWorkloadCredentialsDynamicSecretList
+    plural: beyondtrustworkloadcredentialsdynamicsecrets
+    singular: beyondtrustworkloadcredentialsdynamicsecret
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            BeyondtrustWorkloadCredentialsDynamicSecret represents a generator that requests dynamic credentials from BeyondTrust Workload Credentials.
+            This generator calls the BeyondTrust Workload Credentials API to generate fresh, temporary credentials
+            (such as AWS STS credentials) each time an ExternalSecret is refreshed.
+            Dynamic secret definitions must be created in BeyondTrust Workload Credentials before they can be referenced.
+            For complete documentation, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: |-
+                BeyondtrustWorkloadCredentialsDynamicSecretSpec defines the desired spec for BeyondtrustWorkloadCredentials dynamic generator.
+                This generator enables obtaining temporary, short-lived credentials from BeyondTrust Workload Credentials.
+                For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+              properties:
+                controller:
+                  description: |-
+                    Controller selects the controller that should handle this generator.
+                    Leave empty to use the default controller.
+                  type: string
+                provider:
+                  description: |-
+                    Provider contains the BeyondtrustWorkloadCredentials provider configuration including authentication,
+                    server connection details, and the folder path to the dynamic secret definition.
+                    The folderPath should point to a dynamic secret definition that has been created in
+                    BeyondTrust Workload Credentials (e.g., "production/aws-temp").
+                    For setup details, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                  properties:
+                    auth:
+                      description: |-
+                        Auth configures how the Operator authenticates with the BeyondTrust Workload Credentials API.
+                        Currently supports API key authentication via Kubernetes secret reference.
+                        For authentication setup, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                      properties:
+                        apikey:
+                          description: |-
+                            APIKey configures API token authentication for BeyondTrust Workload Credentials.
+                            The token is retrieved from a Kubernetes secret and used as a Bearer token for API requests.
+                          properties:
+                            token:
+                              description: |-
+                                Token references the Kubernetes secret containing the BeyondTrust Workload Credentials API token.
+                                The secret should contain the API key used to authenticate with BeyondTrust Workload Credentials.
+                                Create an API token in your BeyondTrust Workload Credentials console and store it in a Kubernetes secret.
+                                For details on creating API tokens, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - token
+                          type: object
+                      required:
+                        - apikey
+                      type: object
+                    caBundle:
+                      description: |-
+                        CABundle is a base64-encoded CA certificate used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                        Use this when your BeyondTrust instance uses a self-signed certificate or internal CA.
+                        If not set, the system's trusted root certificates are used.
+                      format: byte
+                      type: string
+                    caProvider:
+                      description: |-
+                        CAProvider points to a Secret or ConfigMap containing a PEM-encoded CA certificate.
+                        This is used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                        Use this as an alternative to CABundle when you want to reference an existing Kubernetes resource.
+                      properties:
+                        key:
+                          description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[-._a-zA-Z0-9]+$
+                          type: string
+                        name:
+                          description: The name of the object located at the provider type.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        namespace:
+                          description: |-
+                            The namespace the Provider type is in.
+                            Can only be defined when used in a ClusterSecretStore.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        type:
+                          description: The type of provider to use such as "Secret", or "ConfigMap".
+                          enum:
+                            - Secret
+                            - ConfigMap
+                          type: string
+                      required:
+                        - name
+                        - type
+                      type: object
+                    folderPath:
+                      description: |-
+                        FolderPath specifies the default folder path for secret retrieval.
+                        Secrets will be fetched from this folder unless overridden in the ExternalSecret spec.
+                        Example: "production/database" or "dev/api-keys"
+                        Leave empty to retrieve secrets from the root folder.
+                        For folder organization, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#folders
+                      type: string
+                    server:
+                      description: |-
+                        Server configures the BeyondTrust Workload Credentials server connection details.
+                        Includes the API URL and Site ID for your BeyondTrust instance.
+                        For API reference, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                      properties:
+                        apiUrl:
+                          description: |-
+                            APIURL is the base URL of your BeyondTrust Workload Credentials API server.
+                            This should be the full URL to your BeyondTrust instance.
+                            Example: https://api.beyondtrust.io/siie
+                            For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#base-url
+                          type: string
+                        siteId:
+                          description: |-
+                            SiteID is your BeyondTrust Workload Credentials site identifier (UUID format).
+                            This identifier is unique to your BeyondTrust Workload Credentials instance.
+                            You can find your Site ID in the BeyondTrust Workload Credentials admin console.
+                            Example: a1b2c3d4-e5f6-4890-abcd-ef1234567890
+                            For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                          type: string
+                      required:
+                        - apiUrl
+                        - siteId
+                      type: object
+                  required:
+                    - auth
+                    - server
+                  type: object
+                retrySettings:
+                  description: |-
+                    RetrySettings configures exponential backoff for failed API requests.
+                    If not specified, uses the default retry settings.
+                  properties:
+                    maxRetries:
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      type: string
+                  type: object
+              required:
+                - provider
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-cloudsmithaccesstokens-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-cloudsmithaccesstokens-generators-external-secrets-io.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: cloudsmithaccesstokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: CloudsmithAccessToken
+    listKind: CloudsmithAccessTokenList
+    plural: cloudsmithaccesstokens
+    singular: cloudsmithaccesstoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: CloudsmithAccessToken generates Cloudsmith access token using OIDC authentication
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: CloudsmithAccessTokenSpec defines the configuration for generating a Cloudsmith access token using OIDC authentication.
+              properties:
+                apiUrl:
+                  description: APIURL configures the Cloudsmith API URL. Defaults to https://api.cloudsmith.io.
+                  type: string
+                orgSlug:
+                  description: OrgSlug is the organization slug in Cloudsmith
+                  type: string
+                serviceAccountRef:
+                  description: Name of the service account you are federating with
+                  properties:
+                    audiences:
+                      description: |-
+                        Audience specifies the `aud` claim for the service account token
+                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                        then this audiences will be appended to the list
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: The name of the ServiceAccount resource being referred to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the resource being referred to.
+                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                    - name
+                  type: object
+                serviceSlug:
+                  description: ServiceSlug is the service slug in Cloudsmith for OIDC authentication
+                  type: string
+              required:
+                - orgSlug
+                - serviceAccountRef
+                - serviceSlug
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-clusterexternalsecrets-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-clusterexternalsecrets-external-secrets-io.yaml
@@ -1,0 +1,1639 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: clusterexternalsecrets.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - external-secrets
+    kind: ClusterExternalSecret
+    listKind: ClusterExternalSecretList
+    plural: clusterexternalsecrets
+    shortNames:
+      - ces
+    singular: clusterexternalsecret
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.externalSecretSpec.secretStoreRef.name
+          name: Store
+          type: string
+        - jsonPath: .spec.refreshTime
+          name: Refresh Interval
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterExternalSecret is the Schema for the clusterexternalsecrets API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterExternalSecretSpec defines the desired state of ClusterExternalSecret.
+              properties:
+                externalSecretMetadata:
+                  description: The metadata of the external secrets to be created
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                externalSecretName:
+                  description: |-
+                    The name of the external secrets to be created.
+                    Defaults to the name of the ClusterExternalSecret
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                externalSecretSpec:
+                  description: The spec for the ExternalSecrets to be created
+                  properties:
+                    data:
+                      description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                      items:
+                        description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                        properties:
+                          remoteRef:
+                            description: |-
+                              RemoteRef points to the remote secret and defines
+                              which secret (version/property/..) to fetch.
+                            properties:
+                              conversionStrategy:
+                                default: Default
+                                description: Used to define a conversion Strategy
+                                enum:
+                                  - Default
+                                  - Unicode
+                                type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
+                                type: string
+                              key:
+                                description: Key is the key used in the Provider, mandatory
+                                type: string
+                              metadataPolicy:
+                                default: None
+                                description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                enum:
+                                  - None
+                                  - Fetch
+                                type: string
+                              nullBytePolicy:
+                                description: Controls how ESO handles fetched secret data containing NUL bytes for this source.
+                                enum:
+                                  - Ignore
+                                  - Fail
+                                type: string
+                              property:
+                                description: Used to select a specific property of the Provider value (if a map), if supported
+                                type: string
+                              version:
+                                description: Used to select a specific version of the Provider value, if supported
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          secretKey:
+                            description: The key in the Kubernetes Secret to store the value.
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[-._a-zA-Z0-9]+$
+                            type: string
+                          sourceRef:
+                            description: |-
+                              SourceRef allows you to override the source
+                              from which the value will be pulled.
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              generatorRef:
+                                description: |-
+                                  GeneratorRef points to a generator custom resource.
+
+                                  Deprecated: The generatorRef is not implemented in .data[].
+                                  this will be removed with v1.
+                                properties:
+                                  apiVersion:
+                                    default: generators.external-secrets.io/v1alpha1
+                                    description: Specify the apiVersion of the generator resource
+                                    type: string
+                                  kind:
+                                    description: Specify the Kind of the generator resource
+                                    enum:
+                                      - ACRAccessToken
+                                      - BeyondtrustWorkloadCredentialsDynamicSecret
+                                      - ClusterGenerator
+                                      - CloudsmithAccessToken
+                                      - ECRAuthorizationToken
+                                      - Fake
+                                      - GCRAccessToken
+                                      - GithubAccessToken
+                                      - GitlabDeployToken
+                                      - QuayAccessToken
+                                      - Password
+                                      - SSHKey
+                                      - STSSessionToken
+                                      - UUID
+                                      - VaultDynamicSecret
+                                      - Webhook
+                                      - Grafana
+                                      - MFA
+                                    type: string
+                                  name:
+                                    description: Specify the name of the generator resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              storeRef:
+                                description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                                properties:
+                                  kind:
+                                    description: |-
+                                      Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                                      Defaults to `SecretStore`
+                                    enum:
+                                      - SecretStore
+                                      - ClusterSecretStore
+                                    type: string
+                                  name:
+                                    description: Name of the SecretStore resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                type: object
+                            type: object
+                        required:
+                          - remoteRef
+                          - secretKey
+                        type: object
+                      type: array
+                    dataFrom:
+                      description: |-
+                        DataFrom is used to fetch all properties from a specific Provider data
+                        If multiple entries are specified, the Secret keys are merged in the specified order
+                      items:
+                        description: |-
+                          ExternalSecretDataFromRemoteRef defines the connection between the Kubernetes Secret keys and the Provider data
+                          when using DataFrom to fetch multiple values from a Provider.
+                        properties:
+                          extract:
+                            description: |-
+                              Used to extract multiple key/value pairs from one secret
+                              Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.
+                            properties:
+                              conversionStrategy:
+                                default: Default
+                                description: Used to define a conversion Strategy
+                                enum:
+                                  - Default
+                                  - Unicode
+                                type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
+                                type: string
+                              key:
+                                description: Key is the key used in the Provider, mandatory
+                                type: string
+                              metadataPolicy:
+                                default: None
+                                description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                enum:
+                                  - None
+                                  - Fetch
+                                type: string
+                              nullBytePolicy:
+                                description: Controls how ESO handles fetched secret data containing NUL bytes for this source.
+                                enum:
+                                  - Ignore
+                                  - Fail
+                                type: string
+                              property:
+                                description: Used to select a specific property of the Provider value (if a map), if supported
+                                type: string
+                              version:
+                                description: Used to select a specific version of the Provider value, if supported
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          find:
+                            description: |-
+                              Used to find secrets based on tags or regular expressions
+                              Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.
+                            properties:
+                              conversionStrategy:
+                                default: Default
+                                description: Used to define a conversion Strategy
+                                enum:
+                                  - Default
+                                  - Unicode
+                                type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
+                                type: string
+                              name:
+                                description: Finds secrets based on the name.
+                                properties:
+                                  regexp:
+                                    description: Finds secrets base
+                                    type: string
+                                type: object
+                              nullBytePolicy:
+                                description: Controls how ESO handles fetched secret data containing NUL bytes for this find source.
+                                enum:
+                                  - Ignore
+                                  - Fail
+                                type: string
+                              path:
+                                description: A root path to start the find operations.
+                                type: string
+                              tags:
+                                additionalProperties:
+                                  type: string
+                                description: Find secrets based on tags.
+                                type: object
+                            type: object
+                          rewrite:
+                            description: |-
+                              Used to rewrite secret Keys after getting them from the secret Provider
+                              Multiple Rewrite operations can be provided. They are applied in a layered order (first to last)
+                            items:
+                              description: ExternalSecretRewrite defines how to rewrite secret data values before they are written to the Secret.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                merge:
+                                  description: |-
+                                    Used to merge key/values in one single Secret
+                                    The resulting key will contain all values from the specified secrets
+                                  properties:
+                                    conflictPolicy:
+                                      default: Error
+                                      description: Used to define the policy to use in conflict resolution.
+                                      enum:
+                                        - Ignore
+                                        - Error
+                                      type: string
+                                    into:
+                                      default: ""
+                                      description: |-
+                                        Used to define the target key of the merge operation.
+                                        Required if strategy is JSON. Ignored otherwise.
+                                      type: string
+                                    priority:
+                                      description: Used to define key priority in conflict resolution.
+                                      items:
+                                        type: string
+                                      type: array
+                                    priorityPolicy:
+                                      default: Strict
+                                      description: Used to define the policy when a key in the priority list does not exist in the input.
+                                      enum:
+                                        - IgnoreNotFound
+                                        - Strict
+                                      type: string
+                                    strategy:
+                                      default: Extract
+                                      description: Used to define the strategy to use in the merge operation.
+                                      enum:
+                                        - Extract
+                                        - JSON
+                                      type: string
+                                  type: object
+                                regexp:
+                                  description: |-
+                                    Used to rewrite with regular expressions.
+                                    The resulting key will be the output of a regexp.ReplaceAll operation.
+                                  properties:
+                                    source:
+                                      description: Used to define the regular expression of a re.Compiler.
+                                      type: string
+                                    target:
+                                      description: Used to define the target pattern of a ReplaceAll operation.
+                                      type: string
+                                  required:
+                                    - source
+                                    - target
+                                  type: object
+                                transform:
+                                  description: |-
+                                    Used to apply string transformation on the secrets.
+                                    The resulting key will be the output of the template applied by the operation.
+                                  properties:
+                                    template:
+                                      description: |-
+                                        Used to define the template to apply on the secret name.
+                                        `.value ` will specify the secret name in the template.
+                                      type: string
+                                  required:
+                                    - template
+                                  type: object
+                              type: object
+                            type: array
+                          sourceRef:
+                            description: |-
+                              SourceRef points to a store or generator
+                              which contains secret values ready to use.
+                              Use this in combination with Extract or Find pull values out of
+                              a specific SecretStore.
+                              When sourceRef points to a generator Extract or Find is not supported.
+                              The generator returns a static map of values
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              generatorRef:
+                                description: GeneratorRef points to a generator custom resource.
+                                properties:
+                                  apiVersion:
+                                    default: generators.external-secrets.io/v1alpha1
+                                    description: Specify the apiVersion of the generator resource
+                                    type: string
+                                  kind:
+                                    description: Specify the Kind of the generator resource
+                                    enum:
+                                      - ACRAccessToken
+                                      - BeyondtrustWorkloadCredentialsDynamicSecret
+                                      - ClusterGenerator
+                                      - CloudsmithAccessToken
+                                      - ECRAuthorizationToken
+                                      - Fake
+                                      - GCRAccessToken
+                                      - GithubAccessToken
+                                      - GitlabDeployToken
+                                      - QuayAccessToken
+                                      - Password
+                                      - SSHKey
+                                      - STSSessionToken
+                                      - UUID
+                                      - VaultDynamicSecret
+                                      - Webhook
+                                      - Grafana
+                                      - MFA
+                                    type: string
+                                  name:
+                                    description: Specify the name of the generator resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              storeRef:
+                                description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                                properties:
+                                  kind:
+                                    description: |-
+                                      Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                                      Defaults to `SecretStore`
+                                    enum:
+                                      - SecretStore
+                                      - ClusterSecretStore
+                                    type: string
+                                  name:
+                                    description: Name of the SecretStore resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    refreshInterval:
+                      default: 1h0m0s
+                      description: |-
+                        RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+                        specified as Golang Duration strings.
+                        Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        Example values: "1h0m0s", "2h30m0s", "10m0s"
+                        May be set to "0s" to fetch and create it once. Defaults to 1h0m0s.
+                      type: string
+                    refreshPolicy:
+                      description: |-
+                        RefreshPolicy determines how the ExternalSecret should be refreshed:
+                        - CreatedOnce: Creates the Secret only if it does not exist and does not update it thereafter
+                        - Periodic: Synchronizes the Secret from the external source at regular intervals specified by refreshInterval.
+                          No periodic updates occur if refreshInterval is 0.
+                        - OnChange: Only synchronizes the Secret when the ExternalSecret's metadata or specification changes
+                      enum:
+                        - CreatedOnce
+                        - Periodic
+                        - OnChange
+                      type: string
+                    secretStoreRef:
+                      description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                      properties:
+                        kind:
+                          description: |-
+                            Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                            Defaults to `SecretStore`
+                          enum:
+                            - SecretStore
+                            - ClusterSecretStore
+                          type: string
+                        name:
+                          description: Name of the SecretStore resource
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      type: object
+                    syncWindows:
+                      description: |-
+                        SyncWindows optionally restricts when periodic refreshes may occur.
+                        Evaluated in UTC, only for Periodic refresh policy (or when refreshPolicy is unset).
+                      properties:
+                        kind:
+                          description: |-
+                            Kind applies to every window in the list.
+                            "allow" -- syncs are permitted only while at least one window is active;
+                                       all other times are blocked.
+                            "deny"  -- syncs are blocked while any window is active;
+                                       all other times are permitted.
+                          enum:
+                            - allow
+                            - deny
+                          type: string
+                        windows:
+                          description: Windows is the list of schedule+duration pairs.
+                          items:
+                            description: |-
+                              ExternalSecretSyncWindowEntry defines a single cron-schedule + duration pair
+                              within a SyncWindows block.
+                            properties:
+                              duration:
+                                description: |-
+                                  Duration specifies how long the window stays open after each Schedule
+                                  firing. Example: "8h".
+                                type: string
+                              schedule:
+                                description: |-
+                                  Schedule is a standard 5-field cron expression evaluated in UTC, or a
+                                  named shorthand such as @daily or @every 1h. It marks the start time of
+                                  each window occurrence.
+                                  Example: "0 22 * * 1-5" opens a window every weekday at 22:00 UTC.
+                                minLength: 1
+                                pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly)|@every [^\s]+.*|[^\s]+( [^\s]+){4})$
+                                type: string
+                            required:
+                              - duration
+                              - schedule
+                            type: object
+                          minItems: 1
+                          type: array
+                      required:
+                        - kind
+                        - windows
+                      type: object
+                    target:
+                      default:
+                        creationPolicy: Owner
+                        deletionPolicy: Retain
+                      description: |-
+                        ExternalSecretTarget defines the Kubernetes Secret to be created,
+                        there can be only one target per ExternalSecret.
+                      properties:
+                        creationPolicy:
+                          default: Owner
+                          description: |-
+                            CreationPolicy defines rules on how to create the resulting Secret.
+                            Defaults to "Owner"
+                          enum:
+                            - Owner
+                            - Orphan
+                            - Merge
+                            - None
+                            - CreateOrMerge
+                          type: string
+                        deletionPolicy:
+                          default: Retain
+                          description: |-
+                            DeletionPolicy defines rules on how to delete the resulting Secret.
+                            Defaults to "Retain"
+                          enum:
+                            - Delete
+                            - Merge
+                            - Retain
+                          type: string
+                        immutable:
+                          description: Immutable defines if the final secret will be immutable
+                          type: boolean
+                        manifest:
+                          description: |-
+                            Manifest defines a custom Kubernetes resource to create instead of a Secret.
+                            When specified, ExternalSecret will create the resource type defined here
+                            (e.g., ConfigMap, Custom Resource) instead of a Secret.
+                            Warning: Using Generic target. Make sure access policies and encryption are properly configured.
+                          properties:
+                            apiVersion:
+                              description: APIVersion of the target resource (e.g., "v1" for ConfigMap, "argoproj.io/v1alpha1" for ArgoCD Application)
+                              minLength: 1
+                              type: string
+                            kind:
+                              description: Kind of the target resource (e.g., "ConfigMap", "Application")
+                              minLength: 1
+                              type: string
+                          required:
+                            - apiVersion
+                            - kind
+                          type: object
+                        name:
+                          description: |-
+                            The name of the Secret resource to be managed.
+                            Defaults to the .metadata.name of the ExternalSecret resource
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        template:
+                          description: Template defines a blueprint for the created Secret resource.
+                          properties:
+                            data:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            engineVersion:
+                              default: v2
+                              description: |-
+                                EngineVersion specifies the template engine version
+                                that should be used to compile/execute the
+                                template specified in .data and .templateFrom[].
+                              enum:
+                                - v2
+                              type: string
+                            mergePolicy:
+                              default: Replace
+                              description: TemplateMergePolicy defines how the rendered template should be merged with the existing Secret data.
+                              enum:
+                                - Replace
+                                - Merge
+                              type: string
+                            metadata:
+                              description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                finalizers:
+                                  items:
+                                    type: string
+                                  type: array
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            templateFrom:
+                              items:
+                                description: |-
+                                  TemplateFrom specifies a source for templates.
+                                  Each item in the list can either reference a ConfigMap or a Secret resource.
+                                properties:
+                                  configMap:
+                                    description: TemplateRef specifies a reference to either a ConfigMap or a Secret resource.
+                                    properties:
+                                      items:
+                                        description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                        items:
+                                          description: TemplateRefItem specifies a key in the ConfigMap/Secret to use as a template for Secret data.
+                                          properties:
+                                            key:
+                                              description: A key in the ConfigMap/Secret
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[-._a-zA-Z0-9]+$
+                                              type: string
+                                            templateAs:
+                                              default: Values
+                                              description: TemplateScope specifies how the template keys should be interpreted.
+                                              enum:
+                                                - Values
+                                                - KeysAndValues
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: The name of the ConfigMap/Secret resource
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        type: string
+                                    required:
+                                      - items
+                                      - name
+                                    type: object
+                                  literal:
+                                    type: string
+                                  secret:
+                                    description: TemplateRef specifies a reference to either a ConfigMap or a Secret resource.
+                                    properties:
+                                      items:
+                                        description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                        items:
+                                          description: TemplateRefItem specifies a key in the ConfigMap/Secret to use as a template for Secret data.
+                                          properties:
+                                            key:
+                                              description: A key in the ConfigMap/Secret
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[-._a-zA-Z0-9]+$
+                                              type: string
+                                            templateAs:
+                                              default: Values
+                                              description: TemplateScope specifies how the template keys should be interpreted.
+                                              enum:
+                                                - Values
+                                                - KeysAndValues
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: The name of the ConfigMap/Secret resource
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        type: string
+                                    required:
+                                      - items
+                                      - name
+                                    type: object
+                                  target:
+                                    default: Data
+                                    description: |-
+                                      Target specifies where to place the template result.
+                                      For Secret resources, common values are: "Data", "Annotations", "Labels".
+                                      For custom resources (when spec.target.manifest is set), this supports
+                                      nested paths like "spec.database.config" or "data".
+                                    type: string
+                                  valuesDecodingStrategy:
+                                    default: None
+                                    description: Used to define a decoding Strategy for the rendered template values.
+                                    enum:
+                                      - Auto
+                                      - Base64
+                                      - Base64URL
+                                      - None
+                                    type: string
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                namespaceSelector:
+                  description: |-
+                    The labels to select by to find the Namespaces to create the ExternalSecrets in.
+
+                    Deprecated: Use NamespaceSelectors instead.
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                namespaceSelectors:
+                  description: A list of labels to select by to find the Namespaces to create the ExternalSecrets in. The selectors are ORed.
+                  items:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                namespaces:
+                  description: |-
+                    Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
+
+                    Deprecated: Use NamespaceSelectors instead.
+                  items:
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  type: array
+                refreshTime:
+                  description: The time in which the controller should reconcile its objects and recheck namespaces for labels.
+                  type: string
+              required:
+                - externalSecretSpec
+              type: object
+            status:
+              description: ClusterExternalSecretStatus defines the observed state of ClusterExternalSecret.
+              properties:
+                conditions:
+                  items:
+                    description: ClusterExternalSecretStatusCondition defines the observed state of a ClusterExternalSecret resource.
+                    properties:
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ClusterExternalSecretConditionType defines a value type for ClusterExternalSecret conditions.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                externalSecretName:
+                  description: ExternalSecretName is the name of the ExternalSecrets created by the ClusterExternalSecret
+                  type: string
+                failedNamespaces:
+                  description: Failed namespaces are the namespaces that failed to apply an ExternalSecret
+                  items:
+                    description: ClusterExternalSecretNamespaceFailure represents a failed namespace deployment and it's reason.
+                    properties:
+                      namespace:
+                        description: Namespace is the namespace that failed when trying to apply an ExternalSecret
+                        type: string
+                      reason:
+                        description: Reason is why the ExternalSecret failed to apply to the namespace
+                        type: string
+                    required:
+                      - namespace
+                    type: object
+                  type: array
+                provisionedNamespaces:
+                  description: ProvisionedNamespaces are the namespaces where the ClusterExternalSecret has secrets
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.externalSecretSpec.secretStoreRef.name
+          name: Store
+          type: string
+        - jsonPath: .spec.refreshTime
+          name: Refresh Interval
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      deprecated: true
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterExternalSecret is the schema for the clusterexternalsecrets API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterExternalSecretSpec defines the desired state of ClusterExternalSecret.
+              properties:
+                externalSecretMetadata:
+                  description: The metadata of the external secrets to be created
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                externalSecretName:
+                  description: |-
+                    The name of the external secrets to be created.
+                    Defaults to the name of the ClusterExternalSecret
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                externalSecretSpec:
+                  description: The spec for the ExternalSecrets to be created
+                  properties:
+                    data:
+                      description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                      items:
+                        description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                        properties:
+                          remoteRef:
+                            description: |-
+                              RemoteRef points to the remote secret and defines
+                              which secret (version/property/..) to fetch.
+                            properties:
+                              conversionStrategy:
+                                default: Default
+                                description: Used to define a conversion Strategy
+                                enum:
+                                  - Default
+                                  - Unicode
+                                type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
+                                type: string
+                              key:
+                                description: Key is the key used in the Provider, mandatory
+                                type: string
+                              metadataPolicy:
+                                default: None
+                                description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                enum:
+                                  - None
+                                  - Fetch
+                                type: string
+                              property:
+                                description: Used to select a specific property of the Provider value (if a map), if supported
+                                type: string
+                              version:
+                                description: Used to select a specific version of the Provider value, if supported
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          secretKey:
+                            description: The key in the Kubernetes Secret to store the value.
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[-._a-zA-Z0-9]+$
+                            type: string
+                          sourceRef:
+                            description: |-
+                              SourceRef allows you to override the source
+                              from which the value will be pulled.
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              generatorRef:
+                                description: |-
+                                  GeneratorRef points to a generator custom resource.
+
+                                  Deprecated: The generatorRef is not implemented in .data[].
+                                  this will be removed with v1.
+                                properties:
+                                  apiVersion:
+                                    default: generators.external-secrets.io/v1alpha1
+                                    description: Specify the apiVersion of the generator resource
+                                    type: string
+                                  kind:
+                                    description: Specify the Kind of the generator resource
+                                    enum:
+                                      - ACRAccessToken
+                                      - ClusterGenerator
+                                      - ECRAuthorizationToken
+                                      - Fake
+                                      - GCRAccessToken
+                                      - GithubAccessToken
+                                      - QuayAccessToken
+                                      - Password
+                                      - SSHKey
+                                      - STSSessionToken
+                                      - UUID
+                                      - VaultDynamicSecret
+                                      - Webhook
+                                      - Grafana
+                                    type: string
+                                  name:
+                                    description: Specify the name of the generator resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              storeRef:
+                                description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                                properties:
+                                  kind:
+                                    description: |-
+                                      Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                                      Defaults to `SecretStore`
+                                    enum:
+                                      - SecretStore
+                                      - ClusterSecretStore
+                                    type: string
+                                  name:
+                                    description: Name of the SecretStore resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                type: object
+                            type: object
+                        required:
+                          - remoteRef
+                          - secretKey
+                        type: object
+                      type: array
+                    dataFrom:
+                      description: |-
+                        DataFrom is used to fetch all properties from a specific Provider data
+                        If multiple entries are specified, the Secret keys are merged in the specified order
+                      items:
+                        description: ExternalSecretDataFromRemoteRef defines a reference to multiple secrets in the provider to be fetched using options.
+                        properties:
+                          extract:
+                            description: |-
+                              Used to extract multiple key/value pairs from one secret
+                              Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.
+                            properties:
+                              conversionStrategy:
+                                default: Default
+                                description: Used to define a conversion Strategy
+                                enum:
+                                  - Default
+                                  - Unicode
+                                type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
+                                type: string
+                              key:
+                                description: Key is the key used in the Provider, mandatory
+                                type: string
+                              metadataPolicy:
+                                default: None
+                                description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                                enum:
+                                  - None
+                                  - Fetch
+                                type: string
+                              property:
+                                description: Used to select a specific property of the Provider value (if a map), if supported
+                                type: string
+                              version:
+                                description: Used to select a specific version of the Provider value, if supported
+                                type: string
+                            required:
+                              - key
+                            type: object
+                          find:
+                            description: |-
+                              Used to find secrets based on tags or regular expressions
+                              Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.
+                            properties:
+                              conversionStrategy:
+                                default: Default
+                                description: Used to define a conversion Strategy
+                                enum:
+                                  - Default
+                                  - Unicode
+                                type: string
+                              decodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
+                                type: string
+                              name:
+                                description: Finds secrets based on the name.
+                                properties:
+                                  regexp:
+                                    description: Finds secrets base
+                                    type: string
+                                type: object
+                              path:
+                                description: A root path to start the find operations.
+                                type: string
+                              tags:
+                                additionalProperties:
+                                  type: string
+                                description: Find secrets based on tags.
+                                type: object
+                            type: object
+                          rewrite:
+                            description: |-
+                              Used to rewrite secret Keys after getting them from the secret Provider
+                              Multiple Rewrite operations can be provided. They are applied in a layered order (first to last)
+                            items:
+                              description: ExternalSecretRewrite defines rules on how to rewrite secret keys.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                regexp:
+                                  description: |-
+                                    Used to rewrite with regular expressions.
+                                    The resulting key will be the output of a regexp.ReplaceAll operation.
+                                  properties:
+                                    source:
+                                      description: Used to define the regular expression of a re.Compiler.
+                                      type: string
+                                    target:
+                                      description: Used to define the target pattern of a ReplaceAll operation.
+                                      type: string
+                                  required:
+                                    - source
+                                    - target
+                                  type: object
+                                transform:
+                                  description: |-
+                                    Used to apply string transformation on the secrets.
+                                    The resulting key will be the output of the template applied by the operation.
+                                  properties:
+                                    template:
+                                      description: |-
+                                        Used to define the template to apply on the secret name.
+                                        `.value ` will specify the secret name in the template.
+                                      type: string
+                                  required:
+                                    - template
+                                  type: object
+                              type: object
+                            type: array
+                          sourceRef:
+                            description: |-
+                              SourceRef points to a store or generator
+                              which contains secret values ready to use.
+                              Use this in combination with Extract or Find pull values out of
+                              a specific SecretStore.
+                              When sourceRef points to a generator Extract or Find is not supported.
+                              The generator returns a static map of values
+                            maxProperties: 1
+                            minProperties: 1
+                            properties:
+                              generatorRef:
+                                description: GeneratorRef points to a generator custom resource.
+                                properties:
+                                  apiVersion:
+                                    default: generators.external-secrets.io/v1alpha1
+                                    description: Specify the apiVersion of the generator resource
+                                    type: string
+                                  kind:
+                                    description: Specify the Kind of the generator resource
+                                    enum:
+                                      - ACRAccessToken
+                                      - ClusterGenerator
+                                      - ECRAuthorizationToken
+                                      - Fake
+                                      - GCRAccessToken
+                                      - GithubAccessToken
+                                      - QuayAccessToken
+                                      - Password
+                                      - SSHKey
+                                      - STSSessionToken
+                                      - UUID
+                                      - VaultDynamicSecret
+                                      - Webhook
+                                      - Grafana
+                                    type: string
+                                  name:
+                                    description: Specify the name of the generator resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              storeRef:
+                                description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                                properties:
+                                  kind:
+                                    description: |-
+                                      Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                                      Defaults to `SecretStore`
+                                    enum:
+                                      - SecretStore
+                                      - ClusterSecretStore
+                                    type: string
+                                  name:
+                                    description: Name of the SecretStore resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                    refreshInterval:
+                      default: 1h0m0s
+                      description: |-
+                        RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+                        specified as Golang Duration strings.
+                        Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                        Example values: "1h0m0s", "2h30m0s", "10m0s"
+                        May be set to "0s" to fetch and create it once. Defaults to 1h0m0s.
+                      type: string
+                    refreshPolicy:
+                      description: |-
+                        RefreshPolicy determines how the ExternalSecret should be refreshed:
+                        - CreatedOnce: Creates the Secret only if it does not exist and does not update it thereafter
+                        - Periodic: Synchronizes the Secret from the external source at regular intervals specified by refreshInterval.
+                          No periodic updates occur if refreshInterval is 0.
+                        - OnChange: Only synchronizes the Secret when the ExternalSecret's metadata or specification changes
+                      enum:
+                        - CreatedOnce
+                        - Periodic
+                        - OnChange
+                      type: string
+                    secretStoreRef:
+                      description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                      properties:
+                        kind:
+                          description: |-
+                            Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                            Defaults to `SecretStore`
+                          enum:
+                            - SecretStore
+                            - ClusterSecretStore
+                          type: string
+                        name:
+                          description: Name of the SecretStore resource
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      type: object
+                    target:
+                      default:
+                        creationPolicy: Owner
+                        deletionPolicy: Retain
+                      description: |-
+                        ExternalSecretTarget defines the Kubernetes Secret to be created
+                        There can be only one target per ExternalSecret.
+                      properties:
+                        creationPolicy:
+                          default: Owner
+                          description: |-
+                            CreationPolicy defines rules on how to create the resulting Secret.
+                            Defaults to "Owner"
+                          enum:
+                            - Owner
+                            - Orphan
+                            - Merge
+                            - None
+                          type: string
+                        deletionPolicy:
+                          default: Retain
+                          description: |-
+                            DeletionPolicy defines rules on how to delete the resulting Secret.
+                            Defaults to "Retain"
+                          enum:
+                            - Delete
+                            - Merge
+                            - Retain
+                          type: string
+                        immutable:
+                          description: Immutable defines if the final secret will be immutable
+                          type: boolean
+                        name:
+                          description: |-
+                            The name of the Secret resource to be managed.
+                            Defaults to the .metadata.name of the ExternalSecret resource
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        template:
+                          description: Template defines a blueprint for the created Secret resource.
+                          properties:
+                            data:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            engineVersion:
+                              default: v2
+                              description: |-
+                                EngineVersion specifies the template engine version
+                                that should be used to compile/execute the
+                                template specified in .data and .templateFrom[].
+                              enum:
+                                - v2
+                              type: string
+                            mergePolicy:
+                              default: Replace
+                              description: TemplateMergePolicy defines how template values should be merged when generating a secret.
+                              enum:
+                                - Replace
+                                - Merge
+                              type: string
+                            metadata:
+                              description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                              type: object
+                            templateFrom:
+                              items:
+                                description: TemplateFrom defines a source for template data.
+                                properties:
+                                  configMap:
+                                    description: TemplateRef defines a reference to a template source in a ConfigMap or Secret.
+                                    properties:
+                                      items:
+                                        description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                        items:
+                                          description: TemplateRefItem defines which key in the referenced ConfigMap or Secret to use as a template.
+                                          properties:
+                                            key:
+                                              description: A key in the ConfigMap/Secret
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[-._a-zA-Z0-9]+$
+                                              type: string
+                                            templateAs:
+                                              default: Values
+                                              description: TemplateScope defines the scope of the template when processing template data.
+                                              enum:
+                                                - Values
+                                                - KeysAndValues
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: The name of the ConfigMap/Secret resource
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        type: string
+                                    required:
+                                      - items
+                                      - name
+                                    type: object
+                                  literal:
+                                    type: string
+                                  secret:
+                                    description: TemplateRef defines a reference to a template source in a ConfigMap or Secret.
+                                    properties:
+                                      items:
+                                        description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                        items:
+                                          description: TemplateRefItem defines which key in the referenced ConfigMap or Secret to use as a template.
+                                          properties:
+                                            key:
+                                              description: A key in the ConfigMap/Secret
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[-._a-zA-Z0-9]+$
+                                              type: string
+                                            templateAs:
+                                              default: Values
+                                              description: TemplateScope defines the scope of the template when processing template data.
+                                              enum:
+                                                - Values
+                                                - KeysAndValues
+                                              type: string
+                                          required:
+                                            - key
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: The name of the ConfigMap/Secret resource
+                                        maxLength: 253
+                                        minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        type: string
+                                    required:
+                                      - items
+                                      - name
+                                    type: object
+                                  target:
+                                    default: Data
+                                    description: TemplateTarget defines the target field where the template result will be stored.
+                                    enum:
+                                      - Data
+                                      - Annotations
+                                      - Labels
+                                    type: string
+                                type: object
+                              type: array
+                            type:
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                namespaceSelector:
+                  description: The labels to select by to find the Namespaces to create the ExternalSecrets in
+                  properties:
+                    matchExpressions:
+                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                      items:
+                        description: |-
+                          A label selector requirement is a selector that contains values, a key, and an operator that
+                          relates the key and values.
+                        properties:
+                          key:
+                            description: key is the label key that the selector applies to.
+                            type: string
+                          operator:
+                            description: |-
+                              operator represents a key's relationship to a set of values.
+                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                            type: string
+                          values:
+                            description: |-
+                              values is an array of string values. If the operator is In or NotIn,
+                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                              the values array must be empty. This array is replaced during a strategic
+                              merge patch.
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                          - key
+                          - operator
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      description: |-
+                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                      type: object
+                  type: object
+                  x-kubernetes-map-type: atomic
+                namespaceSelectors:
+                  description: A list of labels to select by to find the Namespaces to create the ExternalSecrets in. The selectors are ORed.
+                  items:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                namespaces:
+                  description: |-
+                    Choose namespaces by name. This field is ORed with anything that NamespaceSelectors ends up choosing.
+
+                    Deprecated: Use NamespaceSelectors instead.
+                  items:
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  type: array
+                refreshTime:
+                  description: The time in which the controller should reconcile its objects and recheck namespaces for labels.
+                  type: string
+              required:
+                - externalSecretSpec
+              type: object
+            status:
+              description: ClusterExternalSecretStatus defines the observed state of ClusterExternalSecret.
+              properties:
+                conditions:
+                  items:
+                    description: ClusterExternalSecretStatusCondition indicates the status of the ClusterExternalSecret.
+                    properties:
+                      message:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ClusterExternalSecretConditionType indicates the condition of the ClusterExternalSecret.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                externalSecretName:
+                  description: ExternalSecretName is the name of the ExternalSecrets created by the ClusterExternalSecret
+                  type: string
+                failedNamespaces:
+                  description: Failed namespaces are the namespaces that failed to apply an ExternalSecret
+                  items:
+                    description: ClusterExternalSecretNamespaceFailure represents a failed namespace deployment and it's reason.
+                    properties:
+                      namespace:
+                        description: Namespace is the namespace that failed when trying to apply an ExternalSecret
+                        type: string
+                      reason:
+                        description: Reason is why the ExternalSecret failed to apply to the namespace
+                        type: string
+                    required:
+                      - namespace
+                    type: object
+                  type: array
+                provisionedNamespaces:
+                  description: ProvisionedNamespaces are the namespaces where the ClusterExternalSecret has secrets
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: false
+      storage: false
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-clustergenerators-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-clustergenerators-generators-external-secrets-io.yaml
@@ -1,0 +1,2536 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: clustergenerators.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: ClusterGenerator
+    listKind: ClusterGeneratorList
+    plural: clustergenerators
+    singular: clustergenerator
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ClusterGenerator represents a cluster-wide generator which can be referenced as part of `generatorRef` fields.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterGeneratorSpec defines the desired state of a ClusterGenerator.
+              properties:
+                generator:
+                  description: Generator the spec for this generator, must match the kind.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    acrAccessTokenSpec:
+                      description: |-
+                        ACRAccessTokenSpec defines how to generate the access token
+                        e.g. how to authenticate and which registry to use.
+                        see: https://github.com/Azure/acr/blob/main/docs/AAD-OAuth.md#overview
+                      properties:
+                        auth:
+                          description: ACRAuth defines the authentication methods for Azure Container Registry.
+                          properties:
+                            managedIdentity:
+                              description: ManagedIdentity uses Azure Managed Identity to authenticate with Azure.
+                              properties:
+                                identityId:
+                                  description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                                  type: string
+                              type: object
+                            servicePrincipal:
+                              description: ServicePrincipal uses Azure Service Principal credentials to authenticate with Azure.
+                              properties:
+                                secretRef:
+                                  description: |-
+                                    AzureACRServicePrincipalAuthSecretRef defines the secret references for Azure Service Principal authentication.
+                                    It uses static credentials stored in a Kind=Secret.
+                                  properties:
+                                    clientId:
+                                      description: The Azure clientId of the service principle used for authentication.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    clientSecret:
+                                      description: The Azure ClientSecret of the service principle used for authentication.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            workloadIdentity:
+                              description: WorkloadIdentity uses Azure Workload Identity to authenticate with Azure.
+                              properties:
+                                serviceAccountRef:
+                                  description: |-
+                                    ServiceAccountRef specified the service account
+                                    that should be used when authenticating with WorkloadIdentity.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                          type: object
+                        environmentType:
+                          default: PublicCloud
+                          description: |-
+                            EnvironmentType specifies the Azure cloud environment endpoints to use for
+                            connecting and authenticating with Azure. By default, it points to the public cloud AAD endpoint.
+                            The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                            PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud
+                          enum:
+                            - PublicCloud
+                            - USGovernmentCloud
+                            - ChinaCloud
+                            - GermanCloud
+                            - AzureStackCloud
+                          type: string
+                        registry:
+                          description: |-
+                            the domain name of the ACR registry
+                            e.g. foobarexample.azurecr.io
+                          type: string
+                        scope:
+                          description: |-
+                            Define the scope for the access token, e.g. pull/push access for a repository.
+                            if not provided it will return a refresh token that has full scope.
+                            Note: you need to pin it down to the repository level, there is no wildcard available.
+
+                            examples:
+                            repository:my-repository:pull,push
+                            repository:my-repository:pull
+
+                            see docs for details: https://docs.docker.com/registry/spec/auth/scope/
+                          type: string
+                        tenantId:
+                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type.
+                          type: string
+                      required:
+                        - auth
+                        - registry
+                      type: object
+                    beyondtrustWorkloadCredentialsDynamicSecretSpec:
+                      description: |-
+                        BeyondtrustWorkloadCredentialsDynamicSecretSpec defines the desired spec for BeyondtrustWorkloadCredentials dynamic generator.
+                        This generator enables obtaining temporary, short-lived credentials from BeyondTrust Workload Credentials.
+                        For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                      properties:
+                        controller:
+                          description: |-
+                            Controller selects the controller that should handle this generator.
+                            Leave empty to use the default controller.
+                          type: string
+                        provider:
+                          description: |-
+                            Provider contains the BeyondtrustWorkloadCredentials provider configuration including authentication,
+                            server connection details, and the folder path to the dynamic secret definition.
+                            The folderPath should point to a dynamic secret definition that has been created in
+                            BeyondTrust Workload Credentials (e.g., "production/aws-temp").
+                            For setup details, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                          properties:
+                            auth:
+                              description: |-
+                                Auth configures how the Operator authenticates with the BeyondTrust Workload Credentials API.
+                                Currently supports API key authentication via Kubernetes secret reference.
+                                For authentication setup, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                              properties:
+                                apikey:
+                                  description: |-
+                                    APIKey configures API token authentication for BeyondTrust Workload Credentials.
+                                    The token is retrieved from a Kubernetes secret and used as a Bearer token for API requests.
+                                  properties:
+                                    token:
+                                      description: |-
+                                        Token references the Kubernetes secret containing the BeyondTrust Workload Credentials API token.
+                                        The secret should contain the API key used to authenticate with BeyondTrust Workload Credentials.
+                                        Create an API token in your BeyondTrust Workload Credentials console and store it in a Kubernetes secret.
+                                        For details on creating API tokens, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - token
+                                  type: object
+                              required:
+                                - apikey
+                              type: object
+                            caBundle:
+                              description: |-
+                                CABundle is a base64-encoded CA certificate used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                                Use this when your BeyondTrust instance uses a self-signed certificate or internal CA.
+                                If not set, the system's trusted root certificates are used.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: |-
+                                CAProvider points to a Secret or ConfigMap containing a PEM-encoded CA certificate.
+                                This is used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                                Use this as an alternative to CABundle when you want to reference an existing Kubernetes resource.
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            folderPath:
+                              description: |-
+                                FolderPath specifies the default folder path for secret retrieval.
+                                Secrets will be fetched from this folder unless overridden in the ExternalSecret spec.
+                                Example: "production/database" or "dev/api-keys"
+                                Leave empty to retrieve secrets from the root folder.
+                                For folder organization, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#folders
+                              type: string
+                            server:
+                              description: |-
+                                Server configures the BeyondTrust Workload Credentials server connection details.
+                                Includes the API URL and Site ID for your BeyondTrust instance.
+                                For API reference, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                              properties:
+                                apiUrl:
+                                  description: |-
+                                    APIURL is the base URL of your BeyondTrust Workload Credentials API server.
+                                    This should be the full URL to your BeyondTrust instance.
+                                    Example: https://api.beyondtrust.io/siie
+                                    For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#base-url
+                                  type: string
+                                siteId:
+                                  description: |-
+                                    SiteID is your BeyondTrust Workload Credentials site identifier (UUID format).
+                                    This identifier is unique to your BeyondTrust Workload Credentials instance.
+                                    You can find your Site ID in the BeyondTrust Workload Credentials admin console.
+                                    Example: a1b2c3d4-e5f6-4890-abcd-ef1234567890
+                                    For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                                  type: string
+                              required:
+                                - apiUrl
+                                - siteId
+                              type: object
+                          required:
+                            - auth
+                            - server
+                          type: object
+                        retrySettings:
+                          description: |-
+                            RetrySettings configures exponential backoff for failed API requests.
+                            If not specified, uses the default retry settings.
+                          properties:
+                            maxRetries:
+                              format: int32
+                              type: integer
+                            retryInterval:
+                              type: string
+                          type: object
+                      required:
+                        - provider
+                      type: object
+                    cloudsmithAccessTokenSpec:
+                      description: CloudsmithAccessTokenSpec defines the configuration for generating a Cloudsmith access token using OIDC authentication.
+                      properties:
+                        apiUrl:
+                          description: APIURL configures the Cloudsmith API URL. Defaults to https://api.cloudsmith.io.
+                          type: string
+                        orgSlug:
+                          description: OrgSlug is the organization slug in Cloudsmith
+                          type: string
+                        serviceAccountRef:
+                          description: Name of the service account you are federating with
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        serviceSlug:
+                          description: ServiceSlug is the service slug in Cloudsmith for OIDC authentication
+                          type: string
+                      required:
+                        - orgSlug
+                        - serviceAccountRef
+                        - serviceSlug
+                      type: object
+                    ecrAuthorizationTokenSpec:
+                      description: ECRAuthorizationTokenSpec defines the desired state to generate an AWS ECR authorization token.
+                      properties:
+                        auth:
+                          description: Auth defines how to authenticate with AWS
+                          properties:
+                            jwt:
+                              description: AWSJWTAuth provides configuration to authenticate against AWS using service account tokens.
+                              properties:
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: |-
+                                AWSAuthSecretRef holds secret references for AWS credentials
+                                both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                sessionTokenSecretRef:
+                                  description: |-
+                                    The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                    see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        region:
+                          description: Region specifies the region to operate in.
+                          type: string
+                        role:
+                          description: |-
+                            You can assume a role before making calls to the
+                            desired AWS service.
+                          type: string
+                        scope:
+                          description: |-
+                            Scope specifies the ECR service scope.
+                            Valid options are private and public.
+                          type: string
+                      required:
+                        - region
+                      type: object
+                    fakeSpec:
+                      description: FakeSpec contains the static data.
+                      properties:
+                        controller:
+                          description: |-
+                            Used to select the correct ESO controller (think: ingress.ingressClassName)
+                            The ESO controller is instantiated with a specific controller name and filters VDS based on this property
+                          type: string
+                        data:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Data defines the static data returned
+                            by this generator.
+                          type: object
+                      type: object
+                    gcrAccessTokenSpec:
+                      description: GCRAccessTokenSpec defines the desired state to generate a Google Container Registry access token.
+                      properties:
+                        auth:
+                          description: Auth defines the means for authenticating with GCP
+                          properties:
+                            secretRef:
+                              description: GCPSMAuthSecretRef defines the reference to a secret containing Google Cloud Platform credentials.
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            workloadIdentity:
+                              description: GCPWorkloadIdentity defines the configuration for using GCP Workload Identity authentication.
+                              properties:
+                                clusterLocation:
+                                  type: string
+                                clusterName:
+                                  type: string
+                                clusterProjectID:
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - clusterLocation
+                                - clusterName
+                                - serviceAccountRef
+                              type: object
+                            workloadIdentityFederation:
+                              description: GCPWorkloadIdentityFederation holds the configurations required for generating federated access tokens.
+                              properties:
+                                audience:
+                                  description: |-
+                                    audience is the Secure Token Service (STS) audience which contains the resource name for the workload identity pool and the provider identifier in that pool.
+                                    If specified, Audience found in the external account credential config will be overridden with the configured value.
+                                    audience must be provided when serviceAccountRef or awsSecurityCredentials is configured.
+                                  type: string
+                                awsSecurityCredentials:
+                                  description: |-
+                                    awsSecurityCredentials is for configuring AWS region and credentials to use for obtaining the access token,
+                                    when using the AWS metadata server is not an option.
+                                  properties:
+                                    awsCredentialsSecretRef:
+                                      description: |-
+                                        awsCredentialsSecretRef is the reference to the secret which holds the AWS credentials.
+                                        Secret should be created with below names for keys
+                                        - aws_access_key_id: Access Key ID, which is the unique identifier for the AWS account or the IAM user.
+                                        - aws_secret_access_key: Secret Access Key, which is used to authenticate requests made to AWS services.
+                                        - aws_session_token: Session Token, is the short-lived token to authenticate requests made to AWS services.
+                                      properties:
+                                        name:
+                                          description: name of the secret.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: namespace in which the secret exists. If empty, secret will looked up in local namespace.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    region:
+                                      description: region is for configuring the AWS region to be used.
+                                      example: ap-south-1
+                                      maxLength: 50
+                                      minLength: 1
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                  required:
+                                    - awsCredentialsSecretRef
+                                    - region
+                                  type: object
+                                credConfig:
+                                  description: |-
+                                    credConfig holds the configmap reference containing the GCP external account credential configuration in JSON format and the key name containing the json data.
+                                    For using Kubernetes cluster as the identity provider, use serviceAccountRef instead. Operators mounted serviceaccount token cannot be used as the token source, instead
+                                    serviceAccountRef must be used by providing operators service account details.
+                                  properties:
+                                    key:
+                                      description: key name holding the external account credential config.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: name of the configmap.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: namespace in which the configmap exists. If empty, configmap will looked up in local namespace.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - key
+                                    - name
+                                  type: object
+                                externalTokenEndpoint:
+                                  description: |-
+                                    externalTokenEndpoint is the endpoint explicitly set up to provide tokens, which will be matched against the
+                                    credential_source.url in the provided credConfig. This field is merely to double-check the external token source
+                                    URL is having the expected value.
+                                  type: string
+                                gcpServiceAccountEmail:
+                                  description: |-
+                                    GCPServiceAccountEmail is the email of the Google Cloud service account to impersonate
+                                    after Workload Identity Federation. Use this to grant access through the service account's
+                                    IAM bindings (for example roles/secretmanager.secretAccessor). When set, it overrides
+                                    service_account_impersonation_url in the external account JSON from credConfig;
+                                    when serviceAccountRef is set, it also overrides the "iam.gke.io/gcp-service-account" annotation
+                                    on that ServiceAccount.
+                                  example: my-gsa@my-project.iam.gserviceaccount.com
+                                  minLength: 1
+                                  pattern: ^.*@.*\.iam\.gserviceaccount\.com$
+                                  type: string
+                                serviceAccountRef:
+                                  description: |-
+                                    serviceAccountRef is the reference to the kubernetes ServiceAccount to be used for obtaining the tokens,
+                                    when Kubernetes is configured as provider in workload identity pool.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                          type: object
+                        projectID:
+                          description: ProjectID defines which project to use to authenticate with
+                          type: string
+                      required:
+                        - auth
+                        - projectID
+                      type: object
+                    githubAccessTokenSpec:
+                      description: GithubAccessTokenSpec defines the desired state to generate a GitHub access token.
+                      properties:
+                        appID:
+                          type: string
+                        auth:
+                          description: Auth configures how ESO authenticates with a Github instance.
+                          properties:
+                            privateKey:
+                              description: GithubSecretRef references a secret containing GitHub credentials.
+                              properties:
+                                secretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                          required:
+                            - privateKey
+                          type: object
+                        installID:
+                          type: string
+                        permissions:
+                          additionalProperties:
+                            type: string
+                          description: Map of permissions the token will have. If omitted, defaults to all permissions the GitHub App has.
+                          type: object
+                        repositories:
+                          description: |-
+                            List of repositories the token will have access to. If omitted, defaults to all repositories the GitHub App
+                            is installed to.
+                          items:
+                            type: string
+                          type: array
+                        url:
+                          description: URL configures the GitHub instance URL. Defaults to https://github.com/.
+                          type: string
+                      required:
+                        - appID
+                        - auth
+                        - installID
+                      type: object
+                    gitlabDeployTokenSpec:
+                      description: GitlabDeployTokenSpec defines the desired state to generate a GitLab deploy token.
+                      properties:
+                        auth:
+                          description: Auth configures how ESO authenticates with the GitLab API.
+                          properties:
+                            token:
+                              description: |-
+                                Token references a secret containing a GitLab access token (personal, group, or
+                                project) with the api scope and at least the Maintainer role on the target.
+                              properties:
+                                secretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                          required:
+                            - token
+                          type: object
+                        expiresAt:
+                          description: |-
+                            ExpiresAt is an optional expiry for the deploy token. If omitted the token does
+                            not expire on the GitLab side and is revoked only when the generator state is
+                            cleaned up (on regeneration or when the consuming ExternalSecret is deleted).
+                          format: date-time
+                          type: string
+                        groupID:
+                          description: |-
+                            GroupID is the numeric ID or unescaped path (e.g. parent/group) of the group to
+                            create the deploy token in. The generator URL-escapes paths before calling the
+                            GitLab API, so do not pre-encode. Mutually exclusive with projectID.
+                          minLength: 1
+                          type: string
+                        name:
+                          description: Name of the deploy token.
+                          minLength: 1
+                          type: string
+                        projectID:
+                          description: |-
+                            ProjectID is the numeric ID or unescaped path (e.g. group/project) of the
+                            project to create the deploy token in. The generator URL-escapes paths before
+                            calling the GitLab API, so do not pre-encode. Mutually exclusive with groupID.
+                          minLength: 1
+                          type: string
+                        scopes:
+                          description: Scopes granted to the deploy token. At least one scope is required.
+                          items:
+                            description: GitlabDeployTokenScope is a scope that can be granted to a GitLab deploy token.
+                            enum:
+                              - read_repository
+                              - read_registry
+                              - write_registry
+                              - read_package_registry
+                              - write_package_registry
+                              - read_virtual_registry
+                              - write_virtual_registry
+                            type: string
+                          minItems: 1
+                          type: array
+                        url:
+                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com.
+                          type: string
+                        username:
+                          description: |-
+                            Username is an optional username for the deploy token. GitLab defaults it to
+                            gitlab+deploy-token-{n} when omitted.
+                          type: string
+                      required:
+                        - auth
+                        - name
+                        - scopes
+                      type: object
+                      x-kubernetes-validations:
+                        - message: exactly one of projectID or groupID must be set
+                          rule: has(self.projectID) != has(self.groupID)
+                    grafanaSpec:
+                      description: GrafanaSpec controls the behavior of the grafana generator.
+                      properties:
+                        auth:
+                          description: |-
+                            Auth is the authentication configuration to authenticate
+                            against the Grafana instance.
+                          properties:
+                            basic:
+                              description: |-
+                                Basic auth credentials used to authenticate against the Grafana instance.
+                                Note: you need a token which has elevated permissions to create service accounts.
+                                See here for the documentation on basic roles offered by Grafana:
+                                https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/
+                              properties:
+                                password:
+                                  description: A basic auth password used to authenticate against the Grafana instance.
+                                  properties:
+                                    key:
+                                      description: The key where the token is found.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: A basic auth username used to authenticate against the Grafana instance.
+                                  type: string
+                              required:
+                                - password
+                                - username
+                              type: object
+                            token:
+                              description: |-
+                                A service account token used to authenticate against the Grafana instance.
+                                Note: you need a token which has elevated permissions to create service accounts.
+                                See here for the documentation on basic roles offered by Grafana:
+                                https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/
+                              properties:
+                                key:
+                                  description: The key where the token is found.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                              type: object
+                          type: object
+                        serviceAccount:
+                          description: |-
+                            ServiceAccount is the configuration for the service account that
+                            is supposed to be generated by the generator.
+                          properties:
+                            name:
+                              description: Name is the name of the service account that will be created by ESO.
+                              type: string
+                            role:
+                              description: |-
+                                Role is the role of the service account.
+                                See here for the documentation on basic roles offered by Grafana:
+                                https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/
+                              type: string
+                            secondsToLive:
+                              description: |-
+                                SecondsToLive is the number of seconds before the generated service account token will expire.
+                                Some Grafana deployments (e.g. AWS Managed Grafana) require this value to be set.
+                              format: int64
+                              minimum: 1
+                              type: integer
+                          required:
+                            - name
+                            - role
+                          type: object
+                        url:
+                          description: URL is the URL of the Grafana instance.
+                          type: string
+                      required:
+                        - auth
+                        - serviceAccount
+                        - url
+                      type: object
+                    mfaSpec:
+                      description: MFASpec controls the behavior of the mfa generator.
+                      properties:
+                        algorithm:
+                          description: Algorithm to use for encoding. Defaults to SHA1 as per the RFC.
+                          type: string
+                        length:
+                          description: Length defines the token length. Defaults to 6 characters.
+                          type: integer
+                        secret:
+                          description: Secret is a secret selector to a secret containing the seed secret to generate the TOTP value from.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        timePeriod:
+                          description: TimePeriod defines how long the token can be active. Defaults to 30 seconds.
+                          type: integer
+                        when:
+                          description: When defines a time parameter that can be used to pin the origin time of the generated token.
+                          format: date-time
+                          type: string
+                      required:
+                        - secret
+                      type: object
+                    passwordSpec:
+                      description: PasswordSpec controls the behavior of the password generator.
+                      properties:
+                        allowRepeat:
+                          default: false
+                          description: set AllowRepeat to true to allow repeating characters.
+                          type: boolean
+                        digits:
+                          description: |-
+                            Digits specifies the number of digits in the generated
+                            password. If omitted it defaults to 25% of the length of the password
+                          type: integer
+                        encoding:
+                          default: raw
+                          description: |-
+                            Encoding specifies the encoding of the generated password.
+                            Valid values are:
+                            - "raw" (default): no encoding
+                            - "base64": standard base64 encoding
+                            - "base64url": base64url encoding
+                            - "base32": base32 encoding
+                            - "hex": hexadecimal encoding
+                          enum:
+                            - base64
+                            - base64url
+                            - base32
+                            - hex
+                            - raw
+                          type: string
+                        length:
+                          default: 24
+                          description: |-
+                            Length of the password to be generated.
+                            Defaults to 24
+                          type: integer
+                        noUpper:
+                          default: false
+                          description: Set NoUpper to disable uppercase characters
+                          type: boolean
+                        secretKeys:
+                          description: |-
+                            SecretKeys defines the keys that will be populated with generated passwords.
+                            Defaults to "password" when not set.
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                        symbolCharacters:
+                          description: |-
+                            SymbolCharacters specifies the special characters that should be used
+                            in the generated password.
+                          type: string
+                        symbols:
+                          description: |-
+                            Symbols specifies the number of symbol characters in the generated
+                            password. If omitted it defaults to 25% of the length of the password
+                          type: integer
+                      required:
+                        - allowRepeat
+                        - length
+                        - noUpper
+                      type: object
+                    quayAccessTokenSpec:
+                      description: QuayAccessTokenSpec defines the desired state to generate a Quay access token.
+                      properties:
+                        robotAccount:
+                          description: Name of the robot account you are federating with
+                          type: string
+                        serviceAccountRef:
+                          description: Name of the service account you are federating with
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        url:
+                          description: URL configures the Quay instance URL. Defaults to quay.io.
+                          type: string
+                      required:
+                        - robotAccount
+                        - serviceAccountRef
+                      type: object
+                    sshKeySpec:
+                      description: SSHKeySpec controls the behavior of the ssh key generator.
+                      properties:
+                        comment:
+                          description: Comment specifies an optional comment for the SSH key
+                          type: string
+                        keySize:
+                          description: |-
+                            KeySize specifies the key size for RSA keys (default: 2048) and ECDSA keys (default: 256).
+                            For RSA keys: 2048, 3072, 4096
+                            For ECDSA keys: 256, 384, 521
+                            Ignored for ed25519 keys
+                          maximum: 8192
+                          minimum: 256
+                          type: integer
+                        keyType:
+                          default: rsa
+                          description: KeyType specifies the SSH key type (rsa, ecdsa, ed25519)
+                          enum:
+                            - rsa
+                            - ecdsa
+                            - ed25519
+                          type: string
+                      type: object
+                    stsSessionTokenSpec:
+                      description: STSSessionTokenSpec defines the desired state to generate an AWS STS session token.
+                      properties:
+                        auth:
+                          description: Auth defines how to authenticate with AWS
+                          properties:
+                            jwt:
+                              description: AWSJWTAuth provides configuration to authenticate against AWS using service account tokens.
+                              properties:
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: |-
+                                AWSAuthSecretRef holds secret references for AWS credentials
+                                both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                sessionTokenSecretRef:
+                                  description: |-
+                                    The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                    see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        region:
+                          description: Region specifies the region to operate in.
+                          type: string
+                        requestParameters:
+                          description: RequestParameters contains parameters that can be passed to the STS service.
+                          properties:
+                            serialNumber:
+                              description: |-
+                                SerialNumber is the identification number of the MFA device that is associated with the IAM user who is making
+                                the GetSessionToken call.
+                                Possible values: hardware device (such as GAHT12345678) or an Amazon Resource Name (ARN) for a virtual device
+                                (such as arn:aws:iam::123456789012:mfa/user)
+                              type: string
+                            sessionDuration:
+                              format: int32
+                              type: integer
+                            tokenCode:
+                              description: TokenCode is the value provided by the MFA device, if MFA is required.
+                              type: string
+                          type: object
+                        role:
+                          description: |-
+                            You can assume a role before making calls to the
+                            desired AWS service.
+                          type: string
+                      required:
+                        - region
+                      type: object
+                    uuidSpec:
+                      description: UUIDSpec controls the behavior of the uuid generator.
+                      type: object
+                    vaultDynamicSecretSpec:
+                      description: VaultDynamicSecretSpec defines the desired spec of VaultDynamicSecret.
+                      properties:
+                        allowEmptyResponse:
+                          default: false
+                          description: Do not fail if no secrets are found. Useful for requests where no data is expected.
+                          type: boolean
+                        controller:
+                          description: |-
+                            Used to select the correct ESO controller (think: ingress.ingressClassName)
+                            The ESO controller is instantiated with a specific controller name and filters VDS based on this property
+                          type: string
+                        getParameters:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: |-
+                            GetParameters are query-string parameters passed to Vault on GET calls.
+                            Each key may map to multiple values, matching HTTP query-string semantics.
+                            Ignored for non-GET methods; use Parameters for write bodies.
+                          type: object
+                        method:
+                          description: Vault API method to use (GET/POST/other)
+                          type: string
+                        parameters:
+                          description: Parameters to pass to Vault write (for non-GET methods)
+                          x-kubernetes-preserve-unknown-fields: true
+                        path:
+                          description: Vault path to obtain the dynamic secret from
+                          type: string
+                        provider:
+                          description: Vault provider common spec
+                          properties:
+                            auth:
+                              description: Auth configures how secret-manager authenticates with the Vault server.
+                              properties:
+                                appRole:
+                                  description: |-
+                                    AppRole authenticates with Vault using the App Role auth mechanism,
+                                    with the role and secret stored in a Kubernetes Secret resource.
+                                  properties:
+                                    path:
+                                      default: approle
+                                      description: |-
+                                        Path where the App Role authentication backend is mounted
+                                        in Vault, e.g: "approle"
+                                      type: string
+                                    roleId:
+                                      description: |-
+                                        RoleID configured in the App Role authentication backend when setting
+                                        up the authentication backend in Vault.
+                                      type: string
+                                    roleRef:
+                                      description: |-
+                                        Reference to a key in a Secret that contains the App Role ID used
+                                        to authenticate with Vault.
+                                        The `key` field must be specified and denotes which entry within the Secret
+                                        resource is used as the app role id.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    secretRef:
+                                      description: |-
+                                        Reference to a key in a Secret that contains the App Role secret used
+                                        to authenticate with Vault.
+                                        The `key` field must be specified and denotes which entry within the Secret
+                                        resource is used as the app role secret.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - path
+                                    - secretRef
+                                  type: object
+                                cert:
+                                  description: |-
+                                    Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate
+                                    Cert authentication method
+                                  properties:
+                                    clientCert:
+                                      description: |-
+                                        ClientCert is a certificate to authenticate using the Cert Vault
+                                        authentication method
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    path:
+                                      default: cert
+                                      description: |-
+                                        Path where the Certificate authentication backend is mounted
+                                        in Vault, e.g: "cert"
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef to a key in a Secret resource containing client private key to
+                                        authenticate with Vault using the Cert authentication method
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    vaultRole:
+                                      description: VaultRole specifies the Vault role to use for TLS certificate authentication.
+                                      type: string
+                                  type: object
+                                gcp:
+                                  description: |-
+                                    Gcp authenticates with Vault using Google Cloud Platform authentication method
+                                    GCP authentication method
+                                  properties:
+                                    location:
+                                      description: Location optionally defines a location/region for the secret
+                                      type: string
+                                    path:
+                                      default: gcp
+                                      description: 'Path where the GCP auth method is enabled in Vault, e.g: "gcp"'
+                                      type: string
+                                    projectID:
+                                      description: Project ID of the Google Cloud Platform project
+                                      type: string
+                                    role:
+                                      description: Vault Role. In Vault, a role describes an identity with a set of permissions, groups, or policies you want to attach to a user of the secrets engine.
+                                      type: string
+                                    secretRef:
+                                      description: Specify credentials in a Secret object
+                                      properties:
+                                        secretAccessKeySecretRef:
+                                          description: The SecretAccessKey is used for authentication
+                                          properties:
+                                            key:
+                                              description: |-
+                                                A key in the referenced Secret.
+                                                Some instances of this field may be defaulted, in others it may be required.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[-._a-zA-Z0-9]+$
+                                              type: string
+                                            name:
+                                              description: The name of the Secret resource being referred to.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                The namespace of the Secret resource being referred to.
+                                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                          type: object
+                                      type: object
+                                    serviceAccountRef:
+                                      description: ServiceAccountRef to a service account for impersonation
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    workloadIdentity:
+                                      description: Specify a service account with Workload Identity
+                                      properties:
+                                        clusterLocation:
+                                          description: |-
+                                            ClusterLocation is the location of the cluster
+                                            If not specified, it fetches information from the metadata server
+                                          type: string
+                                        clusterName:
+                                          description: |-
+                                            ClusterName is the name of the cluster
+                                            If not specified, it fetches information from the metadata server
+                                          type: string
+                                        clusterProjectID:
+                                          description: |-
+                                            ClusterProjectID is the project ID of the cluster
+                                            If not specified, it fetches information from the metadata server
+                                          type: string
+                                        serviceAccountRef:
+                                          description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                          properties:
+                                            audiences:
+                                              description: |-
+                                                Audience specifies the `aud` claim for the service account token
+                                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                                then this audiences will be appended to the list
+                                              items:
+                                                type: string
+                                              type: array
+                                            name:
+                                              description: The name of the ServiceAccount resource being referred to.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                Namespace of the resource being referred to.
+                                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                      required:
+                                        - serviceAccountRef
+                                      type: object
+                                  required:
+                                    - role
+                                  type: object
+                                iam:
+                                  description: |-
+                                    Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials
+                                    AWS IAM authentication method
+                                  properties:
+                                    externalID:
+                                      description: AWS External ID set on assumed IAM roles
+                                      type: string
+                                    jwt:
+                                      description: Specify a service account with IRSA enabled
+                                      properties:
+                                        serviceAccountRef:
+                                          description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                          properties:
+                                            audiences:
+                                              description: |-
+                                                Audience specifies the `aud` claim for the service account token
+                                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                                then this audiences will be appended to the list
+                                              items:
+                                                type: string
+                                              type: array
+                                            name:
+                                              description: The name of the ServiceAccount resource being referred to.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                Namespace of the resource being referred to.
+                                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                      type: object
+                                    path:
+                                      description: 'Path where the AWS auth method is enabled in Vault, e.g: "aws"'
+                                      type: string
+                                    region:
+                                      description: AWS region
+                                      type: string
+                                    role:
+                                      description: This is the AWS role to be assumed before talking to vault
+                                      type: string
+                                    secretRef:
+                                      description: Specify credentials in a Secret object
+                                      properties:
+                                        accessKeyIDSecretRef:
+                                          description: The AccessKeyID is used for authentication
+                                          properties:
+                                            key:
+                                              description: |-
+                                                A key in the referenced Secret.
+                                                Some instances of this field may be defaulted, in others it may be required.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[-._a-zA-Z0-9]+$
+                                              type: string
+                                            name:
+                                              description: The name of the Secret resource being referred to.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                The namespace of the Secret resource being referred to.
+                                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                          type: object
+                                        secretAccessKeySecretRef:
+                                          description: The SecretAccessKey is used for authentication
+                                          properties:
+                                            key:
+                                              description: |-
+                                                A key in the referenced Secret.
+                                                Some instances of this field may be defaulted, in others it may be required.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[-._a-zA-Z0-9]+$
+                                              type: string
+                                            name:
+                                              description: The name of the Secret resource being referred to.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                The namespace of the Secret resource being referred to.
+                                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                          type: object
+                                        sessionTokenSecretRef:
+                                          description: |-
+                                            The SessionToken used for authentication
+                                            This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                            see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                          properties:
+                                            key:
+                                              description: |-
+                                                A key in the referenced Secret.
+                                                Some instances of this field may be defaulted, in others it may be required.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[-._a-zA-Z0-9]+$
+                                              type: string
+                                            name:
+                                              description: The name of the Secret resource being referred to.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                The namespace of the Secret resource being referred to.
+                                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                          type: object
+                                      type: object
+                                    vaultAwsIamServerID:
+                                      description: 'X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws'
+                                      type: string
+                                    vaultRole:
+                                      description: Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine
+                                      type: string
+                                  required:
+                                    - vaultRole
+                                  type: object
+                                jwt:
+                                  description: |-
+                                    Jwt authenticates with Vault by passing role and JWT token using the
+                                    JWT/OIDC authentication method
+                                  properties:
+                                    kubernetesServiceAccountToken:
+                                      description: |-
+                                        Optional ServiceAccountToken specifies the Kubernetes service account for which to request
+                                        a token for with the `TokenRequest` API.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Optional audiences field that will be used to request a temporary Kubernetes service
+                                            account token for the service account referenced by `serviceAccountRef`.
+                                            Defaults to a single audience `vault` it not specified.
+
+                                            Deprecated: use serviceAccountRef.Audiences instead
+                                          items:
+                                            type: string
+                                          type: array
+                                        expirationSeconds:
+                                          description: |-
+                                            Optional expiration time in seconds that will be used to request a temporary
+                                            Kubernetes service account token for the service account referenced by
+                                            `serviceAccountRef`.
+
+                                            Deprecated: this will be removed in the future.
+                                            Defaults to 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        serviceAccountRef:
+                                          description: Service account field containing the name of a kubernetes ServiceAccount.
+                                          properties:
+                                            audiences:
+                                              description: |-
+                                                Audience specifies the `aud` claim for the service account token
+                                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                                then this audiences will be appended to the list
+                                              items:
+                                                type: string
+                                              type: array
+                                            name:
+                                              description: The name of the ServiceAccount resource being referred to.
+                                              maxLength: 253
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                Namespace of the resource being referred to.
+                                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                      required:
+                                        - serviceAccountRef
+                                      type: object
+                                    path:
+                                      default: jwt
+                                      description: |-
+                                        Path where the JWT authentication backend is mounted
+                                        in Vault, e.g: "jwt"
+                                      type: string
+                                    role:
+                                      description: |-
+                                        Role is a JWT role to authenticate using the JWT/OIDC Vault
+                                        authentication method
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                        authenticate with Vault using the JWT/OIDC authentication method.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  required:
+                                    - path
+                                  type: object
+                                kubernetes:
+                                  description: |-
+                                    Kubernetes authenticates with Vault by passing the ServiceAccount
+                                    token stored in the named Secret resource to the Vault server.
+                                  properties:
+                                    mountPath:
+                                      default: kubernetes
+                                      description: |-
+                                        Path where the Kubernetes authentication backend is mounted in Vault, e.g:
+                                        "kubernetes"
+                                      type: string
+                                    role:
+                                      description: |-
+                                        A required field containing the Vault Role to assume. A Role binds a
+                                        Kubernetes ServiceAccount with a set of Vault policies.
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                        for authenticating with Vault. If a name is specified without a key,
+                                        `token` is the default. If one is not specified, the one bound to
+                                        the controller will be used.
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    serviceAccountRef:
+                                      description: |-
+                                        Optional service account field containing the name of a kubernetes ServiceAccount.
+                                        If the service account is specified, the service account secret token JWT will be used
+                                        for authenticating with Vault. If the service account selector is not supplied,
+                                        the secretRef will be used instead.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - mountPath
+                                    - role
+                                  type: object
+                                ldap:
+                                  description: |-
+                                    Ldap authenticates with Vault by passing username/password pair using
+                                    the LDAP authentication method
+                                  properties:
+                                    path:
+                                      default: ldap
+                                      description: |-
+                                        Path where the LDAP authentication backend is mounted
+                                        in Vault, e.g: "ldap"
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef to a key in a Secret resource containing password for the LDAP
+                                        user used to authenticate with Vault using the LDAP authentication
+                                        method
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    username:
+                                      description: |-
+                                        Username is an LDAP username used to authenticate using the LDAP Vault
+                                        authentication method
+                                      type: string
+                                  required:
+                                    - path
+                                    - username
+                                  type: object
+                                namespace:
+                                  description: |-
+                                    Name of the vault namespace to authenticate to. This can be different than the namespace your secret is in.
+                                    Namespaces is a set of features within Vault Enterprise that allows
+                                    Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                                    More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                                    This will default to Vault.Namespace field if set, or empty otherwise
+                                  type: string
+                                tokenSecretRef:
+                                  description: TokenSecretRef authenticates with Vault by presenting a token.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                userPass:
+                                  description: UserPass authenticates with Vault by passing username/password pair
+                                  properties:
+                                    path:
+                                      default: userpass
+                                      description: |-
+                                        Path where the UserPassword authentication backend is mounted
+                                        in Vault, e.g: "userpass"
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        SecretRef to a key in a Secret resource containing password for the
+                                        user used to authenticate with Vault using the UserPass authentication
+                                        method
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    username:
+                                      description: |-
+                                        Username is a username used to authenticate using the UserPass Vault
+                                        authentication method
+                                      type: string
+                                  required:
+                                    - path
+                                    - username
+                                  type: object
+                              type: object
+                            caBundle:
+                              description: |-
+                                PEM encoded CA bundle used to validate Vault server certificate. Only used
+                                if the Server URL is using HTTPS protocol. This parameter is ignored for
+                                plain HTTP protocol connection. If not set the system root certificates
+                                are used to validate the TLS connection.
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: The provider for the CA bundle to use to validate Vault server certificate.
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            checkAndSet:
+                              description: |-
+                                CheckAndSet defines the Check-And-Set (CAS) settings for PushSecret operations.
+                                Only applies to Vault KV v2 stores. When enabled, write operations must include
+                                the current version of the secret to prevent unintentional overwrites.
+                              properties:
+                                required:
+                                  description: |-
+                                    Required when true, all write operations must include a check-and-set parameter.
+                                    This helps prevent unintentional overwrites of secrets.
+                                  type: boolean
+                              type: object
+                            forwardInconsistent:
+                              description: |-
+                                ForwardInconsistent tells Vault to forward read-after-write requests to the Vault
+                                leader instead of simply retrying within a loop. This can increase performance if
+                                the option is enabled serverside.
+                                https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                              type: boolean
+                            headers:
+                              additionalProperties:
+                                type: string
+                              description: Headers to be added in Vault request
+                              type: object
+                            namespace:
+                              description: |-
+                                Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
+                                Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                                More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                              type: string
+                            path:
+                              description: |-
+                                Path is the mount path of the Vault KV backend endpoint, e.g:
+                                "secret". The v2 KV secret engine version specific "/data" path suffix
+                                for fetching secrets from Vault is optional and will be appended
+                                if not present in specified path.
+                              type: string
+                            readYourWrites:
+                              description: |-
+                                ReadYourWrites ensures isolated read-after-write semantics by
+                                providing discovered cluster replication states in each request.
+                                More information about eventual consistency in Vault can be found here
+                                https://www.vaultproject.io/docs/enterprise/consistency
+                              type: boolean
+                            server:
+                              description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                              type: string
+                            tls:
+                              description: |-
+                                The configuration used for client side related TLS communication, when the Vault server
+                                requires mutual authentication. Only used if the Server URL is using HTTPS protocol.
+                                This parameter is ignored for plain HTTP protocol connection.
+                                It's worth noting this configuration is different from the "TLS certificates auth method",
+                                which is available under the `auth.cert` section.
+                              properties:
+                                certSecretRef:
+                                  description: |-
+                                    CertSecretRef is a certificate added to the transport layer
+                                    when communicating with the Vault server.
+                                    If no key for the Secret is specified, external-secret will default to 'tls.crt'.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                keySecretRef:
+                                  description: |-
+                                    KeySecretRef to a key in a Secret resource containing client private key
+                                    added to the transport layer when communicating with the Vault server.
+                                    If no key for the Secret is specified, external-secret will default to 'tls.key'.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            version:
+                              default: v2
+                              description: |-
+                                Version is the Vault KV secret engine version. This can be either "v1" or
+                                "v2". Version defaults to "v2".
+                              enum:
+                                - v1
+                                - v2
+                              type: string
+                          required:
+                            - server
+                          type: object
+                        resultType:
+                          default: Data
+                          description: |-
+                            Result type defines which data is returned from the generator.
+                            By default, it is the "data" section of the Vault API response.
+                            When using e.g. /auth/token/create the "data" section is empty but
+                            the "auth" section contains the generated token.
+                            Please refer to the vault docs regarding the result data structure.
+                            Additionally, accessing the raw response is possibly by using "Raw" result type.
+                          enum:
+                            - Data
+                            - Auth
+                            - Raw
+                          type: string
+                        retrySettings:
+                          description: Used to configure http retries if failed
+                          properties:
+                            maxRetries:
+                              format: int32
+                              type: integer
+                            retryInterval:
+                              type: string
+                          type: object
+                      required:
+                        - path
+                        - provider
+                      type: object
+                    webhookSpec:
+                      description: WebhookSpec controls the behavior of the external generator. Any body parameters should be passed to the server through the parameters field.
+                      properties:
+                        auth:
+                          description: Auth specifies a authorization protocol. Only one protocol may be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            ntlm:
+                              description: NTLMProtocol configures the store to use NTLM for auth
+                              properties:
+                                passwordSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                usernameSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - passwordSecret
+                                - usernameSecret
+                              type: object
+                          type: object
+                        body:
+                          description: Body
+                          type: string
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate webhook server certificate. Only used
+                            if the Server URL is using HTTPS protocol. This parameter is ignored for
+                            plain HTTP protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers
+                          type: object
+                        method:
+                          description: Webhook Method
+                          type: string
+                        result:
+                          description: Result formatting
+                          properties:
+                            jsonPath:
+                              description: Json path of return value
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets to fill in templates
+                            These secrets will be passed to the templating function as key value pairs under the given name
+                          items:
+                            description: WebhookSecret defines a secret reference that will be used in webhook templates.
+                            properties:
+                              name:
+                                description: Name of this secret in templates
+                                type: string
+                              secretRef:
+                                description: Secret ref to fill in credentials
+                                properties:
+                                  key:
+                                    description: The key where the token is found.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[-._a-zA-Z0-9]+$
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being referred to.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                type: object
+                            required:
+                              - name
+                              - secretRef
+                            type: object
+                          type: array
+                        timeout:
+                          description: Timeout
+                          type: string
+                        url:
+                          description: Webhook url to call
+                          type: string
+                      required:
+                        - result
+                        - url
+                      type: object
+                  type: object
+                kind:
+                  description: Kind the kind of this generator.
+                  enum:
+                    - ACRAccessToken
+                    - BeyondtrustWorkloadCredentialsDynamicSecret
+                    - CloudsmithAccessToken
+                    - ECRAuthorizationToken
+                    - Fake
+                    - GCRAccessToken
+                    - GithubAccessToken
+                    - GitlabDeployToken
+                    - QuayAccessToken
+                    - Password
+                    - SSHKey
+                    - STSSessionToken
+                    - UUID
+                    - VaultDynamicSecret
+                    - Webhook
+                    - Grafana
+                    - MFA
+                  type: string
+              required:
+                - generator
+                - kind
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-clusterpushsecrets-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-clusterpushsecrets-external-secrets-io.yaml
@@ -1,0 +1,689 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: clusterpushsecrets.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - external-secrets
+    kind: ClusterPushSecret
+    listKind: ClusterPushSecretList
+    plural: clusterpushsecrets
+    singular: clusterpushsecret
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: ClusterPushSecret is the Schema for the ClusterPushSecrets API that enables cluster-wide management of pushing Kubernetes secrets to external providers.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterPushSecretSpec defines the configuration for a ClusterPushSecret resource.
+              properties:
+                namespaceSelectors:
+                  description: A list of labels to select by to find the Namespaces to create the ExternalSecrets in. The selectors are ORed.
+                  items:
+                    description: |-
+                      A label selector is a label query over a set of resources. The result of matchLabels and
+                      matchExpressions are ANDed. An empty label selector matches all objects. A null
+                      label selector matches no objects.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                            - key
+                            - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  type: array
+                pushSecretMetadata:
+                  description: The metadata of the external secrets to be created
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                pushSecretName:
+                  description: |-
+                    The name of the push secrets to be created.
+                    Defaults to the name of the ClusterPushSecret
+                  maxLength: 253
+                  minLength: 1
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                pushSecretSpec:
+                  description: PushSecretSpec defines what to do with the secrets.
+                  properties:
+                    data:
+                      description: Secret Data that should be pushed to providers
+                      items:
+                        description: PushSecretData defines data to be pushed to the provider and associated metadata.
+                        properties:
+                          conversionStrategy:
+                            default: None
+                            description: Used to define a conversion Strategy for the secret keys
+                            enum:
+                              - None
+                              - ReverseUnicode
+                            type: string
+                          match:
+                            description: Match a given Secret Key to be pushed to the provider.
+                            properties:
+                              remoteRef:
+                                description: Remote Refs to push to providers.
+                                properties:
+                                  property:
+                                    description: Name of the property in the resulting secret
+                                    type: string
+                                  remoteKey:
+                                    description: Name of the resulting provider secret.
+                                    type: string
+                                required:
+                                  - remoteKey
+                                type: object
+                              secretKey:
+                                description: Secret Key to be pushed
+                                type: string
+                            required:
+                              - remoteRef
+                            type: object
+                          metadata:
+                            description: |-
+                              Metadata is metadata attached to the secret.
+                              The structure of metadata is provider specific, please look it up in the provider documentation.
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                          - match
+                        type: object
+                      type: array
+                    dataTo:
+                      description: DataTo defines bulk push rules that expand source Secret keys into provider entries.
+                      items:
+                        description: PushSecretDataTo defines how to bulk-push secrets to providers without explicit per-key mappings.
+                        properties:
+                          conversionStrategy:
+                            default: None
+                            description: Used to define a conversion Strategy for the secret keys
+                            enum:
+                              - None
+                              - ReverseUnicode
+                            type: string
+                          match:
+                            description: |-
+                              Match pattern for selecting keys from the source Secret.
+                              If not specified, all keys are selected.
+                            properties:
+                              regexp:
+                                description: |-
+                                  Regexp matches keys by regular expression.
+                                  If not specified, all keys are matched.
+                                type: string
+                            type: object
+                          metadata:
+                            description: |-
+                              Metadata is metadata attached to the secret.
+                              The structure of metadata is provider specific, please look it up in the provider documentation.
+                            x-kubernetes-preserve-unknown-fields: true
+                          remoteKey:
+                            description: |-
+                              RemoteKey is the name of the single provider secret that will receive ALL
+                              matched keys bundled as a JSON object (e.g. {"DB_HOST":"...","DB_USER":"..."}).
+                              When set, per-key expansion is skipped and a single push is performed.
+                              The provider's store prefix (if any) is still prepended to this value.
+                              When not set, each matched key is pushed as its own individual provider secret.
+                            type: string
+                          rewrite:
+                            description: |-
+                              Rewrite operations to transform keys before pushing to the provider.
+                              Operations are applied sequentially.
+                            items:
+                              description: PushSecretRewrite defines how to transform secret keys before pushing.
+                              properties:
+                                regexp:
+                                  description: Used to rewrite with regular expressions.
+                                  properties:
+                                    source:
+                                      description: Used to define the regular expression of a re.Compiler.
+                                      type: string
+                                    target:
+                                      description: Used to define the target pattern of a ReplaceAll operation.
+                                      type: string
+                                  required:
+                                    - source
+                                    - target
+                                  type: object
+                                transform:
+                                  description: Used to apply string transformation on the secrets.
+                                  properties:
+                                    template:
+                                      description: |-
+                                        Used to define the template to apply on the secret name.
+                                        `.value ` will specify the secret name in the template.
+                                      type: string
+                                  required:
+                                    - template
+                                  type: object
+                              type: object
+                              x-kubernetes-validations:
+                                - message: exactly one of regexp or transform must be set
+                                  rule: (has(self.regexp) && !has(self.transform)) || (!has(self.regexp) && has(self.transform))
+                            type: array
+                          storeRef:
+                            description: StoreRef specifies which SecretStore to push to. Required.
+                            properties:
+                              kind:
+                                default: SecretStore
+                                description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                                enum:
+                                  - SecretStore
+                                  - ClusterSecretStore
+                                type: string
+                              labelSelector:
+                                description: Optionally, sync to secret stores with label selector
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              name:
+                                description: Optionally, sync to the SecretStore of the given name
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: storeRef must specify either name or labelSelector
+                            rule: has(self.storeRef) && (has(self.storeRef.name) || has(self.storeRef.labelSelector))
+                          - message: 'remoteKey and rewrite are mutually exclusive: rewrite is only supported in per-key mode (without remoteKey)'
+                            rule: '!has(self.remoteKey) || !has(self.rewrite) || size(self.rewrite) == 0'
+                      type: array
+                    deletionPolicy:
+                      default: None
+                      description: Deletion Policy to handle Secrets in the provider.
+                      enum:
+                        - Delete
+                        - None
+                      type: string
+                    refreshInterval:
+                      default: 1h0m0s
+                      description: The Interval to which External Secrets will try to push a secret definition
+                      type: string
+                    secretStoreRefs:
+                      items:
+                        description: PushSecretStoreRef contains a reference on how to sync to a SecretStore.
+                        properties:
+                          kind:
+                            default: SecretStore
+                            description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                            enum:
+                              - SecretStore
+                              - ClusterSecretStore
+                            type: string
+                          labelSelector:
+                            description: Optionally, sync to secret stores with label selector
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          name:
+                            description: Optionally, sync to the SecretStore of the given name
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        type: object
+                      type: array
+                    selector:
+                      description: The Secret Selector (k8s source) for the Push Secret
+                      maxProperties: 1
+                      minProperties: 1
+                      properties:
+                        generatorRef:
+                          description: Point to a generator to create a Secret.
+                          properties:
+                            apiVersion:
+                              default: generators.external-secrets.io/v1alpha1
+                              description: Specify the apiVersion of the generator resource
+                              type: string
+                            kind:
+                              description: Specify the Kind of the generator resource
+                              enum:
+                                - ACRAccessToken
+                                - BeyondtrustWorkloadCredentialsDynamicSecret
+                                - ClusterGenerator
+                                - CloudsmithAccessToken
+                                - ECRAuthorizationToken
+                                - Fake
+                                - GCRAccessToken
+                                - GithubAccessToken
+                                - GitlabDeployToken
+                                - QuayAccessToken
+                                - Password
+                                - SSHKey
+                                - STSSessionToken
+                                - UUID
+                                - VaultDynamicSecret
+                                - Webhook
+                                - Grafana
+                                - MFA
+                              type: string
+                            name:
+                              description: Specify the name of the generator resource
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                          required:
+                            - kind
+                            - name
+                          type: object
+                        secret:
+                          description: Select a Secret to Push.
+                          properties:
+                            name:
+                              description: |-
+                                Name of the Secret.
+                                The Secret must exist in the same namespace as the PushSecret manifest.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            selector:
+                              description: Selector chooses secrets using a labelSelector.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                      - key
+                                      - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      type: object
+                    template:
+                      description: Template defines a blueprint for the created Secret resource.
+                      properties:
+                        data:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        engineVersion:
+                          default: v2
+                          description: |-
+                            EngineVersion specifies the template engine version
+                            that should be used to compile/execute the
+                            template specified in .data and .templateFrom[].
+                          enum:
+                            - v2
+                          type: string
+                        mergePolicy:
+                          default: Replace
+                          description: TemplateMergePolicy defines how the rendered template should be merged with the existing Secret data.
+                          enum:
+                            - Replace
+                            - Merge
+                          type: string
+                        metadata:
+                          description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        templateFrom:
+                          items:
+                            description: |-
+                              TemplateFrom specifies a source for templates.
+                              Each item in the list can either reference a ConfigMap or a Secret resource.
+                            properties:
+                              configMap:
+                                description: TemplateRef specifies a reference to either a ConfigMap or a Secret resource.
+                                properties:
+                                  items:
+                                    description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                    items:
+                                      description: TemplateRefItem specifies a key in the ConfigMap/Secret to use as a template for Secret data.
+                                      properties:
+                                        key:
+                                          description: A key in the ConfigMap/Secret
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        templateAs:
+                                          default: Values
+                                          description: TemplateScope specifies how the template keys should be interpreted.
+                                          enum:
+                                            - Values
+                                            - KeysAndValues
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: The name of the ConfigMap/Secret resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                              literal:
+                                type: string
+                              secret:
+                                description: TemplateRef specifies a reference to either a ConfigMap or a Secret resource.
+                                properties:
+                                  items:
+                                    description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                    items:
+                                      description: TemplateRefItem specifies a key in the ConfigMap/Secret to use as a template for Secret data.
+                                      properties:
+                                        key:
+                                          description: A key in the ConfigMap/Secret
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        templateAs:
+                                          default: Values
+                                          description: TemplateScope specifies how the template keys should be interpreted.
+                                          enum:
+                                            - Values
+                                            - KeysAndValues
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: The name of the ConfigMap/Secret resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                              target:
+                                default: Data
+                                description: |-
+                                  Target specifies where to place the template result.
+                                  For Secret resources, common values are: "Data", "Annotations", "Labels".
+                                  For custom resources (when spec.target.manifest is set), this supports
+                                  nested paths like "spec.database.config" or "data".
+                                type: string
+                              valuesDecodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy for the rendered template values.
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
+                                type: string
+                            type: object
+                          type: array
+                        type:
+                          type: string
+                      type: object
+                    updatePolicy:
+                      default: Replace
+                      description: UpdatePolicy to handle Secrets in the provider.
+                      enum:
+                        - Replace
+                        - IfNotExists
+                      type: string
+                  required:
+                    - secretStoreRefs
+                    - selector
+                  type: object
+                refreshTime:
+                  description: The time in which the controller should reconcile its objects and recheck namespaces for labels.
+                  type: string
+              required:
+                - pushSecretSpec
+              type: object
+            status:
+              description: ClusterPushSecretStatus contains the status information for the ClusterPushSecret resource.
+              properties:
+                conditions:
+                  items:
+                    description: PushSecretStatusCondition indicates the status of the PushSecret.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: PushSecretConditionType indicates the condition of the PushSecret.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                failedNamespaces:
+                  description: Failed namespaces are the namespaces that failed to apply an PushSecret
+                  items:
+                    description: ClusterPushSecretNamespaceFailure represents a failed namespace deployment and it's reason.
+                    properties:
+                      namespace:
+                        description: Namespace is the namespace that failed when trying to apply an PushSecret
+                        type: string
+                      reason:
+                        description: Reason is why the PushSecret failed to apply to the namespace
+                        type: string
+                    required:
+                      - namespace
+                    type: object
+                  type: array
+                provisionedNamespaces:
+                  description: ProvisionedNamespaces are the namespaces where the ClusterPushSecret has secrets
+                  items:
+                    type: string
+                  type: array
+                pushSecretName:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-clustersecretstores-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-clustersecretstores-external-secrets-io.yaml
@@ -1,0 +1,11140 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: clustersecretstores.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - external-secrets
+    kind: ClusterSecretStore
+    listKind: ClusterSecretStoreList
+    plural: clustersecretstores
+    shortNames:
+      - css
+    singular: clustersecretstore
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.capabilities
+          name: Capabilities
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterSecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SecretStoreSpec defines the desired state of SecretStore.
+              properties:
+                conditions:
+                  description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
+                  items:
+                    description: |-
+                      ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
+                      for a ClusterSecretStore instance.
+                    properties:
+                      namespaceRegexes:
+                        description: Choose namespaces by using regex matching
+                        items:
+                          type: string
+                        type: array
+                      namespaceSelector:
+                        description: Choose namespace using a labelSelector
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaces:
+                        description: Choose namespaces by name
+                        items:
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                controller:
+                  description: |-
+                    Used to select the correct ESO controller (think: ingress.ingressClassName)
+                    The ESO controller is instantiated with a specific controller name and filters ES based on this property
+                  type: string
+                provider:
+                  description: Used to configure the provider. Only one provider may be set
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    akeyless:
+                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      properties:
+                        akeylessGWApiURL:
+                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          type: string
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Akeyless.
+                          properties:
+                            kubernetesAuth:
+                              description: |-
+                                Kubernetes authenticates with Akeyless by passing the ServiceAccount
+                                token stored in the named Secret resource.
+                              properties:
+                                accessID:
+                                  description: the Akeyless Kubernetes auth-method access-id
+                                  type: string
+                                k8sConfName:
+                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                    for authenticating with Akeyless. If a name is specified without a key,
+                                    `token` is the default. If one is not specified, the one bound to
+                                    the controller will be used.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional service account field containing the name of a kubernetes ServiceAccount.
+                                    If the service account is specified, the service account secret token JWT will be used
+                                    for authenticating with Akeyless. If the service account selector is not supplied,
+                                    the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - accessID
+                                - k8sConfName
+                              type: object
+                            secretRef:
+                              description: |-
+                                Reference to a Secret that contains the details
+                                to authenticate with Akeyless.
+                              properties:
+                                accessID:
+                                  description: The SecretAccessID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessType:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessTypeParam:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccountRef:
+                              description: |-
+                                ServiceAccountRef specifies a Kubernetes ServiceAccount used for azure_ad
+                                authentication on AKS Workload Identity. The operator obtains a federated
+                                identity token from this ServiceAccount via the TokenRequest API instead
+                                of using the ESO controller pod identity. Ignored for other access types.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used
+                            if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        ignoreCache:
+                          description: |-
+                            IgnoreCache bypasses the Gateway cache for secret reads when true.
+                            Only relevant when akeylessGWApiURL points to an Akeyless Gateway.
+                          type: boolean
+                      required:
+                        - akeylessGWApiURL
+                        - authSecretRef
+                      type: object
+                    aws:
+                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      properties:
+                        additionalRoles:
+                          description: AdditionalRoles is a chained list of Role ARNs which the provider will sequentially assume before assuming the Role
+                          items:
+                            type: string
+                          type: array
+                        auth:
+                          description: |-
+                            Auth defines the information necessary to authenticate against AWS
+                            if not set aws sdk will infer credentials from your environment
+                            see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                          properties:
+                            jwt:
+                              description: AWSJWTAuth stores reference to Authenticate against AWS using service account tokens.
+                              properties:
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: |-
+                                AWSAuthSecretRef holds secret references for AWS credentials
+                                both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                sessionTokenSecretRef:
+                                  description: |-
+                                    The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                    see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        customSessionTags:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            CustomSessionTags defines additional STS session tags to include when SessionTagsPolicy is Custom.
+                            These are merged with the automatically injected esoNamespace, esoStoreName, and esoStoreKind tags.
+                          type: object
+                          x-kubernetes-validations:
+                            - message: 'customSessionTags cannot contain automatically injected reserved keys: esoNamespace, esoStoreName, esoStoreKind'
+                              rule: '!(''esoNamespace'' in self) && !(''esoStoreName'' in self) && !(''esoStoreKind'' in self)'
+                        externalID:
+                          description: AWS External ID set on assumed IAM roles
+                          type: string
+                        prefix:
+                          description: Prefix adds a prefix to all retrieved values.
+                          type: string
+                        region:
+                          description: AWS Region to be used for the provider
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the provider will assume
+                          type: string
+                        secretsManager:
+                          description: SecretsManager defines how the provider behaves when interacting with AWS SecretsManager
+                          properties:
+                            forceDeleteWithoutRecovery:
+                              description: |-
+                                Specifies whether to delete the secret without any recovery window. You
+                                can't use both this parameter and RecoveryWindowInDays in the same call.
+                                If you don't use either, then by default Secrets Manager uses a 30 day
+                                recovery window.
+                                see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-ForceDeleteWithoutRecovery
+                              type: boolean
+                            recoveryWindowInDays:
+                              description: |-
+                                The number of days from 7 to 30 that Secrets Manager waits before
+                                permanently deleting the secret. You can't use both this parameter and
+                                ForceDeleteWithoutRecovery in the same call. If you don't use either,
+                                then by default Secrets Manager uses a 30-day recovery window.
+                                see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-RecoveryWindowInDays
+                              format: int64
+                              type: integer
+                          type: object
+                        service:
+                          description: Service defines which service should be used to fetch the secrets
+                          enum:
+                            - SecretsManager
+                            - ParameterStore
+                            - CertificateManager
+                          type: string
+                        sessionTags:
+                          description: AWS STS assume role session tags
+                          items:
+                            description: |-
+                              Tag is a key-value pair that can be attached to an AWS resource.
+                              see: https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          type: array
+                        sessionTagsPolicy:
+                          default: None
+                          description: |-
+                            SessionTagsPolicy controls whether and how STS session tags are added when assuming roles.
+                            None (default): no tags are added.
+                            Simple: automatically adds esoNamespace (from the ExternalSecret), esoStoreName, and esoStoreKind tags.
+                            Custom: adds esoNamespace, esoStoreName, and esoStoreKind plus any tags defined in CustomSessionTags.
+                            Note: the IAM role must have sts:TagSession permission when using Simple or Custom.
+                          enum:
+                            - None
+                            - Simple
+                            - Custom
+                          type: string
+                        transitiveTagKeys:
+                          description: AWS STS assume role transitive session tags. Required when multiple rules are used with the provider
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - region
+                        - service
+                      type: object
+                    azurekv:
+                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      properties:
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type. Optional for WorkloadIdentity.
+                          properties:
+                            clientCertificate:
+                              description: The Azure ClientCertificate of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            clientId:
+                              description: The Azure clientId of the service principle or managed identity used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            tenantId:
+                              description: The Azure tenantId of the managed identity used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        authType:
+                          default: ServicePrincipal
+                          description: |-
+                            Auth type defines how to authenticate to the keyvault service.
+                            Valid values are:
+                            - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret)
+                            - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)
+                            - "WorkloadIdentity": Using a Kubernetes ServiceAccount federated with Entra ID
+                          enum:
+                            - ServicePrincipal
+                            - ManagedIdentity
+                            - WorkloadIdentity
+                          type: string
+                        customCloudConfig:
+                          description: |-
+                            CustomCloudConfig defines custom Azure endpoints for non-standard clouds.
+                            Required when EnvironmentType is AzureStackCloud.
+                            Optional for other environment types - useful for Azure China when using Workload Identity
+                            with AKS, where the OIDC issuer (login.partner.microsoftonline.cn) differs from the
+                            standard China Cloud endpoint (login.chinacloudapi.cn).
+                            IMPORTANT: This feature REQUIRES UseAzureSDK to be set to true. Custom cloud
+                            configuration is not supported with the legacy go-autorest SDK.
+                          properties:
+                            activeDirectoryEndpoint:
+                              description: |-
+                                ActiveDirectoryEndpoint is the AAD endpoint for authentication
+                                Required when using custom cloud configuration
+                              type: string
+                            keyVaultDNSSuffix:
+                              description: KeyVaultDNSSuffix is the DNS suffix for Key Vault URLs
+                              type: string
+                            keyVaultEndpoint:
+                              description: KeyVaultEndpoint is the Key Vault service endpoint
+                              type: string
+                            resourceManagerEndpoint:
+                              description: ResourceManagerEndpoint is the Azure Resource Manager endpoint
+                              type: string
+                          required:
+                            - activeDirectoryEndpoint
+                          type: object
+                        environmentType:
+                          default: PublicCloud
+                          description: |-
+                            EnvironmentType specifies the Azure cloud environment endpoints to use for
+                            connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint.
+                            The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                            PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud, AzureStackCloud
+                            Use AzureStackCloud when you need to configure custom Azure Stack Hub or Azure Stack Edge endpoints.
+                          enum:
+                            - PublicCloud
+                            - USGovernmentCloud
+                            - ChinaCloud
+                            - GermanCloud
+                            - AzureStackCloud
+                          type: string
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tenantId:
+                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type. Optional for WorkloadIdentity.
+                          type: string
+                        useAzureSDK:
+                          default: false
+                          description: |-
+                            UseAzureSDK enables the use of the new Azure SDK for Go (azcore-based) instead of the legacy go-autorest SDK.
+                            This is experimental and may have behavioral differences. Defaults to false (legacy SDK).
+                          type: boolean
+                        vaultUrl:
+                          description: Vault Url from which the secrets to be fetched from.
+                          type: string
+                      required:
+                        - vaultUrl
+                      type: object
+                    barbican:
+                      description: Barbican configures this store to sync secrets using the OpenStack Barbican provider
+                      properties:
+                        auth:
+                          description: BarbicanAuth contains the authentication information for Barbican.
+                          properties:
+                            password:
+                              description: BarbicanProviderPasswordRef defines a reference to a secret containing password for the Barbican provider.
+                              properties:
+                                secretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            username:
+                              description: BarbicanProviderUsernameRef defines a reference to a secret containing username for the Barbican provider.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                secretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  type: string
+                              type: object
+                          required:
+                            - password
+                            - username
+                          type: object
+                        authURL:
+                          type: string
+                        domainName:
+                          type: string
+                        region:
+                          type: string
+                        tenantName:
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    beyondtrust:
+                      description: Beyondtrust configures this store to sync secrets using Password Safe provider.
+                      properties:
+                        auth:
+                          description: Auth configures how the operator authenticates with Beyondtrust.
+                          properties:
+                            apiKey:
+                              description: APIKey If not provided then ClientID/ClientSecret become required.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            certificate:
+                              description: Certificate (cert.pem) for use when authenticating with an OAuth client Id using a Client Certificate.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            certificateKey:
+                              description: Certificate private key (key.pem). For use when authenticating with an OAuth client Id
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            clientId:
+                              description: ClientID is the API OAuth Client ID.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: ClientSecret is the API OAuth Client Secret.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                          type: object
+                        server:
+                          description: Auth configures how API server works.
+                          properties:
+                            apiUrl:
+                              type: string
+                            apiVersion:
+                              type: string
+                            clientTimeOutSeconds:
+                              description: Timeout specifies a time limit for requests made by this Client. The timeout includes connection time, any redirects, and reading the response body. Defaults to 45 seconds.
+                              type: integer
+                            decrypt:
+                              default: true
+                              description: 'When true, the response includes the decrypted password. When false, the password field is omitted. This option only applies to the SECRET retrieval type. Default: true.'
+                              type: boolean
+                            retrievalType:
+                              description: The secret retrieval type. SECRET = Secrets Safe (credential, text, file). MANAGED_ACCOUNT = Password Safe account associated with a system.
+                              type: string
+                            separator:
+                              description: A character that separates the folder names.
+                              type: string
+                            verifyCA:
+                              type: boolean
+                          required:
+                            - apiUrl
+                            - verifyCA
+                          type: object
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    beyondtrustworkloadcredentials:
+                      description: BeyondtrustWorkloadCredentials configures this store to sync secrets using the BeyondTrust Workload Credentials provider.
+                      properties:
+                        auth:
+                          description: |-
+                            Auth configures how the Operator authenticates with the BeyondTrust Workload Credentials API.
+                            Currently supports API key authentication via Kubernetes secret reference.
+                            For authentication setup, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                          properties:
+                            apikey:
+                              description: |-
+                                APIKey configures API token authentication for BeyondTrust Workload Credentials.
+                                The token is retrieved from a Kubernetes secret and used as a Bearer token for API requests.
+                              properties:
+                                token:
+                                  description: |-
+                                    Token references the Kubernetes secret containing the BeyondTrust Workload Credentials API token.
+                                    The secret should contain the API key used to authenticate with BeyondTrust Workload Credentials.
+                                    Create an API token in your BeyondTrust Workload Credentials console and store it in a Kubernetes secret.
+                                    For details on creating API tokens, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - token
+                              type: object
+                          required:
+                            - apikey
+                          type: object
+                        caBundle:
+                          description: |-
+                            CABundle is a base64-encoded CA certificate used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                            Use this when your BeyondTrust instance uses a self-signed certificate or internal CA.
+                            If not set, the system's trusted root certificates are used.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: |-
+                            CAProvider points to a Secret or ConfigMap containing a PEM-encoded CA certificate.
+                            This is used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                            Use this as an alternative to CABundle when you want to reference an existing Kubernetes resource.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        folderPath:
+                          description: |-
+                            FolderPath specifies the default folder path for secret retrieval.
+                            Secrets will be fetched from this folder unless overridden in the ExternalSecret spec.
+                            Example: "production/database" or "dev/api-keys"
+                            Leave empty to retrieve secrets from the root folder.
+                            For folder organization, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#folders
+                          type: string
+                        server:
+                          description: |-
+                            Server configures the BeyondTrust Workload Credentials server connection details.
+                            Includes the API URL and Site ID for your BeyondTrust instance.
+                            For API reference, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                          properties:
+                            apiUrl:
+                              description: |-
+                                APIURL is the base URL of your BeyondTrust Workload Credentials API server.
+                                This should be the full URL to your BeyondTrust instance.
+                                Example: https://api.beyondtrust.io/siie
+                                For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#base-url
+                              type: string
+                            siteId:
+                              description: |-
+                                SiteID is your BeyondTrust Workload Credentials site identifier (UUID format).
+                                This identifier is unique to your BeyondTrust Workload Credentials instance.
+                                You can find your Site ID in the BeyondTrust Workload Credentials admin console.
+                                Example: a1b2c3d4-e5f6-4890-abcd-ef1234567890
+                                For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                              type: string
+                          required:
+                            - apiUrl
+                            - siteId
+                          type: object
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    bitwardensecretsmanager:
+                      description: BitwardenSecretsManager configures this store to sync secrets using BitwardenSecretsManager provider
+                      properties:
+                        apiURL:
+                          type: string
+                        auth:
+                          description: |-
+                            Auth configures how secret-manager authenticates with a bitwarden machine account instance.
+                            Make sure that the token being used has permissions on the given secret.
+                          properties:
+                            secretRef:
+                              description: BitwardenSecretsManagerSecretRef contains the credential ref to the bitwarden instance.
+                              properties:
+                                credentials:
+                                  description: AccessToken used for the bitwarden instance.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - credentials
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        bitwardenServerSDKURL:
+                          type: string
+                        caBundle:
+                          description: |-
+                            Base64 encoded certificate for the bitwarden server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                            can be performed.
+                          type: string
+                        caProvider:
+                          description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        identityURL:
+                          type: string
+                        organizationID:
+                          description: OrganizationID determines which organization this secret store manages.
+                          type: string
+                        projectID:
+                          description: ProjectID determines which project this secret store manages.
+                          type: string
+                      required:
+                        - auth
+                        - organizationID
+                        - projectID
+                      type: object
+                    chef:
+                      description: Chef configures this store to sync secrets with chef server
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against chef Server
+                          properties:
+                            secretRef:
+                              description: ChefAuthSecretRef holds secret references for chef server login credentials.
+                              properties:
+                                privateKeySecretRef:
+                                  description: SecretKey is the Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - privateKeySecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        serverUrl:
+                          description: ServerURL is the chef server URL used to connect to. If using orgs you should include your org in the url and terminate the url with a "/"
+                          type: string
+                        username:
+                          description: UserName should be the user ID on the chef server
+                          type: string
+                      required:
+                        - auth
+                        - serverUrl
+                        - username
+                      type: object
+                    cloudrusm:
+                      description: CloudruSM configures this store to sync secrets using the Cloud.ru Secret Manager provider
+                      properties:
+                        auth:
+                          description: CSMAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: CSMAuthSecretRef holds secret references for Cloud.ru credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          type: object
+                        projectID:
+                          description: ProjectID is the project, which the secrets are stored in.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    conjur:
+                      description: Conjur configures this store to sync secrets using conjur provider
+                      properties:
+                        auth:
+                          description: Defines authentication settings for connecting to Conjur.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            apikey:
+                              description: Authenticates with Conjur using an API key.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                apiKeyRef:
+                                  description: |-
+                                    A reference to a specific 'key' containing the Conjur API key
+                                    within a Secret resource. In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                userRef:
+                                  description: |-
+                                    A reference to a specific 'key' containing the Conjur username
+                                    within a Secret resource. In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - account
+                                - apiKeyRef
+                                - userRef
+                              type: object
+                            cert:
+                              description: Cert enables certificate-based authentication using a client certificate and key.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                clientCertRef:
+                                  description: |-
+                                    ClientCertRef is a reference to a specific 'key' containing the client certificate
+                                    within a Secret resource. The certificate must be PEM-encoded.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientKeyRef:
+                                  description: |-
+                                    ClientKeyRef is a reference to a specific 'key' containing the private RSA client key
+                                    within a Secret resource. The key must be PEM-encoded.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                hostId:
+                                  description: Optional HostID for cert authentication (can be omitted when using 'spiffe' mode).
+                                  type: string
+                                serviceID:
+                                  description: The conjur authn cert webservice id
+                                  type: string
+                              required:
+                                - account
+                                - clientCertRef
+                                - clientKeyRef
+                                - serviceID
+                              type: object
+                            jwt:
+                              description: Jwt enables JWT authentication using Kubernetes service account tokens.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                hostId:
+                                  description: |-
+                                    Optional HostID for JWT authentication. This may be used depending
+                                    on how the Conjur JWT authenticator policy is configured.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                    authenticate with Conjur using the JWT authentication method.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional ServiceAccountRef specifies the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceID:
+                                  description: The conjur authn jwt webservice id
+                                  type: string
+                              required:
+                                - account
+                                - serviceID
+                              type: object
+                          type: object
+                        caBundle:
+                          description: CABundle is a PEM encoded CA bundle that will be used to validate the Conjur server certificate.
+                          type: string
+                        caProvider:
+                          description: |-
+                            Used to provide custom certificate authority (CA) certificates
+                            for a secret store. The CAProvider points to a Secret or ConfigMap resource
+                            that contains a PEM-encoded certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        url:
+                          description: URL is the endpoint of the Conjur instance.
+                          type: string
+                      required:
+                        - auth
+                        - url
+                      type: object
+                    crd:
+                      description: |-
+                        CRD configures this store to sync secrets from arbitrary Kubernetes resources,
+                        including both custom resources (CRDs) and core API resources. Resources are
+                        selected by API group, version and kind, where group can be "" (empty string)
+                        for core resources such as ConfigMap. Reading the core v1 Secret is
+                        intentionally blocked — use the Kubernetes provider for that.
+                      properties:
+                        auth:
+                          description: |-
+                            Auth configures authentication to the Kubernetes API, same as the
+                            Kubernetes provider. Required when Server.URL is set (unless using AuthRef).
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - clientCert
+                                - clientKey
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - bearerToken
+                              type: object
+                          type: object
+                        authRef:
+                          description: |-
+                            AuthRef references a Secret containing a kubeconfig. Same semantics as the
+                            Kubernetes provider.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        resource:
+                          description: Resource identifies the CRD by its API group, version and kind.
+                          properties:
+                            group:
+                              description: |-
+                                Group is the API group of the resource. Use "" (empty string) for core
+                                Kubernetes resources such as ConfigMap; use e.g. "config.example.io"
+                                for a CRD. The field is required to be present in the manifest — write
+                                `group: ""` explicitly for core resources so typos fail at admission
+                                time rather than later at discovery.
+                              type: string
+                            kind:
+                              description: Kind is the Kubernetes resource kind (e.g. "MyCustomResource").
+                              minLength: 1
+                              type: string
+                            version:
+                              description: Version is the API version of the resource (e.g. "v1alpha1").
+                              minLength: 1
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - version
+                          type: object
+                        server:
+                          description: |-
+                            Server configures the Kubernetes API address and TLS trust, same as the
+                            Kubernetes provider. When omitted, the URL defaults to the in-cluster API.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                        whitelist:
+                          description: |-
+                            Whitelist optionally restricts which object names and requested properties
+                            are allowed to be read.
+                          properties:
+                            rules:
+                              description: |-
+                                Rules is a list of allow rules. If rules are set, at least one rule must
+                                match for a request to be allowed.
+                              items:
+                                description: CRDProviderWhitelistRule defines a single allow rule for CRD reads.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name is an optional regular expression matched against the bare object name.
+                                      For both SecretStore and ClusterSecretStore this is always the object name
+                                      without any namespace prefix (e.g. "my-db-spec", not "prod/my-db-spec").
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is an optional regular expression matched against the namespace of
+                                      the object. Applies only when a ClusterSecretStore is used; it is ignored
+                                      for SecretStore (where the namespace is fixed to the store namespace).
+                                    type: string
+                                  properties:
+                                    description: |-
+                                      Properties is an optional list of regular expressions matched against
+                                      requested property keys (for example: "spec.secretValue").
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                      required:
+                        - resource
+                      type: object
+                      x-kubernetes-validations:
+                        - message: one of auth or authRef is required
+                          rule: has(self.auth) || has(self.authRef)
+                        - message: at most one of the fields in [auth authRef] may be set
+                          rule: '[has(self.auth),has(self.authRef)].filter(x,x==true).size() <= 1'
+                    delinea:
+                      description: |-
+                        Delinea DevOps Secrets Vault
+                        https://docs.delinea.com/online-help/products/devops-secrets-vault/current
+                      properties:
+                        clientId:
+                          description: ClientID is the non-secret part of the credential.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        clientSecret:
+                          description: ClientSecret is the secret part of the credential.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        tenant:
+                          description: Tenant is the chosen hostname / site name.
+                          type: string
+                        tld:
+                          description: |-
+                            TLD is based on the server location that was chosen during provisioning.
+                            If unset, defaults to "com".
+                          type: string
+                        urlTemplate:
+                          description: |-
+                            URLTemplate
+                            If unset, defaults to "https://%s.secretsvaultcloud.%s/v1/%s%s".
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tenant
+                      type: object
+                    doppler:
+                      description: Doppler configures this store to sync secrets using the Doppler provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Doppler API
+                          properties:
+                            oidcConfig:
+                              description: OIDCConfig authenticates using Kubernetes ServiceAccount tokens via OIDC.
+                              properties:
+                                expirationSeconds:
+                                  default: 600
+                                  description: |-
+                                    ExpirationSeconds sets the ServiceAccount token validity duration.
+                                    Defaults to 10 minutes.
+                                  format: int64
+                                  type: integer
+                                identity:
+                                  description: Identity is the Doppler Service Account Identity ID configured for OIDC authentication.
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountRef specifies the Kubernetes ServiceAccount to use for authentication.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - identity
+                                - serviceAccountRef
+                              type: object
+                            secretRef:
+                              description: SecretRef authenticates using a Doppler service token stored in a Kubernetes Secret.
+                              properties:
+                                dopplerToken:
+                                  description: |-
+                                    The DopplerToken is used for authentication.
+                                    See https://docs.doppler.com/reference/api#authentication for auth token types.
+                                    The Key attribute defaults to dopplerToken if not specified.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - dopplerToken
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Exactly one of 'secretRef' or 'oidcConfig' must be specified
+                              rule: (has(self.secretRef) && !has(self.oidcConfig)) || (!has(self.secretRef) && has(self.oidcConfig))
+                        config:
+                          description: Doppler config (required if not using a Service Token)
+                          type: string
+                        format:
+                          description: Format enables the downloading of secrets as a file (string)
+                          enum:
+                            - json
+                            - dotnet-json
+                            - env
+                            - yaml
+                            - docker
+                          type: string
+                        nameTransformer:
+                          description: Environment variable compatible name transforms that change secret names to a different format
+                          enum:
+                            - upper-camel
+                            - camel
+                            - lower-snake
+                            - tf-var
+                            - dotnet-env
+                            - lower-kebab
+                          type: string
+                        project:
+                          description: Doppler project (required if not using a Service Token)
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    dvls:
+                      description: DVLS configures this store to sync secrets using Devolutions Server provider
+                      properties:
+                        auth:
+                          description: Auth defines the authentication method to use.
+                          properties:
+                            secretRef:
+                              description: SecretRef contains the Application ID and Application Secret for authentication.
+                              properties:
+                                appId:
+                                  description: AppID is the reference to the secret containing the Application ID.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                appSecret:
+                                  description: AppSecret is the reference to the secret containing the Application Secret.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - appId
+                                - appSecret
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        insecure:
+                          description: |-
+                            Insecure allows connecting to DVLS over plain HTTP.
+                            This is NOT RECOMMENDED for production use.
+                            Set to true only if you understand the security implications.
+                          type: boolean
+                        serverUrl:
+                          description: ServerURL is the DVLS instance URL (e.g., https://dvls.example.com).
+                          type: string
+                        vault:
+                          description: |-
+                            Vault is the name or UUID of the vault to fetch secrets from.
+                            When omitted, the vault must be specified in the secret key using the legacy format "<vault-id>/<entry-id>".
+                          type: string
+                      required:
+                        - auth
+                        - serverUrl
+                      type: object
+                    fake:
+                      description: Fake configures a store with static key/value pairs
+                      properties:
+                        data:
+                          items:
+                            description: FakeProviderData defines a key-value pair with optional version for the fake provider.
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          type: array
+                        validationResult:
+                          description: ValidationResult is defined type for the number of validation results.
+                          type: integer
+                      required:
+                        - data
+                      type: object
+                    fortanix:
+                      description: Fortanix configures this store to sync secrets using the Fortanix provider
+                      properties:
+                        apiKey:
+                          description: APIKey is the API token to access SDKMS Applications.
+                          properties:
+                            secretRef:
+                              description: SecretRef is a reference to a secret containing the SDKMS API Key.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        apiUrl:
+                          description: APIURL is the URL of SDKMS API. Defaults to `sdkms.fortanix.com`.
+                          type: string
+                      type: object
+                    gcpsm:
+                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against GCP
+                          properties:
+                            secretRef:
+                              description: GCPSMAuthSecretRef contains the secret references for GCP Secret Manager authentication.
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            workloadIdentity:
+                              description: GCPWorkloadIdentity defines configuration for workload identity authentication to GCP.
+                              properties:
+                                clusterLocation:
+                                  description: |-
+                                    ClusterLocation is the location of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterName:
+                                  description: |-
+                                    ClusterName is the name of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterProjectID:
+                                  description: |-
+                                    ClusterProjectID is the project ID of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - serviceAccountRef
+                              type: object
+                            workloadIdentityFederation:
+                              description: GCPWorkloadIdentityFederation holds the configurations required for generating federated access tokens.
+                              properties:
+                                audience:
+                                  description: |-
+                                    audience is the Secure Token Service (STS) audience which contains the resource name for the workload identity pool and the provider identifier in that pool.
+                                    If specified, Audience found in the external account credential config will be overridden with the configured value.
+                                    audience must be provided when serviceAccountRef or awsSecurityCredentials is configured.
+                                  type: string
+                                awsSecurityCredentials:
+                                  description: |-
+                                    awsSecurityCredentials is for configuring AWS region and credentials to use for obtaining the access token,
+                                    when using the AWS metadata server is not an option.
+                                  properties:
+                                    awsCredentialsSecretRef:
+                                      description: |-
+                                        awsCredentialsSecretRef is the reference to the secret which holds the AWS credentials.
+                                        Secret should be created with below names for keys
+                                        - aws_access_key_id: Access Key ID, which is the unique identifier for the AWS account or the IAM user.
+                                        - aws_secret_access_key: Secret Access Key, which is used to authenticate requests made to AWS services.
+                                        - aws_session_token: Session Token, is the short-lived token to authenticate requests made to AWS services.
+                                      properties:
+                                        name:
+                                          description: name of the secret.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: namespace in which the secret exists. If empty, secret will looked up in local namespace.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    region:
+                                      description: region is for configuring the AWS region to be used.
+                                      example: ap-south-1
+                                      maxLength: 50
+                                      minLength: 1
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                  required:
+                                    - awsCredentialsSecretRef
+                                    - region
+                                  type: object
+                                credConfig:
+                                  description: |-
+                                    credConfig holds the configmap reference containing the GCP external account credential configuration in JSON format and the key name containing the json data.
+                                    For using Kubernetes cluster as the identity provider, use serviceAccountRef instead. Operators mounted serviceaccount token cannot be used as the token source, instead
+                                    serviceAccountRef must be used by providing operators service account details.
+                                  properties:
+                                    key:
+                                      description: key name holding the external account credential config.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: name of the configmap.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: namespace in which the configmap exists. If empty, configmap will looked up in local namespace.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - key
+                                    - name
+                                  type: object
+                                externalTokenEndpoint:
+                                  description: |-
+                                    externalTokenEndpoint is the endpoint explicitly set up to provide tokens, which will be matched against the
+                                    credential_source.url in the provided credConfig. This field is merely to double-check the external token source
+                                    URL is having the expected value.
+                                  type: string
+                                gcpServiceAccountEmail:
+                                  description: |-
+                                    GCPServiceAccountEmail is the email of the Google Cloud service account to impersonate
+                                    after Workload Identity Federation. Use this to grant access through the service account's
+                                    IAM bindings (for example roles/secretmanager.secretAccessor). When set, it overrides
+                                    service_account_impersonation_url in the external account JSON from credConfig;
+                                    when serviceAccountRef is set, it also overrides the "iam.gke.io/gcp-service-account" annotation
+                                    on that ServiceAccount.
+                                  example: my-gsa@my-project.iam.gserviceaccount.com
+                                  minLength: 1
+                                  pattern: ^.*@.*\.iam\.gserviceaccount\.com$
+                                  type: string
+                                serviceAccountRef:
+                                  description: |-
+                                    serviceAccountRef is the reference to the kubernetes ServiceAccount to be used for obtaining the tokens,
+                                    when Kubernetes is configured as provider in workload identity pool.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                          type: object
+                        location:
+                          description: Location optionally defines a location for a secret
+                          type: string
+                        projectID:
+                          description: ProjectID project where secret is located
+                          type: string
+                        secretVersionSelectionPolicy:
+                          default: LatestOrFail
+                          description: |-
+                            SecretVersionSelectionPolicy specifies how the provider selects a secret version
+                            when "latest" is disabled or destroyed.
+                            Possible values are:
+                            - LatestOrFail: the provider always uses "latest", or fails if that version is disabled/destroyed.
+                            - LatestOrFetch: the provider falls back to fetching the latest version if the version is DESTROYED or DISABLED
+                          type: string
+                      type: object
+                    github:
+                      description: |-
+                        Github configures this store to push GitHub Actions secrets using the GitHub API provider.
+                        Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
+                      properties:
+                        appID:
+                          description: appID specifies the Github APP that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        auth:
+                          description: auth configures how secret-manager authenticates with a Github instance.
+                          properties:
+                            privateKey:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - privateKey
+                          type: object
+                        environment:
+                          description: environment will be used to fetch secrets from a particular environment within a github repository
+                          type: string
+                        installationID:
+                          description: installationID specifies the Github APP installation that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        orgSecretVisibility:
+                          description: |-
+                            orgSecretVisibility controls the visibility of organization secrets pushed via PushSecret.
+                            Valid values are "all" or "private".
+                            When unset, new secrets are created with visibility "all" and existing secrets preserve
+                            whatever visibility they already have in GitHub.
+                          enum:
+                            - all
+                            - private
+                          type: string
+                        organization:
+                          description: organization will be used to fetch secrets from the Github organization
+                          type: string
+                        repository:
+                          description: repository will be used to fetch secrets from the Github repository within an organization
+                          type: string
+                        uploadURL:
+                          description: Upload URL for enterprise instances. Default to URL.
+                          type: string
+                        url:
+                          default: https://github.com/
+                          description: URL configures the Github instance URL. Defaults to https://github.com/.
+                          type: string
+                      required:
+                        - appID
+                        - auth
+                        - installationID
+                        - organization
+                      type: object
+                    gitlab:
+                      description: GitLab configures this store to sync secrets using GitLab Variables provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          properties:
+                            SecretRef:
+                              description: GitlabSecretRef contains the secret reference for GitLab authentication credentials.
+                              properties:
+                                accessToken:
+                                  description: AccessToken is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - SecretRef
+                          type: object
+                        caBundle:
+                          description: |-
+                            Base64 encoded certificate for the GitLab server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                            can be performed.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        environment:
+                          description: Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)
+                          type: string
+                        groupIDs:
+                          description: GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.
+                          items:
+                            type: string
+                          type: array
+                        inheritFromGroups:
+                          description: InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.
+                          type: boolean
+                        projectID:
+                          description: ProjectID specifies a project where secrets are located.
+                          type: string
+                        url:
+                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    ibm:
+                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            containerAuth:
+                              description: IBMAuthContainerAuth defines container-based authentication with IAM Trusted Profile.
+                              properties:
+                                iamEndpoint:
+                                  type: string
+                                profile:
+                                  description: the IBM Trusted Profile
+                                  type: string
+                                tokenLocation:
+                                  description: Location the token is mounted on the pod
+                                  type: string
+                              required:
+                                - profile
+                              type: object
+                            secretRef:
+                              description: IBMAuthSecretRef contains the secret reference for IBM Cloud API key authentication.
+                              properties:
+                                iamEndpoint:
+                                  description: The IAM endpoint used to obain a token
+                                  type: string
+                                secretApiKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        serviceUrl:
+                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    infisical:
+                      description: Infisical configures this store to sync secrets using the Infisical provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Infisical API
+                          properties:
+                            awsAuthCredentials:
+                              description: AwsAuthCredentials represents the credentials for AWS authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                              type: object
+                            azureAuthCredentials:
+                              description: AzureAuthCredentials represents the credentials for Azure authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                resource:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                              type: object
+                            gcpIamAuthCredentials:
+                              description: GcpIamAuthCredentials represents the credentials for GCP IAM authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountKeyFilePath:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                                - serviceAccountKeyFilePath
+                              type: object
+                            gcpIdTokenAuthCredentials:
+                              description: GcpIDTokenAuthCredentials represents the credentials for GCP ID token authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                              type: object
+                            jwtAuthCredentials:
+                              description: JwtAuthCredentials represents the credentials for JWT authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                jwt:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                                - jwt
+                              type: object
+                            kubernetesAuthCredentials:
+                              description: KubernetesAuthCredentials represents the credentials for Kubernetes authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountTokenPath:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                              type: object
+                            ldapAuthCredentials:
+                              description: LdapAuthCredentials represents the credentials for LDAP authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                ldapPassword:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                ldapUsername:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                                - ldapPassword
+                                - ldapUsername
+                              type: object
+                            ociAuthCredentials:
+                              description: OciAuthCredentials represents the credentials for OCI authentication.
+                              properties:
+                                fingerprint:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                privateKey:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                privateKeyPassphrase:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                region:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                tenancyId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                userId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - identityId
+                                - privateKey
+                                - region
+                                - tenancyId
+                                - userId
+                              type: object
+                            tokenAuthCredentials:
+                              description: TokenAuthCredentials represents the credentials for access token-based authentication.
+                              properties:
+                                accessToken:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessToken
+                              type: object
+                            universalAuthCredentials:
+                              description: UniversalAuthCredentials represents the client credentials for universal authentication.
+                              properties:
+                                clientId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - clientId
+                                - clientSecret
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            CABundle is a PEM-encoded CA certificate bundle used to validate
+                            the Infisical server's TLS certificate. Mutually exclusive with CAProvider.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: |-
+                            CAProvider is a reference to a Secret or ConfigMap that contains a CA certificate.
+                            The certificate is used to validate the Infisical server's TLS certificate.
+                            Mutually exclusive with CABundle.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        hostAPI:
+                          default: https://app.infisical.com/api
+                          description: HostAPI specifies the base URL of the Infisical API. If not provided, it defaults to "https://app.infisical.com/api".
+                          type: string
+                        secretsScope:
+                          description: SecretsScope defines the scope of the secrets within the workspace
+                          properties:
+                            environmentSlug:
+                              description: EnvironmentSlug is the required slug identifier for the environment.
+                              type: string
+                            expandSecretReferences:
+                              default: true
+                              description: ExpandSecretReferences indicates whether secret references should be expanded. Defaults to true if not provided.
+                              type: boolean
+                            organizationSlug:
+                              description: |-
+                                OrganizationSlug is the optional slug that identifies the organization that will be used
+                                during authentication. Useful for sub-organization setups
+                              type: string
+                            projectSlug:
+                              description: ProjectSlug is the required slug identifier for the project.
+                              type: string
+                            recursive:
+                              default: false
+                              description: Recursive indicates whether the secrets should be fetched recursively. Defaults to false if not provided.
+                              type: boolean
+                            secretsPath:
+                              default: /
+                              description: SecretsPath specifies the path to the secrets within the workspace. Defaults to "/" if not provided.
+                              type: string
+                          required:
+                            - environmentSlug
+                            - projectSlug
+                          type: object
+                      required:
+                        - auth
+                        - secretsScope
+                      type: object
+                    keepersecurity:
+                      description: KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider
+                      properties:
+                        authRef:
+                          description: |-
+                            SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                            In some instances, `key` is a required field.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        folderID:
+                          type: string
+                        getByTitleFallback:
+                          type: boolean
+                      required:
+                        - authRef
+                        - folderID
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - clientCert
+                                - clientKey
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - bearerToken
+                              type: object
+                          type: object
+                        authRef:
+                          description: A reference to a secret that contains the auth information.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        remoteNamespace:
+                          default: default
+                          description: Remote namespace to fetch the secrets from
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        server:
+                          description: configures the Kubernetes server Address.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                      type: object
+                    nebiusmysterybox:
+                      description: NebiusMysterybox configures this store to sync secrets using NebiusMysterybox provider
+                      properties:
+                        apiDomain:
+                          description: NebiusMysterybox API endpoint
+                          type: string
+                        auth:
+                          description: Auth defines parameters to authenticate in MysteryBox
+                          properties:
+                            serviceAccountCredsSecretRef:
+                              description: |-
+                                ServiceAccountCreds references a Kubernetes Secret key that contains a JSON
+                                document with service account credentials used to get an IAM token.
+
+                                Expected JSON structure:
+                                {
+                                  "subject-credentials": {
+                                    "alg": "RS256",
+                                    "private-key": "-----BEGIN PRIVATE KEY-----\n<private-key>\n-----END PRIVATE KEY-----\n",
+                                    "kid": "<public-key-id>",
+                                    "iss": "<issuer-service-account-id>",
+                                    "sub": "<subject-service-account-id>"
+                                  }
+                                }
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            tokenSecretRef:
+                              description: Token authenticates with Nebius Mysterybox by presenting a token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: either serviceAccountCredsSecretRef or tokenSecretRef must be set
+                              rule: has(self.serviceAccountCredsSecretRef) || has(self.tokenSecretRef)
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate NebiusMysterybox server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - apiDomain
+                        - auth
+                      type: object
+                    ngrok:
+                      description: Ngrok configures this store to sync secrets using the ngrok provider.
+                      properties:
+                        apiUrl:
+                          default: https://api.ngrok.com
+                          description: APIURL is the URL of the ngrok API.
+                          type: string
+                        auth:
+                          description: Auth configures how the ngrok provider authenticates with the ngrok API.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            apiKey:
+                              description: APIKey is the API Key used to authenticate with ngrok. See https://ngrok.com/docs/api/#authentication
+                              properties:
+                                secretRef:
+                                  description: SecretRef is a reference to a secret containing the ngrok API key.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        vault:
+                          description: Vault configures the ngrok vault to sync secrets with.
+                          properties:
+                            name:
+                              description: Name is the name of the ngrok vault to sync secrets with.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - auth
+                        - vault
+                      type: object
+                    onboardbase:
+                      description: Onboardbase configures this store to sync secrets using the Onboardbase provider
+                      properties:
+                        apiHost:
+                          default: https://public.onboardbase.com/api/v1/
+                          description: APIHost use this to configure the host url for the API for selfhosted installation, default is https://public.onboardbase.com/api/v1/
+                          type: string
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Onboardbase API
+                          properties:
+                            apiKeyRef:
+                              description: |-
+                                OnboardbaseAPIKey is the APIKey generated by an admin account.
+                                It is used to recognize and authorize access to a project and environment within onboardbase
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            passcodeRef:
+                              description: OnboardbasePasscode is the passcode attached to the API Key
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - apiKeyRef
+                            - passcodeRef
+                          type: object
+                        environment:
+                          default: development
+                          description: Environment is the name of an environmnent within a project to pull the secrets from
+                          type: string
+                        project:
+                          default: development
+                          description: Project is an onboardbase project that the secrets should be pulled from
+                          type: string
+                      required:
+                        - apiHost
+                        - auth
+                        - environment
+                        - project
+                      type: object
+                    onepassword:
+                      description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against OnePassword Connect Server
+                          properties:
+                            secretRef:
+                              description: OnePasswordAuthSecretRef holds secret references for 1Password credentials.
+                              properties:
+                                connectTokenSecretRef:
+                                  description: The ConnectToken is used for authentication to a 1Password Connect Server.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - connectTokenSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        connectHost:
+                          description: ConnectHost defines the OnePassword Connect Server to connect to
+                          type: string
+                        vaults:
+                          additionalProperties:
+                            type: integer
+                          description: Vaults defines which OnePassword vaults to search in which order
+                          type: object
+                      required:
+                        - auth
+                        - connectHost
+                        - vaults
+                      type: object
+                    onepasswordSDK:
+                      description: OnePasswordSDK configures this store to use 1Password's new Go SDK to sync secrets.
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against OnePassword API.
+                          properties:
+                            serviceAccountSecretRef:
+                              description: ServiceAccountSecretRef points to the secret containing the token to access 1Password vault.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - serviceAccountSecretRef
+                          type: object
+                        cache:
+                          description: |-
+                            Cache configures client-side caching for read operations (GetSecret, GetSecretMap).
+                            When enabled, secrets are cached with the specified TTL.
+                            Write operations (PushSecret, DeleteSecret) automatically invalidate relevant cache entries.
+                            If omitted, caching is disabled (default).
+                            cache: {} is a valid option to set.
+                          properties:
+                            maxSize:
+                              default: 100
+                              description: |-
+                                MaxSize is the maximum number of secrets to cache.
+                                When the cache is full, least-recently-used entries are evicted.
+                              minimum: 1
+                              type: integer
+                            ttl:
+                              default: 5m
+                              description: |-
+                                TTL is the time-to-live for cached secrets.
+                                Format: duration string (e.g., "5m", "1h", "30s")
+                              type: string
+                          type: object
+                        integrationInfo:
+                          description: |-
+                            IntegrationInfo specifies the name and version of the integration built using the 1Password Go SDK.
+                            If you don't know which name and version to use, use `DefaultIntegrationName` and `DefaultIntegrationVersion`, respectively.
+                          properties:
+                            name:
+                              default: 1Password SDK
+                              description: Name defaults to "1Password SDK".
+                              type: string
+                            version:
+                              default: v1.0.0
+                              description: Version defaults to "v1.0.0".
+                              type: string
+                          type: object
+                        vault:
+                          description: Vault defines the vault's name or uuid to access. Do NOT add op:// prefix. This will be done automatically.
+                          type: string
+                      required:
+                        - auth
+                        - vault
+                      type: object
+                    openBao:
+                      description: OpenBao configures this store to sync secrets using the OpenBao provider.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the OpenBao server.
+                          properties:
+                            appRole:
+                              description: |-
+                                AppRole authenticates with OpenBao using the [App Role auth mechanism],
+                                with the role and secret stored in a Kubernetes Secret resource.
+
+                                [App Role auth mechanism]: https://openbao.org/docs/auth/approle/
+                              properties:
+                                path:
+                                  default: approle
+                                  description: |-
+                                    Path where the App Role authentication backend is mounted
+                                    in OpenBao, e.g: "approle"
+                                  type: string
+                                roleId:
+                                  description: |-
+                                    RoleID configured in the App Role authentication backend when setting
+                                    up the authentication backend in OpenBao.
+                                  minLength: 1
+                                  type: string
+                                roleRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role ID used
+                                    to authenticate with OpenBao.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role id.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role secret used
+                                    to authenticate with OpenBao.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - secretRef
+                              type: object
+                              x-kubernetes-validations:
+                                - message: exactly one of the fields in [roleId roleRef] must be set
+                                  rule: '[has(self.roleId),has(self.roleRef)].filter(x,x==true).size() == 1'
+                            namespace:
+                              description: |-
+                                Name of the [OpenBao Namespace] to authenticate to. This can be different
+                                than the namespace your secret is in. Namespaces is a set of features
+                                within OpenBao that allows OpenBao environments to support secure
+                                multi-tenancy. e.g: "ns1". This will default to OpenBao.Namespace field
+                                if set, or empty otherwise
+
+                                [OpenBao Namespace]: https://openbao.org/docs/concepts/namespaces/
+                              type: string
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with OpenBao by presenting a token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            userPass:
+                              description: UserPass authenticates with OpenBao by passing a username/password pair
+                              properties:
+                                path:
+                                  default: userpass
+                                  description: |-
+                                    Path where the UserPassword authentication backend is mounted
+                                    in OpenBao, e.g: "userpass"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the user
+                                    used to authenticate with OpenBao using the [UserPass authentication
+                                    method]
+
+                                    [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is a username used to authenticate using the [UserPass
+                                    authentication method]
+
+                                    [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exactly one of the fields in [appRole tokenSecretRef userPass] must be set
+                              rule: '[has(self.appRole),has(self.tokenSecretRef),has(self.userPass)].filter(x,x==true).size() == 1'
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate the OpenBao server certificate. If
+                            this and `caProvider` are not set the system root certificates are used
+                            to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: |-
+                            The provider for the CA bundle to use to validate OpenBao server
+                            certificate. If this and `caBundle` are not set the system root
+                            certificates are used to validate the TLS connection.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        namespace:
+                          description: |-
+                            Name of the [OpenBao Namespace]. Namespaces is a set of features within
+                            OpenBao that allows OpenBao environments to support secure multi-tenancy.
+                            e.g: "ns1".
+
+                            [OpenBao Namespace]: https://openbao.org/docs/concepts/namespaces/
+                          type: string
+                        path:
+                          description: |-
+                            Path is the mount path of the OpenBao KV backend endpoint, e.g:
+                            "secret". The v2 KV secret engine version specific "/data" path suffix
+                            for fetching secrets from OpenBao is optional and will be appended
+                            if not present in specified path.
+                          type: string
+                        server:
+                          description: 'Server is the connection address for the OpenBao server, e.g: `https://openbao.example.com:8200`.'
+                          type: string
+                        version:
+                          default: v2
+                          description: |-
+                            Version is the OpenBao KV secret engine version. This can be either "v1" or
+                            "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - server
+                      type: object
+                      x-kubernetes-validations:
+                        - message: at most one of the fields in [caBundle caProvider] may be set
+                          rule: '[has(self.caBundle),has(self.caProvider)].filter(x,x==true).size() <= 1'
+                    oracle:
+                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      properties:
+                        auth:
+                          description: |-
+                            Auth configures how secret-manager authenticates with the Oracle Vault.
+                            If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          properties:
+                            secretRef:
+                              description: SecretRef to pass through sensitive information.
+                              properties:
+                                fingerprint:
+                                  description: Fingerprint is the fingerprint of the API private key.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                privatekey:
+                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - privatekey
+                              type: object
+                            tenancy:
+                              description: Tenancy is the tenancy OCID where user is located.
+                              type: string
+                            user:
+                              description: User is an access OCID specific to the account.
+                              type: string
+                          required:
+                            - secretRef
+                            - tenancy
+                            - user
+                          type: object
+                        compartment:
+                          description: |-
+                            Compartment is the vault compartment OCID.
+                            Required for PushSecret
+                          type: string
+                        encryptionKey:
+                          description: |-
+                            EncryptionKey is the OCID of the encryption key within the vault.
+                            Required for PushSecret
+                          type: string
+                        principalType:
+                          description: |-
+                            The type of principal to use for authentication. If left blank, the Auth struct will
+                            determine the principal type. This optional field must be specified if using
+                            workload identity.
+                          enum:
+                            - ""
+                            - UserPrincipal
+                            - InstancePrincipal
+                            - Workload
+                          type: string
+                        region:
+                          description: Region is the region where vault is located.
+                          type: string
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        vault:
+                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          type: string
+                      required:
+                        - region
+                        - vault
+                      type: object
+                    ovh:
+                      description: OVHcloud configures this store to sync secrets using the OVHcloud provider.
+                      properties:
+                        auth:
+                          description: Authentication method (mtls or token).
+                          properties:
+                            mtls:
+                              description: OvhClientMTLS defines the configuration required to authenticate to OVHcloud's Secret Manager using mTLS.
+                              properties:
+                                caBundle:
+                                  format: byte
+                                  type: string
+                                caProvider:
+                                  description: |-
+                                    CAProvider provides a custom certificate authority for accessing the provider's store.
+                                    The CAProvider points to a Secret or ConfigMap resource that contains a PEM-encoded certificate.
+                                  properties:
+                                    key:
+                                      description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the object located at the provider type.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace the Provider type is in.
+                                        Can only be defined when used in a ClusterSecretStore.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    type:
+                                      description: The type of provider to use such as "Secret", or "ConfigMap".
+                                      enum:
+                                        - Secret
+                                        - ConfigMap
+                                      type: string
+                                  required:
+                                    - name
+                                    - type
+                                  type: object
+                                certSecretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                keySecretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - certSecretRef
+                                - keySecretRef
+                              type: object
+                            token:
+                              description: OvhClientToken defines the configuration required to authenticate to OVHcloud's Secret Manager using a token.
+                              properties:
+                                tokenSecretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - tokenSecretRef
+                              type: object
+                          type: object
+                        casRequired:
+                          description: 'Enables or disables check-and-set (CAS) (default: false).'
+                          type: boolean
+                        okmsTimeout:
+                          default: 30
+                          description: 'Setup a timeout in seconds when requests to the KMS are made (default: 30).'
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        okmsid:
+                          description: specifies the OKMS ID.
+                          type: string
+                        server:
+                          description: specifies the OKMS server endpoint.
+                          type: string
+                      required:
+                        - auth
+                        - okmsid
+                        - server
+                      type: object
+                    passbolt:
+                      description: |-
+                        PassboltProvider provides access to Passbolt secrets manager.
+                        See: https://www.passbolt.com.
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Passbolt Server
+                          properties:
+                            passwordSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            privateKeySecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - passwordSecretRef
+                            - privateKeySecretRef
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate Passbolt server certificate. Only used
+                            if the Host URL is using HTTPS protocol. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Passbolt server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        host:
+                          description: Host defines the Passbolt Server to connect to
+                          type: string
+                      required:
+                        - auth
+                        - host
+                      type: object
+                    passworddepot:
+                      description: PasswordDepotProvider configures a store to sync secrets with a Password Depot instance.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Password Depot instance.
+                          properties:
+                            secretRef:
+                              description: PasswordDepotSecretRef contains the secret reference for Password Depot authentication.
+                              properties:
+                                credentials:
+                                  description: Username / Password is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        database:
+                          description: Database to use as source
+                          type: string
+                        host:
+                          description: URL configures the Password Depot instance URL.
+                          type: string
+                      required:
+                        - auth
+                        - database
+                        - host
+                      type: object
+                    previder:
+                      description: Previder configures this store to sync secrets using the Previder provider
+                      properties:
+                        auth:
+                          description: PreviderAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: PreviderAuthSecretRef holds secret references for Previder Vault credentials.
+                              properties:
+                                accessToken:
+                                  description: The AccessToken is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessToken
+                              type: object
+                          type: object
+                        baseUri:
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    pulumi:
+                      description: Pulumi configures this store to sync secrets using the Pulumi provider
+                      properties:
+                        accessToken:
+                          description: |-
+                            AccessToken is the access tokens to sign in to the Pulumi Cloud Console.
+
+                            Deprecated: Use auth.accessToken instead.
+                          properties:
+                            secretRef:
+                              description: SecretRef is a reference to a secret containing the Pulumi API token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        apiUrl:
+                          default: https://api.pulumi.com/api/esc
+                          description: APIURL is the URL of the Pulumi API.
+                          type: string
+                        auth:
+                          description: |-
+                            Auth configures how the Operator authenticates with the Pulumi API.
+                            Either auth or the deprecated accessToken field must be specified.
+                          properties:
+                            accessToken:
+                              description: AccessToken authenticates using a Pulumi access token stored in a Kubernetes Secret.
+                              properties:
+                                secretRef:
+                                  description: SecretRef is a reference to a secret containing the Pulumi API token.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            oidcConfig:
+                              description: OIDCConfig authenticates using Kubernetes ServiceAccount tokens via OIDC.
+                              properties:
+                                expirationSeconds:
+                                  default: 600
+                                  description: |-
+                                    ExpirationSeconds sets the token validity duration for service account and OIDC token.
+                                    Defaults to 10 minutes.
+                                  format: int64
+                                  minimum: 600
+                                  type: integer
+                                organization:
+                                  description: Organization is the name of the Pulumi organization configured for OIDC authentication.
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountRef specifies the Kubernetes ServiceAccount to use for authentication.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - organization
+                                - serviceAccountRef
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Exactly one of 'accessToken' or 'oidcConfig' must be specified
+                              rule: (has(self.accessToken) && !has(self.oidcConfig)) || (!has(self.accessToken) && has(self.oidcConfig))
+                        environment:
+                          description: |-
+                            Environment are YAML documents composed of static key-value pairs, programmatic expressions,
+                            dynamically retrieved values from supported providers including all major clouds,
+                            and other Pulumi ESC environments.
+                            To create a new environment, visit https://www.pulumi.com/docs/esc/environments/ for more information.
+                          type: string
+                        organization:
+                          description: |-
+                            Organization are a space to collaborate on shared projects and stacks.
+                            To create a new organization, visit https://app.pulumi.com/ and click "New Organization".
+                          type: string
+                        project:
+                          description: Project is the name of the Pulumi ESC project the environment belongs to.
+                          type: string
+                      required:
+                        - environment
+                        - organization
+                        - project
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Exactly one of 'auth' or deprecated 'accessToken' must be specified
+                          rule: (has(self.auth) && !has(self.accessToken)) || (!has(self.auth) && has(self.accessToken))
+                    scaleway:
+                      description: Scaleway configures this store to sync secrets using the Scaleway provider.
+                      properties:
+                        accessKey:
+                          description: AccessKey is the non-secret part of the api key.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        apiUrl:
+                          description: APIURL is the url of the api to use. Defaults to https://api.scaleway.com
+                          type: string
+                        projectId:
+                          description: 'ProjectID is the id of your project, which you can find in the console: https://console.scaleway.com/project/settings'
+                          type: string
+                        region:
+                          description: 'Region where your secrets are located: https://developers.scaleway.com/en/quickstart/#region-and-zone'
+                          type: string
+                        secretKey:
+                          description: SecretKey is the non-secret part of the api key.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                      required:
+                        - accessKey
+                        - projectId
+                        - region
+                        - secretKey
+                      type: object
+                    secretserver:
+                      description: |-
+                        SecretServer configures this store to sync secrets using SecretServer provider
+                        https://docs.delinea.com/online-help/secret-server/start.htm
+                      properties:
+                        caBundle:
+                          description: |-
+                            PEM/base64 encoded CA bundle used to validate Secret ServerURL. Only used
+                            if the ServerURL URL is using HTTPS protocol. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Secret ServerURL certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        domain:
+                          description: Domain is the secret server domain.
+                          type: string
+                        password:
+                          description: |-
+                            Password is the secret server account password.
+                            Required unless Token is set.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              minLength: 1
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exactly one of value or secretRef must be set
+                              rule: has(self.value) != has(self.secretRef)
+                        serverURL:
+                          description: |-
+                            ServerURL
+                            URL to your secret server installation
+                          type: string
+                        token:
+                          description: |-
+                            Token is an access token used to authenticate to the secret server,
+                            as an alternative to Username and Password. When set, Username and
+                            Password are not required and are ignored.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              minLength: 1
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exactly one of value or secretRef must be set
+                              rule: has(self.value) != has(self.secretRef)
+                        username:
+                          description: |-
+                            Username is the secret server account username.
+                            Required unless Token is set.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              minLength: 1
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exactly one of value or secretRef must be set
+                              rule: has(self.value) != has(self.secretRef)
+                      required:
+                        - serverURL
+                      type: object
+                      x-kubernetes-validations:
+                        - message: either token, or both username and password, must be set
+                          rule: has(self.token) || (has(self.username) && has(self.password))
+                    senhasegura:
+                      description: Senhasegura configures this store to sync secrets using senhasegura provider
+                      properties:
+                        auth:
+                          description: Auth defines parameters to authenticate in senhasegura
+                          properties:
+                            clientId:
+                              type: string
+                            clientSecretSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - clientId
+                            - clientSecretSecretRef
+                          type: object
+                        ignoreSslCertificate:
+                          default: false
+                          description: IgnoreSslCertificate defines if SSL certificate must be ignored
+                          type: boolean
+                        module:
+                          description: Module defines which senhasegura module should be used to get secrets
+                          type: string
+                        url:
+                          description: URL of senhasegura
+                          type: string
+                      required:
+                        - auth
+                        - module
+                        - url
+                      type: object
+                    vault:
+                      description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          properties:
+                            appRole:
+                              description: |-
+                                AppRole authenticates with Vault using the App Role auth mechanism,
+                                with the role and secret stored in a Kubernetes Secret resource.
+                              properties:
+                                path:
+                                  default: approle
+                                  description: |-
+                                    Path where the App Role authentication backend is mounted
+                                    in Vault, e.g: "approle"
+                                  type: string
+                                roleId:
+                                  description: |-
+                                    RoleID configured in the App Role authentication backend when setting
+                                    up the authentication backend in Vault.
+                                  type: string
+                                roleRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role ID used
+                                    to authenticate with Vault.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role id.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role secret used
+                                    to authenticate with Vault.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - secretRef
+                              type: object
+                            cert:
+                              description: |-
+                                Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate
+                                Cert authentication method
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    ClientCert is a certificate to authenticate using the Cert Vault
+                                    authentication method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                path:
+                                  default: cert
+                                  description: |-
+                                    Path where the Certificate authentication backend is mounted
+                                    in Vault, e.g: "cert"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing client private key to
+                                    authenticate with Vault using the Cert authentication method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                vaultRole:
+                                  description: VaultRole specifies the Vault role to use for TLS certificate authentication.
+                                  type: string
+                              type: object
+                            gcp:
+                              description: |-
+                                Gcp authenticates with Vault using Google Cloud Platform authentication method
+                                GCP authentication method
+                              properties:
+                                location:
+                                  description: Location optionally defines a location/region for the secret
+                                  type: string
+                                path:
+                                  default: gcp
+                                  description: 'Path where the GCP auth method is enabled in Vault, e.g: "gcp"'
+                                  type: string
+                                projectID:
+                                  description: Project ID of the Google Cloud Platform project
+                                  type: string
+                                role:
+                                  description: Vault Role. In Vault, a role describes an identity with a set of permissions, groups, or policies you want to attach to a user of the secrets engine.
+                                  type: string
+                                secretRef:
+                                  description: Specify credentials in a Secret object
+                                  properties:
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  type: object
+                                serviceAccountRef:
+                                  description: ServiceAccountRef to a service account for impersonation
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                workloadIdentity:
+                                  description: Specify a service account with Workload Identity
+                                  properties:
+                                    clusterLocation:
+                                      description: |-
+                                        ClusterLocation is the location of the cluster
+                                        If not specified, it fetches information from the metadata server
+                                      type: string
+                                    clusterName:
+                                      description: |-
+                                        ClusterName is the name of the cluster
+                                        If not specified, it fetches information from the metadata server
+                                      type: string
+                                    clusterProjectID:
+                                      description: |-
+                                        ClusterProjectID is the project ID of the cluster
+                                        If not specified, it fetches information from the metadata server
+                                      type: string
+                                    serviceAccountRef:
+                                      description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                              required:
+                                - role
+                              type: object
+                            iam:
+                              description: |-
+                                Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials
+                                AWS IAM authentication method
+                              properties:
+                                externalID:
+                                  description: AWS External ID set on assumed IAM roles
+                                  type: string
+                                jwt:
+                                  description: Specify a service account with IRSA enabled
+                                  properties:
+                                    serviceAccountRef:
+                                      description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  type: object
+                                path:
+                                  description: 'Path where the AWS auth method is enabled in Vault, e.g: "aws"'
+                                  type: string
+                                region:
+                                  description: AWS region
+                                  type: string
+                                role:
+                                  description: This is the AWS role to be assumed before talking to vault
+                                  type: string
+                                secretRef:
+                                  description: Specify credentials in a Secret object
+                                  properties:
+                                    accessKeyIDSecretRef:
+                                      description: The AccessKeyID is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    sessionTokenSecretRef:
+                                      description: |-
+                                        The SessionToken used for authentication
+                                        This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                        see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  type: object
+                                vaultAwsIamServerID:
+                                  description: 'X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws'
+                                  type: string
+                                vaultRole:
+                                  description: Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine
+                                  type: string
+                              required:
+                                - vaultRole
+                              type: object
+                            jwt:
+                              description: |-
+                                Jwt authenticates with Vault by passing role and JWT token using the
+                                JWT/OIDC authentication method
+                              properties:
+                                kubernetesServiceAccountToken:
+                                  description: |-
+                                    Optional ServiceAccountToken specifies the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Optional audiences field that will be used to request a temporary Kubernetes service
+                                        account token for the service account referenced by `serviceAccountRef`.
+                                        Defaults to a single audience `vault` it not specified.
+
+                                        Deprecated: use serviceAccountRef.Audiences instead
+                                      items:
+                                        type: string
+                                      type: array
+                                    expirationSeconds:
+                                      description: |-
+                                        Optional expiration time in seconds that will be used to request a temporary
+                                        Kubernetes service account token for the service account referenced by
+                                        `serviceAccountRef`.
+
+                                        Deprecated: this will be removed in the future.
+                                        Defaults to 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    serviceAccountRef:
+                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                                path:
+                                  default: jwt
+                                  description: |-
+                                    Path where the JWT authentication backend is mounted
+                                    in Vault, e.g: "jwt"
+                                  type: string
+                                role:
+                                  description: |-
+                                    Role is a JWT role to authenticate using the JWT/OIDC Vault
+                                    authentication method
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                    authenticate with Vault using the JWT/OIDC authentication method.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                              type: object
+                            kubernetes:
+                              description: |-
+                                Kubernetes authenticates with Vault by passing the ServiceAccount
+                                token stored in the named Secret resource to the Vault server.
+                              properties:
+                                mountPath:
+                                  default: kubernetes
+                                  description: |-
+                                    Path where the Kubernetes authentication backend is mounted in Vault, e.g:
+                                    "kubernetes"
+                                  type: string
+                                role:
+                                  description: |-
+                                    A required field containing the Vault Role to assume. A Role binds a
+                                    Kubernetes ServiceAccount with a set of Vault policies.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                    for authenticating with Vault. If a name is specified without a key,
+                                    `token` is the default. If one is not specified, the one bound to
+                                    the controller will be used.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional service account field containing the name of a kubernetes ServiceAccount.
+                                    If the service account is specified, the service account secret token JWT will be used
+                                    for authenticating with Vault. If the service account selector is not supplied,
+                                    the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - mountPath
+                                - role
+                              type: object
+                            ldap:
+                              description: |-
+                                Ldap authenticates with Vault by passing username/password pair using
+                                the LDAP authentication method
+                              properties:
+                                path:
+                                  default: ldap
+                                  description: |-
+                                    Path where the LDAP authentication backend is mounted
+                                    in Vault, e.g: "ldap"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the LDAP
+                                    user used to authenticate with Vault using the LDAP authentication
+                                    method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is an LDAP username used to authenticate using the LDAP Vault
+                                    authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                            namespace:
+                              description: |-
+                                Name of the vault namespace to authenticate to. This can be different than the namespace your secret is in.
+                                Namespaces is a set of features within Vault Enterprise that allows
+                                Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                                More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                                This will default to Vault.Namespace field if set, or empty otherwise
+                              type: string
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            userPass:
+                              description: UserPass authenticates with Vault by passing username/password pair
+                              properties:
+                                path:
+                                  default: userpass
+                                  description: |-
+                                    Path where the UserPassword authentication backend is mounted
+                                    in Vault, e.g: "userpass"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the
+                                    user used to authenticate with Vault using the UserPass authentication
+                                    method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is a username used to authenticate using the UserPass Vault
+                                    authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate Vault server certificate. Only used
+                            if the Server URL is using HTTPS protocol. This parameter is ignored for
+                            plain HTTP protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        checkAndSet:
+                          description: |-
+                            CheckAndSet defines the Check-And-Set (CAS) settings for PushSecret operations.
+                            Only applies to Vault KV v2 stores. When enabled, write operations must include
+                            the current version of the secret to prevent unintentional overwrites.
+                          properties:
+                            required:
+                              description: |-
+                                Required when true, all write operations must include a check-and-set parameter.
+                                This helps prevent unintentional overwrites of secrets.
+                              type: boolean
+                          type: object
+                        forwardInconsistent:
+                          description: |-
+                            ForwardInconsistent tells Vault to forward read-after-write requests to the Vault
+                            leader instead of simply retrying within a loop. This can increase performance if
+                            the option is enabled serverside.
+                            https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          type: boolean
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers to be added in Vault request
+                          type: object
+                        namespace:
+                          description: |-
+                            Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
+                            Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                            More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                          type: string
+                        path:
+                          description: |-
+                            Path is the mount path of the Vault KV backend endpoint, e.g:
+                            "secret". The v2 KV secret engine version specific "/data" path suffix
+                            for fetching secrets from Vault is optional and will be appended
+                            if not present in specified path.
+                          type: string
+                        readYourWrites:
+                          description: |-
+                            ReadYourWrites ensures isolated read-after-write semantics by
+                            providing discovered cluster replication states in each request.
+                            More information about eventual consistency in Vault can be found here
+                            https://www.vaultproject.io/docs/enterprise/consistency
+                          type: boolean
+                        server:
+                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          type: string
+                        tls:
+                          description: |-
+                            The configuration used for client side related TLS communication, when the Vault server
+                            requires mutual authentication. Only used if the Server URL is using HTTPS protocol.
+                            This parameter is ignored for plain HTTP protocol connection.
+                            It's worth noting this configuration is different from the "TLS certificates auth method",
+                            which is available under the `auth.cert` section.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                CertSecretRef is a certificate added to the transport layer
+                                when communicating with the Vault server.
+                                If no key for the Secret is specified, external-secret will default to 'tls.crt'.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            keySecretRef:
+                              description: |-
+                                KeySecretRef to a key in a Secret resource containing client private key
+                                added to the transport layer when communicating with the Vault server.
+                                If no key for the Secret is specified, external-secret will default to 'tls.key'.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        version:
+                          default: v2
+                          description: |-
+                            Version is the Vault KV secret engine version. This can be either "v1" or
+                            "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - server
+                      type: object
+                    volcengine:
+                      description: Volcengine configures this store to sync secrets using the Volcengine provider
+                      properties:
+                        auth:
+                          description: |-
+                            Auth defines the authentication method to use.
+                            If not specified, the provider will try to use IRSA (IAM Role for Service Account).
+                          properties:
+                            secretRef:
+                              description: |-
+                                SecretRef defines the static credentials to use for authentication.
+                                If not set, IRSA is used.
+                              properties:
+                                accessKeyID:
+                                  description: AccessKeyID is the reference to the secret containing the Access Key ID.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretAccessKey:
+                                  description: SecretAccessKey is the reference to the secret containing the Secret Access Key.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                token:
+                                  description: Token is the reference to the secret containing the STS(Security Token Service) Token.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyID
+                                - secretAccessKey
+                              type: object
+                          type: object
+                        region:
+                          description: Region specifies the Volcengine region to connect to.
+                          type: string
+                      required:
+                        - region
+                      type: object
+                    webhook:
+                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      properties:
+                        auth:
+                          description: Auth specifies a authorization protocol. Only one protocol may be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            ntlm:
+                              description: NTLMProtocol configures the store to use NTLM for auth
+                              properties:
+                                passwordSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                usernameSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - passwordSecret
+                                - usernameSecret
+                              type: object
+                          type: object
+                        body:
+                          description: Body
+                          type: string
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate webhook server certificate. Only used
+                            if the Server URL is using HTTPS protocol. This parameter is ignored for
+                            plain HTTP protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers
+                          type: object
+                        method:
+                          description: Webhook Method
+                          type: string
+                        result:
+                          description: Result formatting
+                          properties:
+                            jsonPath:
+                              description: Json path of return value
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets to fill in templates
+                            These secrets will be passed to the templating function as key value pairs under the given name
+                          items:
+                            description: WebhookSecret defines a secret that will be passed to the webhook request.
+                            properties:
+                              name:
+                                description: Name of this secret in templates
+                                type: string
+                              secretRef:
+                                description: Secret ref to fill in credentials
+                                properties:
+                                  key:
+                                    description: |-
+                                      A key in the referenced Secret.
+                                      Some instances of this field may be defaulted, in others it may be required.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[-._a-zA-Z0-9]+$
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being referred to.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      The namespace of the Secret resource being referred to.
+                                      Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                type: object
+                            required:
+                              - name
+                              - secretRef
+                            type: object
+                          type: array
+                        timeout:
+                          description: Timeout
+                          type: string
+                        url:
+                          description: Webhook url to call
+                          type: string
+                      required:
+                        - url
+                      type: object
+                    yandexcertificatemanager:
+                      description: YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex.Cloud
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        fetching:
+                          description: FetchingPolicy configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as certificate ID or certificate name
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            byID:
+                              description: ByID configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret ID.
+                              type: object
+                            byName:
+                              description: ByName configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret name.
+                              properties:
+                                folderID:
+                                  description: The folder to fetch secrets from
+                                  type: string
+                              required:
+                                - folderID
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    yandexlockbox:
+                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex.Cloud
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        fetching:
+                          description: FetchingPolicy configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret ID or secret name
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            byID:
+                              description: ByID configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret ID.
+                              type: object
+                            byName:
+                              description: ByName configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret name.
+                              properties:
+                                folderID:
+                                  description: The folder to fetch secrets from
+                                  type: string
+                              required:
+                                - folderID
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                  type: object
+                refreshInterval:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    Used to configure store refresh interval. Accepts either an integer number
+                    of seconds (legacy) or a Go duration string such as "1h" or "5m". Empty or
+                    0 will default to the controller config.
+                  x-kubernetes-int-or-string: true
+                retrySettings:
+                  description: Used to configure HTTP retries on failures.
+                  properties:
+                    maxRetries:
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      type: string
+                  type: object
+              required:
+                - provider
+              type: object
+            status:
+              description: SecretStoreStatus defines the observed state of the SecretStore.
+              properties:
+                capabilities:
+                  description: SecretStoreCapabilities defines the possible operations a SecretStore can do.
+                  type: string
+                conditions:
+                  items:
+                    description: SecretStoreStatusCondition contains condition information for a SecretStore.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: SecretStoreConditionType represents the condition of the SecretStore.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.capabilities
+          name: Capabilities
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      deprecated: true
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ClusterSecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SecretStoreSpec defines the desired state of SecretStore.
+              properties:
+                conditions:
+                  description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
+                  items:
+                    description: |-
+                      ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
+                      for a ClusterSecretStore instance.
+                    properties:
+                      namespaceRegexes:
+                        description: Choose namespaces by using regex matching
+                        items:
+                          type: string
+                        type: array
+                      namespaceSelector:
+                        description: Choose namespace using a labelSelector
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaces:
+                        description: Choose namespaces by name
+                        items:
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                controller:
+                  description: |-
+                    Used to select the correct ESO controller (think: ingress.ingressClassName)
+                    The ESO controller is instantiated with a specific controller name and filters ES based on this property
+                  type: string
+                provider:
+                  description: Used to configure the provider. Only one provider may be set
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    akeyless:
+                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      properties:
+                        akeylessGWApiURL:
+                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          type: string
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Akeyless.
+                          properties:
+                            kubernetesAuth:
+                              description: |-
+                                Kubernetes authenticates with Akeyless by passing the ServiceAccount
+                                token stored in the named Secret resource.
+                              properties:
+                                accessID:
+                                  description: the Akeyless Kubernetes auth-method access-id
+                                  type: string
+                                k8sConfName:
+                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                    for authenticating with Akeyless. If a name is specified without a key,
+                                    `token` is the default. If one is not specified, the one bound to
+                                    the controller will be used.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional service account field containing the name of a kubernetes ServiceAccount.
+                                    If the service account is specified, the service account secret token JWT will be used
+                                    for authenticating with Akeyless. If the service account selector is not supplied,
+                                    the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - accessID
+                                - k8sConfName
+                              type: object
+                            secretRef:
+                              description: |-
+                                Reference to a Secret that contains the details
+                                to authenticate with Akeyless.
+                              properties:
+                                accessID:
+                                  description: The SecretAccessID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessType:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessTypeParam:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used
+                            if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                      required:
+                        - akeylessGWApiURL
+                        - authSecretRef
+                      type: object
+                    alibaba:
+                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      properties:
+                        auth:
+                          description: AlibabaAuth contains a secretRef for credentials.
+                          properties:
+                            rrsa:
+                              description: AlibabaRRSAAuth authenticates against Alibaba using RRSA (Resource-oriented RAM-based Service Authentication).
+                              properties:
+                                oidcProviderArn:
+                                  type: string
+                                oidcTokenFilePath:
+                                  type: string
+                                roleArn:
+                                  type: string
+                                sessionName:
+                                  type: string
+                              required:
+                                - oidcProviderArn
+                                - oidcTokenFilePath
+                                - roleArn
+                                - sessionName
+                              type: object
+                            secretRef:
+                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          type: object
+                        regionID:
+                          description: Alibaba Region to be used for the provider
+                          type: string
+                      required:
+                        - auth
+                        - regionID
+                      type: object
+                    aws:
+                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      properties:
+                        additionalRoles:
+                          description: AdditionalRoles is a chained list of Role ARNs which the provider will sequentially assume before assuming the Role
+                          items:
+                            type: string
+                          type: array
+                        auth:
+                          description: |-
+                            Auth defines the information necessary to authenticate against AWS
+                            if not set aws sdk will infer credentials from your environment
+                            see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                          properties:
+                            jwt:
+                              description: AWSJWTAuth authenticates against AWS using service account tokens from the Kubernetes cluster.
+                              properties:
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: |-
+                                AWSAuthSecretRef holds secret references for AWS credentials
+                                both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                sessionTokenSecretRef:
+                                  description: |-
+                                    The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                    see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        externalID:
+                          description: AWS External ID set on assumed IAM roles
+                          type: string
+                        prefix:
+                          description: Prefix adds a prefix to all retrieved values.
+                          type: string
+                        region:
+                          description: AWS Region to be used for the provider
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the provider will assume
+                          type: string
+                        secretsManager:
+                          description: SecretsManager defines how the provider behaves when interacting with AWS SecretsManager
+                          properties:
+                            forceDeleteWithoutRecovery:
+                              description: |-
+                                Specifies whether to delete the secret without any recovery window. You
+                                can't use both this parameter and RecoveryWindowInDays in the same call.
+                                If you don't use either, then by default Secrets Manager uses a 30 day
+                                recovery window.
+                                see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-ForceDeleteWithoutRecovery
+                              type: boolean
+                            recoveryWindowInDays:
+                              description: |-
+                                The number of days from 7 to 30 that Secrets Manager waits before
+                                permanently deleting the secret. You can't use both this parameter and
+                                ForceDeleteWithoutRecovery in the same call. If you don't use either,
+                                then by default Secrets Manager uses a 30 day recovery window.
+                                see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-RecoveryWindowInDays
+                              format: int64
+                              type: integer
+                          type: object
+                        service:
+                          description: Service defines which service should be used to fetch the secrets
+                          enum:
+                            - SecretsManager
+                            - ParameterStore
+                          type: string
+                        sessionTags:
+                          description: AWS STS assume role session tags
+                          items:
+                            description: Tag defines a tag key and value for AWS resources.
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          type: array
+                        transitiveTagKeys:
+                          description: AWS STS assume role transitive session tags. Required when multiple rules are used with the provider
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - region
+                        - service
+                      type: object
+                    azurekv:
+                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      properties:
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type. Optional for WorkloadIdentity.
+                          properties:
+                            clientCertificate:
+                              description: The Azure ClientCertificate of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            clientId:
+                              description: The Azure clientId of the service principle or managed identity used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            tenantId:
+                              description: The Azure tenantId of the managed identity used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        authType:
+                          default: ServicePrincipal
+                          description: |-
+                            Auth type defines how to authenticate to the keyvault service.
+                            Valid values are:
+                            - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret)
+                            - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)
+                          enum:
+                            - ServicePrincipal
+                            - ManagedIdentity
+                            - WorkloadIdentity
+                          type: string
+                        environmentType:
+                          default: PublicCloud
+                          description: |-
+                            EnvironmentType specifies the Azure cloud environment endpoints to use for
+                            connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint.
+                            The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                            PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud
+                          enum:
+                            - PublicCloud
+                            - USGovernmentCloud
+                            - ChinaCloud
+                            - GermanCloud
+                          type: string
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tenantId:
+                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type. Optional for WorkloadIdentity.
+                          type: string
+                        vaultUrl:
+                          description: Vault Url from which the secrets to be fetched from.
+                          type: string
+                      required:
+                        - vaultUrl
+                      type: object
+                    beyondtrust:
+                      description: Beyondtrust configures this store to sync secrets using Password Safe provider.
+                      properties:
+                        auth:
+                          description: Auth configures how the operator authenticates with Beyondtrust.
+                          properties:
+                            apiKey:
+                              description: APIKey If not provided then ClientID/ClientSecret become required.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            certificate:
+                              description: Certificate (cert.pem) for use when authenticating with an OAuth client Id using a Client Certificate.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            certificateKey:
+                              description: Certificate private key (key.pem). For use when authenticating with an OAuth client Id
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            clientId:
+                              description: ClientID is the API OAuth Client ID.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: ClientSecret is the API OAuth Client Secret.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                          type: object
+                        server:
+                          description: Auth configures how API server works.
+                          properties:
+                            apiUrl:
+                              type: string
+                            apiVersion:
+                              type: string
+                            clientTimeOutSeconds:
+                              description: Timeout specifies a time limit for requests made by this Client. The timeout includes connection time, any redirects, and reading the response body. Defaults to 45 seconds.
+                              type: integer
+                            decrypt:
+                              default: true
+                              description: 'When true, the response includes the decrypted password. When false, the password field is omitted. This option only applies to the SECRET retrieval type. Default: true.'
+                              type: boolean
+                            retrievalType:
+                              description: The secret retrieval type. SECRET = Secrets Safe (credential, text, file). MANAGED_ACCOUNT = Password Safe account associated with a system.
+                              type: string
+                            separator:
+                              description: A character that separates the folder names.
+                              type: string
+                            verifyCA:
+                              type: boolean
+                          required:
+                            - apiUrl
+                            - verifyCA
+                          type: object
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    bitwardensecretsmanager:
+                      description: BitwardenSecretsManager configures this store to sync secrets using BitwardenSecretsManager provider
+                      properties:
+                        apiURL:
+                          type: string
+                        auth:
+                          description: |-
+                            Auth configures how secret-manager authenticates with a bitwarden machine account instance.
+                            Make sure that the token being used has permissions on the given secret.
+                          properties:
+                            secretRef:
+                              description: BitwardenSecretsManagerSecretRef contains the credential ref to the bitwarden instance.
+                              properties:
+                                credentials:
+                                  description: AccessToken used for the bitwarden instance.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - credentials
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        bitwardenServerSDKURL:
+                          type: string
+                        caBundle:
+                          description: |-
+                            Base64 encoded certificate for the bitwarden server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                            can be performed.
+                          type: string
+                        caProvider:
+                          description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        identityURL:
+                          type: string
+                        organizationID:
+                          description: OrganizationID determines which organization this secret store manages.
+                          type: string
+                        projectID:
+                          description: ProjectID determines which project this secret store manages.
+                          type: string
+                      required:
+                        - auth
+                        - organizationID
+                        - projectID
+                      type: object
+                    chef:
+                      description: Chef configures this store to sync secrets with chef server
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against chef Server
+                          properties:
+                            secretRef:
+                              description: ChefAuthSecretRef holds secret references for chef server login credentials.
+                              properties:
+                                privateKeySecretRef:
+                                  description: SecretKey is the Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - privateKeySecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        serverUrl:
+                          description: ServerURL is the chef server URL used to connect to. If using orgs you should include your org in the url and terminate the url with a "/"
+                          type: string
+                        username:
+                          description: UserName should be the user ID on the chef server
+                          type: string
+                      required:
+                        - auth
+                        - serverUrl
+                        - username
+                      type: object
+                    cloudrusm:
+                      description: CloudruSM configures this store to sync secrets using the Cloud.ru Secret Manager provider
+                      properties:
+                        auth:
+                          description: CSMAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: CSMAuthSecretRef holds secret references for Cloud.ru credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          type: object
+                        projectID:
+                          description: ProjectID is the project, which the secrets are stored in.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    conjur:
+                      description: Conjur configures this store to sync secrets using conjur provider
+                      properties:
+                        auth:
+                          description: Defines authentication settings for connecting to Conjur.
+                          properties:
+                            apikey:
+                              description: Authenticates with Conjur using an API key.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                apiKeyRef:
+                                  description: |-
+                                    A reference to a specific 'key' containing the Conjur API key
+                                    within a Secret resource. In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                userRef:
+                                  description: |-
+                                    A reference to a specific 'key' containing the Conjur username
+                                    within a Secret resource. In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - account
+                                - apiKeyRef
+                                - userRef
+                              type: object
+                            jwt:
+                              description: Jwt enables JWT authentication using Kubernetes service account tokens.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                hostId:
+                                  description: |-
+                                    Optional HostID for JWT authentication. This may be used depending
+                                    on how the Conjur JWT authenticator policy is configured.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                    authenticate with Conjur using the JWT authentication method.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional ServiceAccountRef specifies the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceID:
+                                  description: The conjur authn jwt webservice id
+                                  type: string
+                              required:
+                                - account
+                                - serviceID
+                              type: object
+                          type: object
+                        caBundle:
+                          description: CABundle is a PEM encoded CA bundle that will be used to validate the Conjur server certificate.
+                          type: string
+                        caProvider:
+                          description: |-
+                            Used to provide custom certificate authority (CA) certificates
+                            for a secret store. The CAProvider points to a Secret or ConfigMap resource
+                            that contains a PEM-encoded certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        url:
+                          description: URL is the endpoint of the Conjur instance.
+                          type: string
+                      required:
+                        - auth
+                        - url
+                      type: object
+                    delinea:
+                      description: |-
+                        Delinea DevOps Secrets Vault
+                        https://docs.delinea.com/online-help/products/devops-secrets-vault/current
+                      properties:
+                        clientId:
+                          description: ClientID is the non-secret part of the credential.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        clientSecret:
+                          description: ClientSecret is the secret part of the credential.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        tenant:
+                          description: Tenant is the chosen hostname / site name.
+                          type: string
+                        tld:
+                          description: |-
+                            TLD is based on the server location that was chosen during provisioning.
+                            If unset, defaults to "com".
+                          type: string
+                        urlTemplate:
+                          description: |-
+                            URLTemplate
+                            If unset, defaults to "https://%s.secretsvaultcloud.%s/v1/%s%s".
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tenant
+                      type: object
+                    device42:
+                      description: Device42 configures this store to sync secrets using the Device42 provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Device42 instance.
+                          properties:
+                            secretRef:
+                              description: Device42SecretRef defines a reference to a secret containing credentials for the Device42 provider.
+                              properties:
+                                credentials:
+                                  description: Username / Password is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        host:
+                          description: URL configures the Device42 instance URL.
+                          type: string
+                      required:
+                        - auth
+                        - host
+                      type: object
+                    doppler:
+                      description: Doppler configures this store to sync secrets using the Doppler provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Doppler API
+                          properties:
+                            secretRef:
+                              description: DopplerAuthSecretRef defines a reference to a secret containing credentials for the Doppler provider.
+                              properties:
+                                dopplerToken:
+                                  description: |-
+                                    The DopplerToken is used for authentication.
+                                    See https://docs.doppler.com/reference/api#authentication for auth token types.
+                                    The Key attribute defaults to dopplerToken if not specified.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - dopplerToken
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        config:
+                          description: Doppler config (required if not using a Service Token)
+                          type: string
+                        format:
+                          description: Format enables the downloading of secrets as a file (string)
+                          enum:
+                            - json
+                            - dotnet-json
+                            - env
+                            - yaml
+                            - docker
+                          type: string
+                        nameTransformer:
+                          description: Environment variable compatible name transforms that change secret names to a different format
+                          enum:
+                            - upper-camel
+                            - camel
+                            - lower-snake
+                            - tf-var
+                            - dotnet-env
+                            - lower-kebab
+                          type: string
+                        project:
+                          description: Doppler project (required if not using a Service Token)
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    fake:
+                      description: Fake configures a store with static key/value pairs
+                      properties:
+                        data:
+                          items:
+                            description: FakeProviderData defines a key-value pair for the fake provider used in testing.
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          type: array
+                      required:
+                        - data
+                      type: object
+                    fortanix:
+                      description: Fortanix configures this store to sync secrets using the Fortanix provider
+                      properties:
+                        apiKey:
+                          description: APIKey is the API token to access SDKMS Applications.
+                          properties:
+                            secretRef:
+                              description: SecretRef is a reference to a secret containing the SDKMS API Key.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        apiUrl:
+                          description: APIURL is the URL of SDKMS API. Defaults to `sdkms.fortanix.com`.
+                          type: string
+                      type: object
+                    gcpsm:
+                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against GCP
+                          properties:
+                            secretRef:
+                              description: GCPSMAuthSecretRef defines a reference to a secret containing credentials for the GCP Secret Manager provider.
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            workloadIdentity:
+                              description: GCPWorkloadIdentity defines configuration for using GCP Workload Identity authentication.
+                              properties:
+                                clusterLocation:
+                                  description: |-
+                                    ClusterLocation is the location of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterName:
+                                  description: |-
+                                    ClusterName is the name of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterProjectID:
+                                  description: |-
+                                    ClusterProjectID is the project ID of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - serviceAccountRef
+                              type: object
+                          type: object
+                        location:
+                          description: Location optionally defines a location for a secret
+                          type: string
+                        projectID:
+                          description: ProjectID project where secret is located
+                          type: string
+                      type: object
+                    github:
+                      description: Github configures this store to push GitHub Actions secrets using the GitHub API provider.
+                      properties:
+                        appID:
+                          description: appID specifies the Github APP that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        auth:
+                          description: auth configures how secret-manager authenticates with a Github instance.
+                          properties:
+                            privateKey:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - privateKey
+                          type: object
+                        environment:
+                          description: environment will be used to fetch secrets from a particular environment within a github repository
+                          type: string
+                        installationID:
+                          description: installationID specifies the Github APP installation that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        organization:
+                          description: organization will be used to fetch secrets from the Github organization
+                          type: string
+                        repository:
+                          description: repository will be used to fetch secrets from the Github repository within an organization
+                          type: string
+                        uploadURL:
+                          description: Upload URL for enterprise instances. Default to URL.
+                          type: string
+                        url:
+                          default: https://github.com/
+                          description: URL configures the Github instance URL. Defaults to https://github.com/.
+                          type: string
+                      required:
+                        - appID
+                        - auth
+                        - installationID
+                        - organization
+                      type: object
+                    gitlab:
+                      description: GitLab configures this store to sync secrets using GitLab Variables provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          properties:
+                            SecretRef:
+                              description: GitlabSecretRef defines a reference to a secret containing credentials for the GitLab provider.
+                              properties:
+                                accessToken:
+                                  description: AccessToken is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - SecretRef
+                          type: object
+                        caBundle:
+                          description: |-
+                            Base64 encoded certificate for the GitLab server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                            can be performed.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        environment:
+                          description: Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)
+                          type: string
+                        groupIDs:
+                          description: GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.
+                          items:
+                            type: string
+                          type: array
+                        inheritFromGroups:
+                          description: InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.
+                          type: boolean
+                        projectID:
+                          description: ProjectID specifies a project where secrets are located.
+                          type: string
+                        url:
+                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    ibm:
+                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            containerAuth:
+                              description: IBMAuthContainerAuth defines authentication using IBM Container-based auth with IAM Trusted Profile.
+                              properties:
+                                iamEndpoint:
+                                  type: string
+                                profile:
+                                  description: the IBM Trusted Profile
+                                  type: string
+                                tokenLocation:
+                                  description: Location the token is mounted on the pod
+                                  type: string
+                              required:
+                                - profile
+                              type: object
+                            secretRef:
+                              description: IBMAuthSecretRef defines a reference to a secret containing credentials for the IBM provider.
+                              properties:
+                                secretApiKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        serviceUrl:
+                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    infisical:
+                      description: Infisical configures this store to sync secrets using the Infisical provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Infisical API
+                          properties:
+                            universalAuthCredentials:
+                              description: UniversalAuthCredentials defines the credentials for Infisical Universal Auth.
+                              properties:
+                                clientId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - clientId
+                                - clientSecret
+                              type: object
+                          type: object
+                        hostAPI:
+                          default: https://app.infisical.com/api
+                          description: HostAPI specifies the base URL of the Infisical API. If not provided, it defaults to "https://app.infisical.com/api".
+                          type: string
+                        secretsScope:
+                          description: SecretsScope defines the scope of the secrets within the workspace
+                          properties:
+                            environmentSlug:
+                              description: EnvironmentSlug is the required slug identifier for the environment.
+                              type: string
+                            expandSecretReferences:
+                              default: true
+                              description: ExpandSecretReferences indicates whether secret references should be expanded. Defaults to true if not provided.
+                              type: boolean
+                            projectSlug:
+                              description: ProjectSlug is the required slug identifier for the project.
+                              type: string
+                            recursive:
+                              default: false
+                              description: Recursive indicates whether the secrets should be fetched recursively. Defaults to false if not provided.
+                              type: boolean
+                            secretsPath:
+                              default: /
+                              description: SecretsPath specifies the path to the secrets within the workspace. Defaults to "/" if not provided.
+                              type: string
+                          required:
+                            - environmentSlug
+                            - projectSlug
+                          type: object
+                      required:
+                        - auth
+                        - secretsScope
+                      type: object
+                    keepersecurity:
+                      description: KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider
+                      properties:
+                        authRef:
+                          description: |-
+                            SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                            In some instances, `key` is a required field.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        folderID:
+                          type: string
+                      required:
+                        - authRef
+                        - folderID
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        authRef:
+                          description: A reference to a secret that contains the auth information.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        remoteNamespace:
+                          default: default
+                          description: Remote namespace to fetch the secrets from
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        server:
+                          description: configures the Kubernetes server Address.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                      type: object
+                    onboardbase:
+                      description: Onboardbase configures this store to sync secrets using the Onboardbase provider
+                      properties:
+                        apiHost:
+                          default: https://public.onboardbase.com/api/v1/
+                          description: APIHost use this to configure the host url for the API for selfhosted installation, default is https://public.onboardbase.com/api/v1/
+                          type: string
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Onboardbase API
+                          properties:
+                            apiKeyRef:
+                              description: |-
+                                OnboardbaseAPIKey is the APIKey generated by an admin account.
+                                It is used to recognize and authorize access to a project and environment within onboardbase
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            passcodeRef:
+                              description: OnboardbasePasscode is the passcode attached to the API Key
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - apiKeyRef
+                            - passcodeRef
+                          type: object
+                        environment:
+                          default: development
+                          description: Environment is the name of an environmnent within a project to pull the secrets from
+                          type: string
+                        project:
+                          default: development
+                          description: Project is an onboardbase project that the secrets should be pulled from
+                          type: string
+                      required:
+                        - apiHost
+                        - auth
+                        - environment
+                        - project
+                      type: object
+                    onepassword:
+                      description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against OnePassword Connect Server
+                          properties:
+                            secretRef:
+                              description: OnePasswordAuthSecretRef holds secret references for 1Password credentials.
+                              properties:
+                                connectTokenSecretRef:
+                                  description: The ConnectToken is used for authentication to a 1Password Connect Server.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - connectTokenSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        connectHost:
+                          description: ConnectHost defines the OnePassword Connect Server to connect to
+                          type: string
+                        vaults:
+                          additionalProperties:
+                            type: integer
+                          description: Vaults defines which OnePassword vaults to search in which order
+                          type: object
+                      required:
+                        - auth
+                        - connectHost
+                        - vaults
+                      type: object
+                    oracle:
+                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      properties:
+                        auth:
+                          description: |-
+                            Auth configures how secret-manager authenticates with the Oracle Vault.
+                            If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          properties:
+                            secretRef:
+                              description: SecretRef to pass through sensitive information.
+                              properties:
+                                fingerprint:
+                                  description: Fingerprint is the fingerprint of the API private key.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                privatekey:
+                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - privatekey
+                              type: object
+                            tenancy:
+                              description: Tenancy is the tenancy OCID where user is located.
+                              type: string
+                            user:
+                              description: User is an access OCID specific to the account.
+                              type: string
+                          required:
+                            - secretRef
+                            - tenancy
+                            - user
+                          type: object
+                        compartment:
+                          description: |-
+                            Compartment is the vault compartment OCID.
+                            Required for PushSecret
+                          type: string
+                        encryptionKey:
+                          description: |-
+                            EncryptionKey is the OCID of the encryption key within the vault.
+                            Required for PushSecret
+                          type: string
+                        principalType:
+                          description: |-
+                            The type of principal to use for authentication. If left blank, the Auth struct will
+                            determine the principal type. This optional field must be specified if using
+                            workload identity.
+                          enum:
+                            - ""
+                            - UserPrincipal
+                            - InstancePrincipal
+                            - Workload
+                          type: string
+                        region:
+                          description: Region is the region where vault is located.
+                          type: string
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        vault:
+                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          type: string
+                      required:
+                        - region
+                        - vault
+                      type: object
+                    passbolt:
+                      description: PassboltProvider defines configuration for the Passbolt provider.
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Passbolt Server
+                          properties:
+                            passwordSecretRef:
+                              description: PasswordSecretRef is a reference to the secret containing the Passbolt password
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            privateKeySecretRef:
+                              description: PrivateKeySecretRef is a reference to the secret containing the Passbolt private key
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - passwordSecretRef
+                            - privateKeySecretRef
+                          type: object
+                        host:
+                          description: Host defines the Passbolt Server to connect to
+                          type: string
+                      required:
+                        - auth
+                        - host
+                      type: object
+                    passworddepot:
+                      description: PasswordDepotProvider configures a store to sync secrets with a Password Depot instance.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Password Depot instance.
+                          properties:
+                            secretRef:
+                              description: PasswordDepotSecretRef defines a reference to a secret containing credentials for the Password Depot provider.
+                              properties:
+                                credentials:
+                                  description: Username / Password is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        database:
+                          description: Database to use as source
+                          type: string
+                        host:
+                          description: URL configures the Password Depot instance URL.
+                          type: string
+                      required:
+                        - auth
+                        - database
+                        - host
+                      type: object
+                    previder:
+                      description: Previder configures this store to sync secrets using the Previder provider
+                      properties:
+                        auth:
+                          description: PreviderAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: PreviderAuthSecretRef holds secret references for Previder Vault credentials.
+                              properties:
+                                accessToken:
+                                  description: The AccessToken is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessToken
+                              type: object
+                          type: object
+                        baseUri:
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    pulumi:
+                      description: Pulumi configures this store to sync secrets using the Pulumi provider
+                      properties:
+                        accessToken:
+                          description: AccessToken is the access tokens to sign in to the Pulumi Cloud Console.
+                          properties:
+                            secretRef:
+                              description: SecretRef is a reference to a secret containing the Pulumi API token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        apiUrl:
+                          default: https://api.pulumi.com/api/esc
+                          description: APIURL is the URL of the Pulumi API.
+                          type: string
+                        environment:
+                          description: |-
+                            Environment are YAML documents composed of static key-value pairs, programmatic expressions,
+                            dynamically retrieved values from supported providers including all major clouds,
+                            and other Pulumi ESC environments.
+                            To create a new environment, visit https://www.pulumi.com/docs/esc/environments/ for more information.
+                          type: string
+                        organization:
+                          description: |-
+                            Organization are a space to collaborate on shared projects and stacks.
+                            To create a new organization, visit https://app.pulumi.com/ and click "New Organization".
+                          type: string
+                        project:
+                          description: Project is the name of the Pulumi ESC project the environment belongs to.
+                          type: string
+                      required:
+                        - accessToken
+                        - environment
+                        - organization
+                        - project
+                      type: object
+                    scaleway:
+                      description: Scaleway configures this store to sync secrets using the Scaleway provider.
+                      properties:
+                        accessKey:
+                          description: AccessKey is the non-secret part of the api key.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        apiUrl:
+                          description: APIURL is the url of the api to use. Defaults to https://api.scaleway.com
+                          type: string
+                        projectId:
+                          description: 'ProjectID is the id of your project, which you can find in the console: https://console.scaleway.com/project/settings'
+                          type: string
+                        region:
+                          description: 'Region where your secrets are located: https://developers.scaleway.com/en/quickstart/#region-and-zone'
+                          type: string
+                        secretKey:
+                          description: SecretKey is the non-secret part of the api key.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                      required:
+                        - accessKey
+                        - projectId
+                        - region
+                        - secretKey
+                      type: object
+                    secretserver:
+                      description: |-
+                        SecretServer configures this store to sync secrets using SecretServer provider
+                        https://docs.delinea.com/online-help/secret-server/start.htm
+                      properties:
+                        password:
+                          description: Password is the secret server account password.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        serverURL:
+                          description: |-
+                            ServerURL
+                            URL to your secret server installation
+                          type: string
+                        username:
+                          description: Username is the secret server account username.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                      required:
+                        - password
+                        - serverURL
+                        - username
+                      type: object
+                    senhasegura:
+                      description: Senhasegura configures this store to sync secrets using senhasegura provider
+                      properties:
+                        auth:
+                          description: Auth defines parameters to authenticate in senhasegura
+                          properties:
+                            clientId:
+                              type: string
+                            clientSecretSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - clientId
+                            - clientSecretSecretRef
+                          type: object
+                        ignoreSslCertificate:
+                          default: false
+                          description: IgnoreSslCertificate defines if SSL certificate must be ignored
+                          type: boolean
+                        module:
+                          description: Module defines which senhasegura module should be used to get secrets
+                          type: string
+                        url:
+                          description: URL of senhasegura
+                          type: string
+                      required:
+                        - auth
+                        - module
+                        - url
+                      type: object
+                    vault:
+                      description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          properties:
+                            appRole:
+                              description: |-
+                                AppRole authenticates with Vault using the App Role auth mechanism,
+                                with the role and secret stored in a Kubernetes Secret resource.
+                              properties:
+                                path:
+                                  default: approle
+                                  description: |-
+                                    Path where the App Role authentication backend is mounted
+                                    in Vault, e.g: "approle"
+                                  type: string
+                                roleId:
+                                  description: |-
+                                    RoleID configured in the App Role authentication backend when setting
+                                    up the authentication backend in Vault.
+                                  type: string
+                                roleRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role ID used
+                                    to authenticate with Vault.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role id.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role secret used
+                                    to authenticate with Vault.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - secretRef
+                              type: object
+                            cert:
+                              description: |-
+                                Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate
+                                Cert authentication method
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    ClientCert is a certificate to authenticate using the Cert Vault
+                                    authentication method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing client private key to
+                                    authenticate with Vault using the Cert authentication method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            iam:
+                              description: |-
+                                Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials
+                                AWS IAM authentication method
+                              properties:
+                                externalID:
+                                  description: AWS External ID set on assumed IAM roles
+                                  type: string
+                                jwt:
+                                  description: Specify a service account with IRSA enabled
+                                  properties:
+                                    serviceAccountRef:
+                                      description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  type: object
+                                path:
+                                  description: 'Path where the AWS auth method is enabled in Vault, e.g: "aws"'
+                                  type: string
+                                region:
+                                  description: AWS region
+                                  type: string
+                                role:
+                                  description: This is the AWS role to be assumed before talking to vault
+                                  type: string
+                                secretRef:
+                                  description: Specify credentials in a Secret object
+                                  properties:
+                                    accessKeyIDSecretRef:
+                                      description: The AccessKeyID is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    sessionTokenSecretRef:
+                                      description: |-
+                                        The SessionToken used for authentication
+                                        This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                        see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  type: object
+                                vaultAwsIamServerID:
+                                  description: 'X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws'
+                                  type: string
+                                vaultRole:
+                                  description: Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine
+                                  type: string
+                              required:
+                                - vaultRole
+                              type: object
+                            jwt:
+                              description: |-
+                                Jwt authenticates with Vault by passing role and JWT token using the
+                                JWT/OIDC authentication method
+                              properties:
+                                kubernetesServiceAccountToken:
+                                  description: |-
+                                    Optional ServiceAccountToken specifies the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Optional audiences field that will be used to request a temporary Kubernetes service
+                                        account token for the service account referenced by `serviceAccountRef`.
+                                        Defaults to a single audience `vault` it not specified.
+
+                                        Deprecated: use serviceAccountRef.Audiences instead
+                                      items:
+                                        type: string
+                                      type: array
+                                    expirationSeconds:
+                                      description: |-
+                                        Optional expiration time in seconds that will be used to request a temporary
+                                        Kubernetes service account token for the service account referenced by
+                                        `serviceAccountRef`.
+
+                                        Deprecated: this will be removed in the future.
+                                        Defaults to 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    serviceAccountRef:
+                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                                path:
+                                  default: jwt
+                                  description: |-
+                                    Path where the JWT authentication backend is mounted
+                                    in Vault, e.g: "jwt"
+                                  type: string
+                                role:
+                                  description: |-
+                                    Role is a JWT role to authenticate using the JWT/OIDC Vault
+                                    authentication method
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                    authenticate with Vault using the JWT/OIDC authentication method.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                              type: object
+                            kubernetes:
+                              description: |-
+                                Kubernetes authenticates with Vault by passing the ServiceAccount
+                                token stored in the named Secret resource to the Vault server.
+                              properties:
+                                mountPath:
+                                  default: kubernetes
+                                  description: |-
+                                    Path where the Kubernetes authentication backend is mounted in Vault, e.g:
+                                    "kubernetes"
+                                  type: string
+                                role:
+                                  description: |-
+                                    A required field containing the Vault Role to assume. A Role binds a
+                                    Kubernetes ServiceAccount with a set of Vault policies.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                    for authenticating with Vault. If a name is specified without a key,
+                                    `token` is the default. If one is not specified, the one bound to
+                                    the controller will be used.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional service account field containing the name of a kubernetes ServiceAccount.
+                                    If the service account is specified, the service account secret token JWT will be used
+                                    for authenticating with Vault. If the service account selector is not supplied,
+                                    the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - mountPath
+                                - role
+                              type: object
+                            ldap:
+                              description: |-
+                                Ldap authenticates with Vault by passing username/password pair using
+                                the LDAP authentication method
+                              properties:
+                                path:
+                                  default: ldap
+                                  description: |-
+                                    Path where the LDAP authentication backend is mounted
+                                    in Vault, e.g: "ldap"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the LDAP
+                                    user used to authenticate with Vault using the LDAP authentication
+                                    method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is an LDAP username used to authenticate using the LDAP Vault
+                                    authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                            namespace:
+                              description: |-
+                                Name of the vault namespace to authenticate to. This can be different than the namespace your secret is in.
+                                Namespaces is a set of features within Vault Enterprise that allows
+                                Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                                More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                                This will default to Vault.Namespace field if set, or empty otherwise
+                              type: string
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            userPass:
+                              description: UserPass authenticates with Vault by passing username/password pair
+                              properties:
+                                path:
+                                  default: userpass
+                                  description: |-
+                                    Path where the UserPassword authentication backend is mounted
+                                    in Vault, e.g: "userpass"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the
+                                    user used to authenticate with Vault using the UserPass authentication
+                                    method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is a username used to authenticate using the UserPass Vault
+                                    authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate Vault server certificate. Only used
+                            if the Server URL is using HTTPS protocol. This parameter is ignored for
+                            plain HTTP protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        forwardInconsistent:
+                          description: |-
+                            ForwardInconsistent tells Vault to forward read-after-write requests to the Vault
+                            leader instead of simply retrying within a loop. This can increase performance if
+                            the option is enabled serverside.
+                            https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          type: boolean
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers to be added in Vault request
+                          type: object
+                        namespace:
+                          description: |-
+                            Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
+                            Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                            More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                          type: string
+                        path:
+                          description: |-
+                            Path is the mount path of the Vault KV backend endpoint, e.g:
+                            "secret". The v2 KV secret engine version specific "/data" path suffix
+                            for fetching secrets from Vault is optional and will be appended
+                            if not present in specified path.
+                          type: string
+                        readYourWrites:
+                          description: |-
+                            ReadYourWrites ensures isolated read-after-write semantics by
+                            providing discovered cluster replication states in each request.
+                            More information about eventual consistency in Vault can be found here
+                            https://www.vaultproject.io/docs/enterprise/consistency
+                          type: boolean
+                        server:
+                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          type: string
+                        tls:
+                          description: |-
+                            The configuration used for client side related TLS communication, when the Vault server
+                            requires mutual authentication. Only used if the Server URL is using HTTPS protocol.
+                            This parameter is ignored for plain HTTP protocol connection.
+                            It's worth noting this configuration is different from the "TLS certificates auth method",
+                            which is available under the `auth.cert` section.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                CertSecretRef is a certificate added to the transport layer
+                                when communicating with the Vault server.
+                                If no key for the Secret is specified, external-secret will default to 'tls.crt'.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            keySecretRef:
+                              description: |-
+                                KeySecretRef to a key in a Secret resource containing client private key
+                                added to the transport layer when communicating with the Vault server.
+                                If no key for the Secret is specified, external-secret will default to 'tls.key'.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        version:
+                          default: v2
+                          description: |-
+                            Version is the Vault KV secret engine version. This can be either "v1" or
+                            "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - server
+                      type: object
+                    webhook:
+                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      properties:
+                        auth:
+                          description: Auth specifies a authorization protocol. Only one protocol may be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            ntlm:
+                              description: NTLMProtocol configures the store to use NTLM for auth
+                              properties:
+                                passwordSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                usernameSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - passwordSecret
+                                - usernameSecret
+                              type: object
+                          type: object
+                        body:
+                          description: Body
+                          type: string
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate webhook server certificate. Only used
+                            if the Server URL is using HTTPS protocol. This parameter is ignored for
+                            plain HTTP protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers
+                          type: object
+                        method:
+                          description: Webhook Method
+                          type: string
+                        result:
+                          description: Result formatting
+                          properties:
+                            jsonPath:
+                              description: Json path of return value
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets to fill in templates
+                            These secrets will be passed to the templating function as key value pairs under the given name
+                          items:
+                            description: WebhookSecret defines a secret to be used in webhook templates.
+                            properties:
+                              name:
+                                description: Name of this secret in templates
+                                type: string
+                              secretRef:
+                                description: Secret ref to fill in credentials
+                                properties:
+                                  key:
+                                    description: |-
+                                      A key in the referenced Secret.
+                                      Some instances of this field may be defaulted, in others it may be required.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[-._a-zA-Z0-9]+$
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being referred to.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      The namespace of the Secret resource being referred to.
+                                      Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                type: object
+                            required:
+                              - name
+                              - secretRef
+                            type: object
+                          type: array
+                        timeout:
+                          description: Timeout
+                          type: string
+                        url:
+                          description: Webhook url to call
+                          type: string
+                      required:
+                        - result
+                        - url
+                      type: object
+                    yandexcertificatemanager:
+                      description: YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Certificate Manager
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    yandexlockbox:
+                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                  type: object
+                refreshInterval:
+                  description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
+                  type: integer
+                retrySettings:
+                  description: Used to configure HTTP retries on failures.
+                  properties:
+                    maxRetries:
+                      description: MaxRetries is the maximum number of retry attempts.
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      description: RetryInterval is the interval between retry attempts.
+                      type: string
+                  type: object
+              required:
+                - provider
+              type: object
+            status:
+              description: SecretStoreStatus defines the observed state of the SecretStore.
+              properties:
+                capabilities:
+                  description: SecretStoreCapabilities defines the possible operations a SecretStore can do.
+                  type: string
+                conditions:
+                  items:
+                    description: SecretStoreStatusCondition defines the observed condition of the SecretStore.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: SecretStoreConditionType represents the condition type of the SecretStore.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: false
+      storage: false
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-ecrauthorizationtokens-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-ecrauthorizationtokens-generators-external-secrets-io.yaml
@@ -1,0 +1,194 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: ecrauthorizationtokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: ECRAuthorizationToken
+    listKind: ECRAuthorizationTokenList
+    plural: ecrauthorizationtokens
+    singular: ecrauthorizationtoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ECRAuthorizationToken uses the GetAuthorizationToken API to retrieve an authorization token.
+            The authorization token is valid for 12 hours.
+            The authorizationToken returned is a base64 encoded string that can be decoded
+            and used in a docker login command to authenticate to a registry.
+            For more information, see Registry authentication (https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth) in the Amazon Elastic Container Registry User Guide.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ECRAuthorizationTokenSpec defines the desired state to generate an AWS ECR authorization token.
+              properties:
+                auth:
+                  description: Auth defines how to authenticate with AWS
+                  properties:
+                    jwt:
+                      description: AWSJWTAuth provides configuration to authenticate against AWS using service account tokens.
+                      properties:
+                        serviceAccountRef:
+                          description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                    secretRef:
+                      description: |-
+                        AWSAuthSecretRef holds secret references for AWS credentials
+                        both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                      properties:
+                        accessKeyIDSecretRef:
+                          description: The AccessKeyID is used for authentication
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        secretAccessKeySecretRef:
+                          description: The SecretAccessKey is used for authentication
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        sessionTokenSecretRef:
+                          description: |-
+                            The SessionToken used for authentication
+                            This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                            see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                region:
+                  description: Region specifies the region to operate in.
+                  type: string
+                role:
+                  description: |-
+                    You can assume a role before making calls to the
+                    desired AWS service.
+                  type: string
+                scope:
+                  description: |-
+                    Scope specifies the ECR service scope.
+                    Valid options are private and public.
+                  type: string
+              required:
+                - region
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-externalsecrets-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-externalsecrets-external-secrets-io.yaml
@@ -1,0 +1,1408 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: externalsecrets.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - external-secrets
+    kind: ExternalSecret
+    listKind: ExternalSecretList
+    plural: externalsecrets
+    shortNames:
+      - es
+    singular: externalsecret
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.secretStoreRef.kind
+          name: StoreType
+          type: string
+        - jsonPath: .spec.secretStoreRef.name
+          name: Store
+          type: string
+        - jsonPath: .spec.refreshInterval
+          name: Refresh Interval
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.refreshTime
+          name: Last Sync
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            ExternalSecret is the Schema for the external-secrets API.
+            It defines how to fetch data from external APIs and make it available as Kubernetes Secrets.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ExternalSecretSpec defines the desired state of ExternalSecret.
+              properties:
+                data:
+                  description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                  items:
+                    description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                    properties:
+                      remoteRef:
+                        description: |-
+                          RemoteRef points to the remote secret and defines
+                          which secret (version/property/..) to fetch.
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
+                            type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
+                            type: string
+                          key:
+                            description: Key is the key used in the Provider, mandatory
+                            type: string
+                          metadataPolicy:
+                            default: None
+                            description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            enum:
+                              - None
+                              - Fetch
+                            type: string
+                          nullBytePolicy:
+                            description: Controls how ESO handles fetched secret data containing NUL bytes for this source.
+                            enum:
+                              - Ignore
+                              - Fail
+                            type: string
+                          property:
+                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            type: string
+                          version:
+                            description: Used to select a specific version of the Provider value, if supported
+                            type: string
+                        required:
+                          - key
+                        type: object
+                      secretKey:
+                        description: The key in the Kubernetes Secret to store the value.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[-._a-zA-Z0-9]+$
+                        type: string
+                      sourceRef:
+                        description: |-
+                          SourceRef allows you to override the source
+                          from which the value will be pulled.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          generatorRef:
+                            description: |-
+                              GeneratorRef points to a generator custom resource.
+
+                              Deprecated: The generatorRef is not implemented in .data[].
+                              this will be removed with v1.
+                            properties:
+                              apiVersion:
+                                default: generators.external-secrets.io/v1alpha1
+                                description: Specify the apiVersion of the generator resource
+                                type: string
+                              kind:
+                                description: Specify the Kind of the generator resource
+                                enum:
+                                  - ACRAccessToken
+                                  - BeyondtrustWorkloadCredentialsDynamicSecret
+                                  - ClusterGenerator
+                                  - CloudsmithAccessToken
+                                  - ECRAuthorizationToken
+                                  - Fake
+                                  - GCRAccessToken
+                                  - GithubAccessToken
+                                  - GitlabDeployToken
+                                  - QuayAccessToken
+                                  - Password
+                                  - SSHKey
+                                  - STSSessionToken
+                                  - UUID
+                                  - VaultDynamicSecret
+                                  - Webhook
+                                  - Grafana
+                                  - MFA
+                                type: string
+                              name:
+                                description: Specify the name of the generator resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          storeRef:
+                            description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                            properties:
+                              kind:
+                                description: |-
+                                  Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                                  Defaults to `SecretStore`
+                                enum:
+                                  - SecretStore
+                                  - ClusterSecretStore
+                                type: string
+                              name:
+                                description: Name of the SecretStore resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - remoteRef
+                      - secretKey
+                    type: object
+                  type: array
+                dataFrom:
+                  description: |-
+                    DataFrom is used to fetch all properties from a specific Provider data
+                    If multiple entries are specified, the Secret keys are merged in the specified order
+                  items:
+                    description: |-
+                      ExternalSecretDataFromRemoteRef defines the connection between the Kubernetes Secret keys and the Provider data
+                      when using DataFrom to fetch multiple values from a Provider.
+                    properties:
+                      extract:
+                        description: |-
+                          Used to extract multiple key/value pairs from one secret
+                          Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
+                            type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
+                            type: string
+                          key:
+                            description: Key is the key used in the Provider, mandatory
+                            type: string
+                          metadataPolicy:
+                            default: None
+                            description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            enum:
+                              - None
+                              - Fetch
+                            type: string
+                          nullBytePolicy:
+                            description: Controls how ESO handles fetched secret data containing NUL bytes for this source.
+                            enum:
+                              - Ignore
+                              - Fail
+                            type: string
+                          property:
+                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            type: string
+                          version:
+                            description: Used to select a specific version of the Provider value, if supported
+                            type: string
+                        required:
+                          - key
+                        type: object
+                      find:
+                        description: |-
+                          Used to find secrets based on tags or regular expressions
+                          Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
+                            type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
+                            type: string
+                          name:
+                            description: Finds secrets based on the name.
+                            properties:
+                              regexp:
+                                description: Finds secrets base
+                                type: string
+                            type: object
+                          nullBytePolicy:
+                            description: Controls how ESO handles fetched secret data containing NUL bytes for this find source.
+                            enum:
+                              - Ignore
+                              - Fail
+                            type: string
+                          path:
+                            description: A root path to start the find operations.
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: Find secrets based on tags.
+                            type: object
+                        type: object
+                      rewrite:
+                        description: |-
+                          Used to rewrite secret Keys after getting them from the secret Provider
+                          Multiple Rewrite operations can be provided. They are applied in a layered order (first to last)
+                        items:
+                          description: ExternalSecretRewrite defines how to rewrite secret data values before they are written to the Secret.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            merge:
+                              description: |-
+                                Used to merge key/values in one single Secret
+                                The resulting key will contain all values from the specified secrets
+                              properties:
+                                conflictPolicy:
+                                  default: Error
+                                  description: Used to define the policy to use in conflict resolution.
+                                  enum:
+                                    - Ignore
+                                    - Error
+                                  type: string
+                                into:
+                                  default: ""
+                                  description: |-
+                                    Used to define the target key of the merge operation.
+                                    Required if strategy is JSON. Ignored otherwise.
+                                  type: string
+                                priority:
+                                  description: Used to define key priority in conflict resolution.
+                                  items:
+                                    type: string
+                                  type: array
+                                priorityPolicy:
+                                  default: Strict
+                                  description: Used to define the policy when a key in the priority list does not exist in the input.
+                                  enum:
+                                    - IgnoreNotFound
+                                    - Strict
+                                  type: string
+                                strategy:
+                                  default: Extract
+                                  description: Used to define the strategy to use in the merge operation.
+                                  enum:
+                                    - Extract
+                                    - JSON
+                                  type: string
+                              type: object
+                            regexp:
+                              description: |-
+                                Used to rewrite with regular expressions.
+                                The resulting key will be the output of a regexp.ReplaceAll operation.
+                              properties:
+                                source:
+                                  description: Used to define the regular expression of a re.Compiler.
+                                  type: string
+                                target:
+                                  description: Used to define the target pattern of a ReplaceAll operation.
+                                  type: string
+                              required:
+                                - source
+                                - target
+                              type: object
+                            transform:
+                              description: |-
+                                Used to apply string transformation on the secrets.
+                                The resulting key will be the output of the template applied by the operation.
+                              properties:
+                                template:
+                                  description: |-
+                                    Used to define the template to apply on the secret name.
+                                    `.value ` will specify the secret name in the template.
+                                  type: string
+                              required:
+                                - template
+                              type: object
+                          type: object
+                        type: array
+                      sourceRef:
+                        description: |-
+                          SourceRef points to a store or generator
+                          which contains secret values ready to use.
+                          Use this in combination with Extract or Find pull values out of
+                          a specific SecretStore.
+                          When sourceRef points to a generator Extract or Find is not supported.
+                          The generator returns a static map of values
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          generatorRef:
+                            description: GeneratorRef points to a generator custom resource.
+                            properties:
+                              apiVersion:
+                                default: generators.external-secrets.io/v1alpha1
+                                description: Specify the apiVersion of the generator resource
+                                type: string
+                              kind:
+                                description: Specify the Kind of the generator resource
+                                enum:
+                                  - ACRAccessToken
+                                  - BeyondtrustWorkloadCredentialsDynamicSecret
+                                  - ClusterGenerator
+                                  - CloudsmithAccessToken
+                                  - ECRAuthorizationToken
+                                  - Fake
+                                  - GCRAccessToken
+                                  - GithubAccessToken
+                                  - GitlabDeployToken
+                                  - QuayAccessToken
+                                  - Password
+                                  - SSHKey
+                                  - STSSessionToken
+                                  - UUID
+                                  - VaultDynamicSecret
+                                  - Webhook
+                                  - Grafana
+                                  - MFA
+                                type: string
+                              name:
+                                description: Specify the name of the generator resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          storeRef:
+                            description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                            properties:
+                              kind:
+                                description: |-
+                                  Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                                  Defaults to `SecretStore`
+                                enum:
+                                  - SecretStore
+                                  - ClusterSecretStore
+                                type: string
+                              name:
+                                description: Name of the SecretStore resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+                refreshInterval:
+                  default: 1h0m0s
+                  description: |-
+                    RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+                    specified as Golang Duration strings.
+                    Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                    Example values: "1h0m0s", "2h30m0s", "10m0s"
+                    May be set to "0s" to fetch and create it once. Defaults to 1h0m0s.
+                  type: string
+                refreshPolicy:
+                  description: |-
+                    RefreshPolicy determines how the ExternalSecret should be refreshed:
+                    - CreatedOnce: Creates the Secret only if it does not exist and does not update it thereafter
+                    - Periodic: Synchronizes the Secret from the external source at regular intervals specified by refreshInterval.
+                      No periodic updates occur if refreshInterval is 0.
+                    - OnChange: Only synchronizes the Secret when the ExternalSecret's metadata or specification changes
+                  enum:
+                    - CreatedOnce
+                    - Periodic
+                    - OnChange
+                  type: string
+                secretStoreRef:
+                  description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                  properties:
+                    kind:
+                      description: |-
+                        Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                        Defaults to `SecretStore`
+                      enum:
+                        - SecretStore
+                        - ClusterSecretStore
+                      type: string
+                    name:
+                      description: Name of the SecretStore resource
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  type: object
+                syncWindows:
+                  description: |-
+                    SyncWindows optionally restricts when periodic refreshes may occur.
+                    Evaluated in UTC, only for Periodic refresh policy (or when refreshPolicy is unset).
+                  properties:
+                    kind:
+                      description: |-
+                        Kind applies to every window in the list.
+                        "allow" -- syncs are permitted only while at least one window is active;
+                                   all other times are blocked.
+                        "deny"  -- syncs are blocked while any window is active;
+                                   all other times are permitted.
+                      enum:
+                        - allow
+                        - deny
+                      type: string
+                    windows:
+                      description: Windows is the list of schedule+duration pairs.
+                      items:
+                        description: |-
+                          ExternalSecretSyncWindowEntry defines a single cron-schedule + duration pair
+                          within a SyncWindows block.
+                        properties:
+                          duration:
+                            description: |-
+                              Duration specifies how long the window stays open after each Schedule
+                              firing. Example: "8h".
+                            type: string
+                          schedule:
+                            description: |-
+                              Schedule is a standard 5-field cron expression evaluated in UTC, or a
+                              named shorthand such as @daily or @every 1h. It marks the start time of
+                              each window occurrence.
+                              Example: "0 22 * * 1-5" opens a window every weekday at 22:00 UTC.
+                            minLength: 1
+                            pattern: ^(@(annually|yearly|monthly|weekly|daily|midnight|hourly)|@every [^\s]+.*|[^\s]+( [^\s]+){4})$
+                            type: string
+                        required:
+                          - duration
+                          - schedule
+                        type: object
+                      minItems: 1
+                      type: array
+                  required:
+                    - kind
+                    - windows
+                  type: object
+                target:
+                  default:
+                    creationPolicy: Owner
+                    deletionPolicy: Retain
+                  description: |-
+                    ExternalSecretTarget defines the Kubernetes Secret to be created,
+                    there can be only one target per ExternalSecret.
+                  properties:
+                    creationPolicy:
+                      default: Owner
+                      description: |-
+                        CreationPolicy defines rules on how to create the resulting Secret.
+                        Defaults to "Owner"
+                      enum:
+                        - Owner
+                        - Orphan
+                        - Merge
+                        - None
+                        - CreateOrMerge
+                      type: string
+                    deletionPolicy:
+                      default: Retain
+                      description: |-
+                        DeletionPolicy defines rules on how to delete the resulting Secret.
+                        Defaults to "Retain"
+                      enum:
+                        - Delete
+                        - Merge
+                        - Retain
+                      type: string
+                    immutable:
+                      description: Immutable defines if the final secret will be immutable
+                      type: boolean
+                    manifest:
+                      description: |-
+                        Manifest defines a custom Kubernetes resource to create instead of a Secret.
+                        When specified, ExternalSecret will create the resource type defined here
+                        (e.g., ConfigMap, Custom Resource) instead of a Secret.
+                        Warning: Using Generic target. Make sure access policies and encryption are properly configured.
+                      properties:
+                        apiVersion:
+                          description: APIVersion of the target resource (e.g., "v1" for ConfigMap, "argoproj.io/v1alpha1" for ArgoCD Application)
+                          minLength: 1
+                          type: string
+                        kind:
+                          description: Kind of the target resource (e.g., "ConfigMap", "Application")
+                          minLength: 1
+                          type: string
+                      required:
+                        - apiVersion
+                        - kind
+                      type: object
+                    name:
+                      description: |-
+                        The name of the Secret resource to be managed.
+                        Defaults to the .metadata.name of the ExternalSecret resource
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    template:
+                      description: Template defines a blueprint for the created Secret resource.
+                      properties:
+                        data:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        engineVersion:
+                          default: v2
+                          description: |-
+                            EngineVersion specifies the template engine version
+                            that should be used to compile/execute the
+                            template specified in .data and .templateFrom[].
+                          enum:
+                            - v2
+                          type: string
+                        mergePolicy:
+                          default: Replace
+                          description: TemplateMergePolicy defines how the rendered template should be merged with the existing Secret data.
+                          enum:
+                            - Replace
+                            - Merge
+                          type: string
+                        metadata:
+                          description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        templateFrom:
+                          items:
+                            description: |-
+                              TemplateFrom specifies a source for templates.
+                              Each item in the list can either reference a ConfigMap or a Secret resource.
+                            properties:
+                              configMap:
+                                description: TemplateRef specifies a reference to either a ConfigMap or a Secret resource.
+                                properties:
+                                  items:
+                                    description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                    items:
+                                      description: TemplateRefItem specifies a key in the ConfigMap/Secret to use as a template for Secret data.
+                                      properties:
+                                        key:
+                                          description: A key in the ConfigMap/Secret
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        templateAs:
+                                          default: Values
+                                          description: TemplateScope specifies how the template keys should be interpreted.
+                                          enum:
+                                            - Values
+                                            - KeysAndValues
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: The name of the ConfigMap/Secret resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                              literal:
+                                type: string
+                              secret:
+                                description: TemplateRef specifies a reference to either a ConfigMap or a Secret resource.
+                                properties:
+                                  items:
+                                    description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                    items:
+                                      description: TemplateRefItem specifies a key in the ConfigMap/Secret to use as a template for Secret data.
+                                      properties:
+                                        key:
+                                          description: A key in the ConfigMap/Secret
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        templateAs:
+                                          default: Values
+                                          description: TemplateScope specifies how the template keys should be interpreted.
+                                          enum:
+                                            - Values
+                                            - KeysAndValues
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: The name of the ConfigMap/Secret resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                              target:
+                                default: Data
+                                description: |-
+                                  Target specifies where to place the template result.
+                                  For Secret resources, common values are: "Data", "Annotations", "Labels".
+                                  For custom resources (when spec.target.manifest is set), this supports
+                                  nested paths like "spec.database.config" or "data".
+                                type: string
+                              valuesDecodingStrategy:
+                                default: None
+                                description: Used to define a decoding Strategy for the rendered template values.
+                                enum:
+                                  - Auto
+                                  - Base64
+                                  - Base64URL
+                                  - None
+                                type: string
+                            type: object
+                          type: array
+                        type:
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: ExternalSecretStatus defines the observed state of ExternalSecret.
+              properties:
+                binding:
+                  description: Binding represents a servicebinding.io Provisioned Service reference to the secret
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                conditions:
+                  items:
+                    description: ExternalSecretStatusCondition defines a status condition of an ExternalSecret resource.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ExternalSecretConditionType defines a value type for ExternalSecret conditions.
+                        enum:
+                          - Ready
+                          - Deleted
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                refreshTime:
+                  description: |-
+                    refreshTime is the time and date the external secret was fetched and
+                    the target secret updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                syncedResourceVersion:
+                  description: SyncedResourceVersion keeps track of the last synced version
+                  type: string
+              type: object
+          type: object
+      selectableFields:
+        - jsonPath: .spec.secretStoreRef.name
+        - jsonPath: .spec.secretStoreRef.kind
+        - jsonPath: .spec.target.name
+        - jsonPath: .spec.refreshInterval
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.secretStoreRef.kind
+          name: StoreType
+          type: string
+        - jsonPath: .spec.secretStoreRef.name
+          name: Store
+          type: string
+        - jsonPath: .spec.refreshInterval
+          name: Refresh Interval
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+        - jsonPath: .status.refreshTime
+          name: Last Sync
+          type: date
+      deprecated: true
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ExternalSecret is the schema for the external-secrets API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ExternalSecretSpec defines the desired state of ExternalSecret.
+              properties:
+                data:
+                  description: Data defines the connection between the Kubernetes Secret keys and the Provider data
+                  items:
+                    description: ExternalSecretData defines the connection between the Kubernetes Secret key (spec.data.<key>) and the Provider data.
+                    properties:
+                      remoteRef:
+                        description: |-
+                          RemoteRef points to the remote secret and defines
+                          which secret (version/property/..) to fetch.
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
+                            type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
+                            type: string
+                          key:
+                            description: Key is the key used in the Provider, mandatory
+                            type: string
+                          metadataPolicy:
+                            default: None
+                            description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            enum:
+                              - None
+                              - Fetch
+                            type: string
+                          property:
+                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            type: string
+                          version:
+                            description: Used to select a specific version of the Provider value, if supported
+                            type: string
+                        required:
+                          - key
+                        type: object
+                      secretKey:
+                        description: The key in the Kubernetes Secret to store the value.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[-._a-zA-Z0-9]+$
+                        type: string
+                      sourceRef:
+                        description: |-
+                          SourceRef allows you to override the source
+                          from which the value will be pulled.
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          generatorRef:
+                            description: |-
+                              GeneratorRef points to a generator custom resource.
+
+                              Deprecated: The generatorRef is not implemented in .data[].
+                              this will be removed with v1.
+                            properties:
+                              apiVersion:
+                                default: generators.external-secrets.io/v1alpha1
+                                description: Specify the apiVersion of the generator resource
+                                type: string
+                              kind:
+                                description: Specify the Kind of the generator resource
+                                enum:
+                                  - ACRAccessToken
+                                  - ClusterGenerator
+                                  - ECRAuthorizationToken
+                                  - Fake
+                                  - GCRAccessToken
+                                  - GithubAccessToken
+                                  - QuayAccessToken
+                                  - Password
+                                  - SSHKey
+                                  - STSSessionToken
+                                  - UUID
+                                  - VaultDynamicSecret
+                                  - Webhook
+                                  - Grafana
+                                type: string
+                              name:
+                                description: Specify the name of the generator resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          storeRef:
+                            description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                            properties:
+                              kind:
+                                description: |-
+                                  Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                                  Defaults to `SecretStore`
+                                enum:
+                                  - SecretStore
+                                  - ClusterSecretStore
+                                type: string
+                              name:
+                                description: Name of the SecretStore resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            type: object
+                        type: object
+                    required:
+                      - remoteRef
+                      - secretKey
+                    type: object
+                  type: array
+                dataFrom:
+                  description: |-
+                    DataFrom is used to fetch all properties from a specific Provider data
+                    If multiple entries are specified, the Secret keys are merged in the specified order
+                  items:
+                    description: ExternalSecretDataFromRemoteRef defines a reference to multiple secrets in the provider to be fetched using options.
+                    properties:
+                      extract:
+                        description: |-
+                          Used to extract multiple key/value pairs from one secret
+                          Note: Extract does not support sourceRef.Generator or sourceRef.GeneratorRef.
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
+                            type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
+                            type: string
+                          key:
+                            description: Key is the key used in the Provider, mandatory
+                            type: string
+                          metadataPolicy:
+                            default: None
+                            description: Policy for fetching tags/labels from provider secrets, possible options are Fetch, None. Defaults to None
+                            enum:
+                              - None
+                              - Fetch
+                            type: string
+                          property:
+                            description: Used to select a specific property of the Provider value (if a map), if supported
+                            type: string
+                          version:
+                            description: Used to select a specific version of the Provider value, if supported
+                            type: string
+                        required:
+                          - key
+                        type: object
+                      find:
+                        description: |-
+                          Used to find secrets based on tags or regular expressions
+                          Note: Find does not support sourceRef.Generator or sourceRef.GeneratorRef.
+                        properties:
+                          conversionStrategy:
+                            default: Default
+                            description: Used to define a conversion Strategy
+                            enum:
+                              - Default
+                              - Unicode
+                            type: string
+                          decodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
+                            type: string
+                          name:
+                            description: Finds secrets based on the name.
+                            properties:
+                              regexp:
+                                description: Finds secrets base
+                                type: string
+                            type: object
+                          path:
+                            description: A root path to start the find operations.
+                            type: string
+                          tags:
+                            additionalProperties:
+                              type: string
+                            description: Find secrets based on tags.
+                            type: object
+                        type: object
+                      rewrite:
+                        description: |-
+                          Used to rewrite secret Keys after getting them from the secret Provider
+                          Multiple Rewrite operations can be provided. They are applied in a layered order (first to last)
+                        items:
+                          description: ExternalSecretRewrite defines rules on how to rewrite secret keys.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            regexp:
+                              description: |-
+                                Used to rewrite with regular expressions.
+                                The resulting key will be the output of a regexp.ReplaceAll operation.
+                              properties:
+                                source:
+                                  description: Used to define the regular expression of a re.Compiler.
+                                  type: string
+                                target:
+                                  description: Used to define the target pattern of a ReplaceAll operation.
+                                  type: string
+                              required:
+                                - source
+                                - target
+                              type: object
+                            transform:
+                              description: |-
+                                Used to apply string transformation on the secrets.
+                                The resulting key will be the output of the template applied by the operation.
+                              properties:
+                                template:
+                                  description: |-
+                                    Used to define the template to apply on the secret name.
+                                    `.value ` will specify the secret name in the template.
+                                  type: string
+                              required:
+                                - template
+                              type: object
+                          type: object
+                        type: array
+                      sourceRef:
+                        description: |-
+                          SourceRef points to a store or generator
+                          which contains secret values ready to use.
+                          Use this in combination with Extract or Find pull values out of
+                          a specific SecretStore.
+                          When sourceRef points to a generator Extract or Find is not supported.
+                          The generator returns a static map of values
+                        maxProperties: 1
+                        minProperties: 1
+                        properties:
+                          generatorRef:
+                            description: GeneratorRef points to a generator custom resource.
+                            properties:
+                              apiVersion:
+                                default: generators.external-secrets.io/v1alpha1
+                                description: Specify the apiVersion of the generator resource
+                                type: string
+                              kind:
+                                description: Specify the Kind of the generator resource
+                                enum:
+                                  - ACRAccessToken
+                                  - ClusterGenerator
+                                  - ECRAuthorizationToken
+                                  - Fake
+                                  - GCRAccessToken
+                                  - GithubAccessToken
+                                  - QuayAccessToken
+                                  - Password
+                                  - SSHKey
+                                  - STSSessionToken
+                                  - UUID
+                                  - VaultDynamicSecret
+                                  - Webhook
+                                  - Grafana
+                                type: string
+                              name:
+                                description: Specify the name of the generator resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          storeRef:
+                            description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                            properties:
+                              kind:
+                                description: |-
+                                  Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                                  Defaults to `SecretStore`
+                                enum:
+                                  - SecretStore
+                                  - ClusterSecretStore
+                                type: string
+                              name:
+                                description: Name of the SecretStore resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            type: object
+                        type: object
+                    type: object
+                  type: array
+                refreshInterval:
+                  default: 1h0m0s
+                  description: |-
+                    RefreshInterval is the amount of time before the values are read again from the SecretStore provider,
+                    specified as Golang Duration strings.
+                    Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h"
+                    Example values: "1h0m0s", "2h30m0s", "10m0s"
+                    May be set to "0s" to fetch and create it once. Defaults to 1h0m0s.
+                  type: string
+                refreshPolicy:
+                  description: |-
+                    RefreshPolicy determines how the ExternalSecret should be refreshed:
+                    - CreatedOnce: Creates the Secret only if it does not exist and does not update it thereafter
+                    - Periodic: Synchronizes the Secret from the external source at regular intervals specified by refreshInterval.
+                      No periodic updates occur if refreshInterval is 0.
+                    - OnChange: Only synchronizes the Secret when the ExternalSecret's metadata or specification changes
+                  enum:
+                    - CreatedOnce
+                    - Periodic
+                    - OnChange
+                  type: string
+                secretStoreRef:
+                  description: SecretStoreRef defines which SecretStore to fetch the ExternalSecret data.
+                  properties:
+                    kind:
+                      description: |-
+                        Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                        Defaults to `SecretStore`
+                      enum:
+                        - SecretStore
+                        - ClusterSecretStore
+                      type: string
+                    name:
+                      description: Name of the SecretStore resource
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  type: object
+                target:
+                  default:
+                    creationPolicy: Owner
+                    deletionPolicy: Retain
+                  description: |-
+                    ExternalSecretTarget defines the Kubernetes Secret to be created
+                    There can be only one target per ExternalSecret.
+                  properties:
+                    creationPolicy:
+                      default: Owner
+                      description: |-
+                        CreationPolicy defines rules on how to create the resulting Secret.
+                        Defaults to "Owner"
+                      enum:
+                        - Owner
+                        - Orphan
+                        - Merge
+                        - None
+                      type: string
+                    deletionPolicy:
+                      default: Retain
+                      description: |-
+                        DeletionPolicy defines rules on how to delete the resulting Secret.
+                        Defaults to "Retain"
+                      enum:
+                        - Delete
+                        - Merge
+                        - Retain
+                      type: string
+                    immutable:
+                      description: Immutable defines if the final secret will be immutable
+                      type: boolean
+                    name:
+                      description: |-
+                        The name of the Secret resource to be managed.
+                        Defaults to the .metadata.name of the ExternalSecret resource
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    template:
+                      description: Template defines a blueprint for the created Secret resource.
+                      properties:
+                        data:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        engineVersion:
+                          default: v2
+                          description: |-
+                            EngineVersion specifies the template engine version
+                            that should be used to compile/execute the
+                            template specified in .data and .templateFrom[].
+                          enum:
+                            - v2
+                          type: string
+                        mergePolicy:
+                          default: Replace
+                          description: TemplateMergePolicy defines how template values should be merged when generating a secret.
+                          enum:
+                            - Replace
+                            - Merge
+                          type: string
+                        metadata:
+                          description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        templateFrom:
+                          items:
+                            description: TemplateFrom defines a source for template data.
+                            properties:
+                              configMap:
+                                description: TemplateRef defines a reference to a template source in a ConfigMap or Secret.
+                                properties:
+                                  items:
+                                    description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                    items:
+                                      description: TemplateRefItem defines which key in the referenced ConfigMap or Secret to use as a template.
+                                      properties:
+                                        key:
+                                          description: A key in the ConfigMap/Secret
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        templateAs:
+                                          default: Values
+                                          description: TemplateScope defines the scope of the template when processing template data.
+                                          enum:
+                                            - Values
+                                            - KeysAndValues
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: The name of the ConfigMap/Secret resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                              literal:
+                                type: string
+                              secret:
+                                description: TemplateRef defines a reference to a template source in a ConfigMap or Secret.
+                                properties:
+                                  items:
+                                    description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                    items:
+                                      description: TemplateRefItem defines which key in the referenced ConfigMap or Secret to use as a template.
+                                      properties:
+                                        key:
+                                          description: A key in the ConfigMap/Secret
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        templateAs:
+                                          default: Values
+                                          description: TemplateScope defines the scope of the template when processing template data.
+                                          enum:
+                                            - Values
+                                            - KeysAndValues
+                                          type: string
+                                      required:
+                                        - key
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: The name of the ConfigMap/Secret resource
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                required:
+                                  - items
+                                  - name
+                                type: object
+                              target:
+                                default: Data
+                                description: TemplateTarget defines the target field where the template result will be stored.
+                                enum:
+                                  - Data
+                                  - Annotations
+                                  - Labels
+                                type: string
+                            type: object
+                          type: array
+                        type:
+                          type: string
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: ExternalSecretStatus defines the observed state of ExternalSecret.
+              properties:
+                binding:
+                  description: Binding represents a servicebinding.io Provisioned Service reference to the secret
+                  properties:
+                    name:
+                      default: ""
+                      description: |-
+                        Name of the referent.
+                        This field is effectively required, but due to backwards compatibility is
+                        allowed to be empty. Instances of this type with an empty value here are
+                        almost certainly wrong.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                conditions:
+                  items:
+                    description: ExternalSecretStatusCondition contains condition information for an ExternalSecret.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: ExternalSecretConditionType defines the condition type for an ExternalSecret.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                refreshTime:
+                  description: |-
+                    refreshTime is the time and date the external secret was fetched and
+                    the target secret updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                syncedResourceVersion:
+                  description: SyncedResourceVersion keeps track of the last synced version
+                  type: string
+              type: object
+          type: object
+      served: false
+      storage: false
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-fakes-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-fakes-generators-external-secrets-io.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: fakes.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: Fake
+    listKind: FakeList
+    plural: fakes
+    singular: fake
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Fake generator is used for testing. It lets you define
+            a static set of credentials that is always returned.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: FakeSpec contains the static data.
+              properties:
+                controller:
+                  description: |-
+                    Used to select the correct ESO controller (think: ingress.ingressClassName)
+                    The ESO controller is instantiated with a specific controller name and filters VDS based on this property
+                  type: string
+                data:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    Data defines the static data returned
+                    by this generator.
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-gcraccesstokens-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-gcraccesstokens-generators-external-secrets-io.yaml
@@ -1,0 +1,260 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: gcraccesstokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: GCRAccessToken
+    listKind: GCRAccessTokenList
+    plural: gcraccesstokens
+    singular: gcraccesstoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            GCRAccessToken generates an GCP access token
+            that can be used to authenticate with GCR.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GCRAccessTokenSpec defines the desired state to generate a Google Container Registry access token.
+              properties:
+                auth:
+                  description: Auth defines the means for authenticating with GCP
+                  properties:
+                    secretRef:
+                      description: GCPSMAuthSecretRef defines the reference to a secret containing Google Cloud Platform credentials.
+                      properties:
+                        secretAccessKeySecretRef:
+                          description: The SecretAccessKey is used for authentication
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                      type: object
+                    workloadIdentity:
+                      description: GCPWorkloadIdentity defines the configuration for using GCP Workload Identity authentication.
+                      properties:
+                        clusterLocation:
+                          type: string
+                        clusterName:
+                          type: string
+                        clusterProjectID:
+                          type: string
+                        serviceAccountRef:
+                          description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - clusterLocation
+                        - clusterName
+                        - serviceAccountRef
+                      type: object
+                    workloadIdentityFederation:
+                      description: GCPWorkloadIdentityFederation holds the configurations required for generating federated access tokens.
+                      properties:
+                        audience:
+                          description: |-
+                            audience is the Secure Token Service (STS) audience which contains the resource name for the workload identity pool and the provider identifier in that pool.
+                            If specified, Audience found in the external account credential config will be overridden with the configured value.
+                            audience must be provided when serviceAccountRef or awsSecurityCredentials is configured.
+                          type: string
+                        awsSecurityCredentials:
+                          description: |-
+                            awsSecurityCredentials is for configuring AWS region and credentials to use for obtaining the access token,
+                            when using the AWS metadata server is not an option.
+                          properties:
+                            awsCredentialsSecretRef:
+                              description: |-
+                                awsCredentialsSecretRef is the reference to the secret which holds the AWS credentials.
+                                Secret should be created with below names for keys
+                                - aws_access_key_id: Access Key ID, which is the unique identifier for the AWS account or the IAM user.
+                                - aws_secret_access_key: Secret Access Key, which is used to authenticate requests made to AWS services.
+                                - aws_session_token: Session Token, is the short-lived token to authenticate requests made to AWS services.
+                              properties:
+                                name:
+                                  description: name of the secret.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: namespace in which the secret exists. If empty, secret will looked up in local namespace.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            region:
+                              description: region is for configuring the AWS region to be used.
+                              example: ap-south-1
+                              maxLength: 50
+                              minLength: 1
+                              pattern: ^[a-z0-9-]+$
+                              type: string
+                          required:
+                            - awsCredentialsSecretRef
+                            - region
+                          type: object
+                        credConfig:
+                          description: |-
+                            credConfig holds the configmap reference containing the GCP external account credential configuration in JSON format and the key name containing the json data.
+                            For using Kubernetes cluster as the identity provider, use serviceAccountRef instead. Operators mounted serviceaccount token cannot be used as the token source, instead
+                            serviceAccountRef must be used by providing operators service account details.
+                          properties:
+                            key:
+                              description: key name holding the external account credential config.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: name of the configmap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: namespace in which the configmap exists. If empty, configmap will looked up in local namespace.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - key
+                            - name
+                          type: object
+                        externalTokenEndpoint:
+                          description: |-
+                            externalTokenEndpoint is the endpoint explicitly set up to provide tokens, which will be matched against the
+                            credential_source.url in the provided credConfig. This field is merely to double-check the external token source
+                            URL is having the expected value.
+                          type: string
+                        gcpServiceAccountEmail:
+                          description: |-
+                            GCPServiceAccountEmail is the email of the Google Cloud service account to impersonate
+                            after Workload Identity Federation. Use this to grant access through the service account's
+                            IAM bindings (for example roles/secretmanager.secretAccessor). When set, it overrides
+                            service_account_impersonation_url in the external account JSON from credConfig;
+                            when serviceAccountRef is set, it also overrides the "iam.gke.io/gcp-service-account" annotation
+                            on that ServiceAccount.
+                          example: my-gsa@my-project.iam.gserviceaccount.com
+                          minLength: 1
+                          pattern: ^.*@.*\.iam\.gserviceaccount\.com$
+                          type: string
+                        serviceAccountRef:
+                          description: |-
+                            serviceAccountRef is the reference to the kubernetes ServiceAccount to be used for obtaining the tokens,
+                            when Kubernetes is configured as provider in workload identity pool.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                  type: object
+                projectID:
+                  description: ProjectID defines which project to use to authenticate with
+                  type: string
+              required:
+                - auth
+                - projectID
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-generatorstates-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-generatorstates-generators-external-secrets-io.yaml
@@ -1,0 +1,107 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: generatorstates.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: GeneratorState
+    listKind: GeneratorStateList
+    plural: generatorstates
+    shortNames:
+      - gs
+    singular: generatorstate
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.garbageCollectionDeadline
+          name: GC Deadline
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: GeneratorState represents the state created and managed by a generator resource.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GeneratorStateSpec defines the desired state of a generator state resource.
+              properties:
+                garbageCollectionDeadline:
+                  description: |-
+                    GarbageCollectionDeadline is the time after which the generator state
+                    will be deleted.
+                    It is set by the controller which creates the generator state and
+                    can be set configured by the user.
+                    If the garbage collection deadline is not set the generator state will not be deleted.
+                  format: date-time
+                  type: string
+                resource:
+                  description: |-
+                    Resource is the generator manifest that produced the state.
+                    It is a snapshot of the generator manifest at the time the state was produced.
+                    This manifest will be used to delete the resource. Any configuration that is referenced
+                    in the manifest should be available at the time of garbage collection. If that is not the case deletion will
+                    be blocked by a finalizer.
+                  x-kubernetes-preserve-unknown-fields: true
+                state:
+                  description: State is the state that was produced by the generator implementation.
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - resource
+                - state
+              type: object
+            status:
+              description: GeneratorStateStatus defines the observed state of a generator state resource.
+              properties:
+                conditions:
+                  items:
+                    description: GeneratorStateStatusCondition represents the observed condition of a generator state.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: GeneratorStateConditionType represents the type of condition for a generator state.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-githubaccesstokens-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-githubaccesstokens-generators-external-secrets-io.yaml
@@ -1,0 +1,114 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: githubaccesstokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: GithubAccessToken
+    listKind: GithubAccessTokenList
+    plural: githubaccesstokens
+    singular: githubaccesstoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: GithubAccessToken generates ghs_ accessToken
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GithubAccessTokenSpec defines the desired state to generate a GitHub access token.
+              properties:
+                appID:
+                  type: string
+                auth:
+                  description: Auth configures how ESO authenticates with a Github instance.
+                  properties:
+                    privateKey:
+                      description: GithubSecretRef references a secret containing GitHub credentials.
+                      properties:
+                        secretRef:
+                          description: |-
+                            SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                            In some instances, `key` is a required field.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                      required:
+                        - secretRef
+                      type: object
+                  required:
+                    - privateKey
+                  type: object
+                installID:
+                  type: string
+                permissions:
+                  additionalProperties:
+                    type: string
+                  description: Map of permissions the token will have. If omitted, defaults to all permissions the GitHub App has.
+                  type: object
+                repositories:
+                  description: |-
+                    List of repositories the token will have access to. If omitted, defaults to all repositories the GitHub App
+                    is installed to.
+                  items:
+                    type: string
+                  type: array
+                url:
+                  description: URL configures the GitHub instance URL. Defaults to https://github.com/.
+                  type: string
+              required:
+                - appID
+                - auth
+                - installID
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-gitlabdeploytokens-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-gitlabdeploytokens-generators-external-secrets-io.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: gitlabdeploytokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: GitlabDeployToken
+    listKind: GitlabDeployTokenList
+    plural: gitlabdeploytokens
+    singular: gitlabdeploytoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: GitlabDeployToken generates a GitLab deploy token.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GitlabDeployTokenSpec defines the desired state to generate a GitLab deploy token.
+              properties:
+                auth:
+                  description: Auth configures how ESO authenticates with the GitLab API.
+                  properties:
+                    token:
+                      description: |-
+                        Token references a secret containing a GitLab access token (personal, group, or
+                        project) with the api scope and at least the Maintainer role on the target.
+                      properties:
+                        secretRef:
+                          description: |-
+                            SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                            In some instances, `key` is a required field.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                      required:
+                        - secretRef
+                      type: object
+                  required:
+                    - token
+                  type: object
+                expiresAt:
+                  description: |-
+                    ExpiresAt is an optional expiry for the deploy token. If omitted the token does
+                    not expire on the GitLab side and is revoked only when the generator state is
+                    cleaned up (on regeneration or when the consuming ExternalSecret is deleted).
+                  format: date-time
+                  type: string
+                groupID:
+                  description: |-
+                    GroupID is the numeric ID or unescaped path (e.g. parent/group) of the group to
+                    create the deploy token in. The generator URL-escapes paths before calling the
+                    GitLab API, so do not pre-encode. Mutually exclusive with projectID.
+                  minLength: 1
+                  type: string
+                name:
+                  description: Name of the deploy token.
+                  minLength: 1
+                  type: string
+                projectID:
+                  description: |-
+                    ProjectID is the numeric ID or unescaped path (e.g. group/project) of the
+                    project to create the deploy token in. The generator URL-escapes paths before
+                    calling the GitLab API, so do not pre-encode. Mutually exclusive with groupID.
+                  minLength: 1
+                  type: string
+                scopes:
+                  description: Scopes granted to the deploy token. At least one scope is required.
+                  items:
+                    description: GitlabDeployTokenScope is a scope that can be granted to a GitLab deploy token.
+                    enum:
+                      - read_repository
+                      - read_registry
+                      - write_registry
+                      - read_package_registry
+                      - write_package_registry
+                      - read_virtual_registry
+                      - write_virtual_registry
+                    type: string
+                  minItems: 1
+                  type: array
+                url:
+                  description: URL configures the GitLab instance URL. Defaults to https://gitlab.com.
+                  type: string
+                username:
+                  description: |-
+                    Username is an optional username for the deploy token. GitLab defaults it to
+                    gitlab+deploy-token-{n} when omitted.
+                  type: string
+              required:
+                - auth
+                - name
+                - scopes
+              type: object
+              x-kubernetes-validations:
+                - message: exactly one of projectID or groupID must be set
+                  rule: has(self.projectID) != has(self.groupID)
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-grafanas-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-grafanas-generators-external-secrets-io.yaml
@@ -1,0 +1,139 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: grafanas.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: Grafana
+    listKind: GrafanaList
+    plural: grafanas
+    singular: grafana
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Grafana represents a generator for Grafana service account tokens.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GrafanaSpec controls the behavior of the grafana generator.
+              properties:
+                auth:
+                  description: |-
+                    Auth is the authentication configuration to authenticate
+                    against the Grafana instance.
+                  properties:
+                    basic:
+                      description: |-
+                        Basic auth credentials used to authenticate against the Grafana instance.
+                        Note: you need a token which has elevated permissions to create service accounts.
+                        See here for the documentation on basic roles offered by Grafana:
+                        https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/
+                      properties:
+                        password:
+                          description: A basic auth password used to authenticate against the Grafana instance.
+                          properties:
+                            key:
+                              description: The key where the token is found.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                          type: object
+                        username:
+                          description: A basic auth username used to authenticate against the Grafana instance.
+                          type: string
+                      required:
+                        - password
+                        - username
+                      type: object
+                    token:
+                      description: |-
+                        A service account token used to authenticate against the Grafana instance.
+                        Note: you need a token which has elevated permissions to create service accounts.
+                        See here for the documentation on basic roles offered by Grafana:
+                        https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/
+                      properties:
+                        key:
+                          description: The key where the token is found.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[-._a-zA-Z0-9]+$
+                          type: string
+                        name:
+                          description: The name of the Secret resource being referred to.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      type: object
+                  type: object
+                serviceAccount:
+                  description: |-
+                    ServiceAccount is the configuration for the service account that
+                    is supposed to be generated by the generator.
+                  properties:
+                    name:
+                      description: Name is the name of the service account that will be created by ESO.
+                      type: string
+                    role:
+                      description: |-
+                        Role is the role of the service account.
+                        See here for the documentation on basic roles offered by Grafana:
+                        https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/
+                      type: string
+                    secondsToLive:
+                      description: |-
+                        SecondsToLive is the number of seconds before the generated service account token will expire.
+                        Some Grafana deployments (e.g. AWS Managed Grafana) require this value to be set.
+                      format: int64
+                      minimum: 1
+                      type: integer
+                  required:
+                    - name
+                    - role
+                  type: object
+                url:
+                  description: URL is the URL of the Grafana instance.
+                  type: string
+              required:
+                - auth
+                - serviceAccount
+                - url
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-mfas-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-mfas-generators-external-secrets-io.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: mfas.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: MFA
+    listKind: MFAList
+    plural: mfas
+    singular: mfa
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: MFA generates a new TOTP token that is compliant with RFC 6238.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MFASpec controls the behavior of the mfa generator.
+              properties:
+                algorithm:
+                  description: Algorithm to use for encoding. Defaults to SHA1 as per the RFC.
+                  type: string
+                length:
+                  description: Length defines the token length. Defaults to 6 characters.
+                  type: integer
+                secret:
+                  description: Secret is a secret selector to a secret containing the seed secret to generate the TOTP value from.
+                  properties:
+                    key:
+                      description: |-
+                        A key in the referenced Secret.
+                        Some instances of this field may be defaulted, in others it may be required.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[-._a-zA-Z0-9]+$
+                      type: string
+                    name:
+                      description: The name of the Secret resource being referred to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    namespace:
+                      description: |-
+                        The namespace of the Secret resource being referred to.
+                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  type: object
+                timePeriod:
+                  description: TimePeriod defines how long the token can be active. Defaults to 30 seconds.
+                  type: integer
+                when:
+                  description: When defines a time parameter that can be used to pin the origin time of the generated token.
+                  format: date-time
+                  type: string
+              required:
+                - secret
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-passwords-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-passwords-generators-external-secrets-io.yaml
@@ -1,0 +1,112 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: passwords.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: Password
+    listKind: PasswordList
+    plural: passwords
+    singular: password
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Password generates a random password based on the
+            configuration parameters in spec.
+            You can specify the length, characterset and other attributes.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PasswordSpec controls the behavior of the password generator.
+              properties:
+                allowRepeat:
+                  default: false
+                  description: set AllowRepeat to true to allow repeating characters.
+                  type: boolean
+                digits:
+                  description: |-
+                    Digits specifies the number of digits in the generated
+                    password. If omitted it defaults to 25% of the length of the password
+                  type: integer
+                encoding:
+                  default: raw
+                  description: |-
+                    Encoding specifies the encoding of the generated password.
+                    Valid values are:
+                    - "raw" (default): no encoding
+                    - "base64": standard base64 encoding
+                    - "base64url": base64url encoding
+                    - "base32": base32 encoding
+                    - "hex": hexadecimal encoding
+                  enum:
+                    - base64
+                    - base64url
+                    - base32
+                    - hex
+                    - raw
+                  type: string
+                length:
+                  default: 24
+                  description: |-
+                    Length of the password to be generated.
+                    Defaults to 24
+                  type: integer
+                noUpper:
+                  default: false
+                  description: Set NoUpper to disable uppercase characters
+                  type: boolean
+                secretKeys:
+                  description: |-
+                    SecretKeys defines the keys that will be populated with generated passwords.
+                    Defaults to "password" when not set.
+                  items:
+                    type: string
+                  minItems: 1
+                  type: array
+                symbolCharacters:
+                  description: |-
+                    SymbolCharacters specifies the special characters that should be used
+                    in the generated password.
+                  type: string
+                symbols:
+                  description: |-
+                    Symbols specifies the number of symbol characters in the generated
+                    password. If omitted it defaults to 25% of the length of the password
+                  type: integer
+              required:
+                - allowRepeat
+                - length
+                - noUpper
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-pushsecrets-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-pushsecrets-external-secrets-io.yaml
@@ -1,0 +1,649 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: pushsecrets.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - external-secrets
+    kind: PushSecret
+    listKind: PushSecretList
+    plural: pushsecrets
+    shortNames:
+      - ps
+    singular: pushsecret
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.refreshTime
+          name: Last Sync
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: PushSecret is the Schema for the PushSecrets API that enables pushing Kubernetes secrets to external secret providers.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: PushSecretSpec configures the behavior of the PushSecret.
+              properties:
+                data:
+                  description: Secret Data that should be pushed to providers
+                  items:
+                    description: PushSecretData defines data to be pushed to the provider and associated metadata.
+                    properties:
+                      conversionStrategy:
+                        default: None
+                        description: Used to define a conversion Strategy for the secret keys
+                        enum:
+                          - None
+                          - ReverseUnicode
+                        type: string
+                      match:
+                        description: Match a given Secret Key to be pushed to the provider.
+                        properties:
+                          remoteRef:
+                            description: Remote Refs to push to providers.
+                            properties:
+                              property:
+                                description: Name of the property in the resulting secret
+                                type: string
+                              remoteKey:
+                                description: Name of the resulting provider secret.
+                                type: string
+                            required:
+                              - remoteKey
+                            type: object
+                          secretKey:
+                            description: Secret Key to be pushed
+                            type: string
+                        required:
+                          - remoteRef
+                        type: object
+                      metadata:
+                        description: |-
+                          Metadata is metadata attached to the secret.
+                          The structure of metadata is provider specific, please look it up in the provider documentation.
+                        x-kubernetes-preserve-unknown-fields: true
+                    required:
+                      - match
+                    type: object
+                  type: array
+                dataTo:
+                  description: DataTo defines bulk push rules that expand source Secret keys into provider entries.
+                  items:
+                    description: PushSecretDataTo defines how to bulk-push secrets to providers without explicit per-key mappings.
+                    properties:
+                      conversionStrategy:
+                        default: None
+                        description: Used to define a conversion Strategy for the secret keys
+                        enum:
+                          - None
+                          - ReverseUnicode
+                        type: string
+                      match:
+                        description: |-
+                          Match pattern for selecting keys from the source Secret.
+                          If not specified, all keys are selected.
+                        properties:
+                          regexp:
+                            description: |-
+                              Regexp matches keys by regular expression.
+                              If not specified, all keys are matched.
+                            type: string
+                        type: object
+                      metadata:
+                        description: |-
+                          Metadata is metadata attached to the secret.
+                          The structure of metadata is provider specific, please look it up in the provider documentation.
+                        x-kubernetes-preserve-unknown-fields: true
+                      remoteKey:
+                        description: |-
+                          RemoteKey is the name of the single provider secret that will receive ALL
+                          matched keys bundled as a JSON object (e.g. {"DB_HOST":"...","DB_USER":"..."}).
+                          When set, per-key expansion is skipped and a single push is performed.
+                          The provider's store prefix (if any) is still prepended to this value.
+                          When not set, each matched key is pushed as its own individual provider secret.
+                        type: string
+                      rewrite:
+                        description: |-
+                          Rewrite operations to transform keys before pushing to the provider.
+                          Operations are applied sequentially.
+                        items:
+                          description: PushSecretRewrite defines how to transform secret keys before pushing.
+                          properties:
+                            regexp:
+                              description: Used to rewrite with regular expressions.
+                              properties:
+                                source:
+                                  description: Used to define the regular expression of a re.Compiler.
+                                  type: string
+                                target:
+                                  description: Used to define the target pattern of a ReplaceAll operation.
+                                  type: string
+                              required:
+                                - source
+                                - target
+                              type: object
+                            transform:
+                              description: Used to apply string transformation on the secrets.
+                              properties:
+                                template:
+                                  description: |-
+                                    Used to define the template to apply on the secret name.
+                                    `.value ` will specify the secret name in the template.
+                                  type: string
+                              required:
+                                - template
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exactly one of regexp or transform must be set
+                              rule: (has(self.regexp) && !has(self.transform)) || (!has(self.regexp) && has(self.transform))
+                        type: array
+                      storeRef:
+                        description: StoreRef specifies which SecretStore to push to. Required.
+                        properties:
+                          kind:
+                            default: SecretStore
+                            description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                            enum:
+                              - SecretStore
+                              - ClusterSecretStore
+                            type: string
+                          labelSelector:
+                            description: Optionally, sync to secret stores with label selector
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          name:
+                            description: Optionally, sync to the SecretStore of the given name
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        type: object
+                    type: object
+                    x-kubernetes-validations:
+                      - message: storeRef must specify either name or labelSelector
+                        rule: has(self.storeRef) && (has(self.storeRef.name) || has(self.storeRef.labelSelector))
+                      - message: 'remoteKey and rewrite are mutually exclusive: rewrite is only supported in per-key mode (without remoteKey)'
+                        rule: '!has(self.remoteKey) || !has(self.rewrite) || size(self.rewrite) == 0'
+                  type: array
+                deletionPolicy:
+                  default: None
+                  description: Deletion Policy to handle Secrets in the provider.
+                  enum:
+                    - Delete
+                    - None
+                  type: string
+                refreshInterval:
+                  default: 1h0m0s
+                  description: The Interval to which External Secrets will try to push a secret definition
+                  type: string
+                secretStoreRefs:
+                  items:
+                    description: PushSecretStoreRef contains a reference on how to sync to a SecretStore.
+                    properties:
+                      kind:
+                        default: SecretStore
+                        description: Kind of the SecretStore resource (SecretStore or ClusterSecretStore)
+                        enum:
+                          - SecretStore
+                          - ClusterSecretStore
+                        type: string
+                      labelSelector:
+                        description: Optionally, sync to secret stores with label selector
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      name:
+                        description: Optionally, sync to the SecretStore of the given name
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    type: object
+                  type: array
+                selector:
+                  description: The Secret Selector (k8s source) for the Push Secret
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    generatorRef:
+                      description: Point to a generator to create a Secret.
+                      properties:
+                        apiVersion:
+                          default: generators.external-secrets.io/v1alpha1
+                          description: Specify the apiVersion of the generator resource
+                          type: string
+                        kind:
+                          description: Specify the Kind of the generator resource
+                          enum:
+                            - ACRAccessToken
+                            - BeyondtrustWorkloadCredentialsDynamicSecret
+                            - ClusterGenerator
+                            - CloudsmithAccessToken
+                            - ECRAuthorizationToken
+                            - Fake
+                            - GCRAccessToken
+                            - GithubAccessToken
+                            - GitlabDeployToken
+                            - QuayAccessToken
+                            - Password
+                            - SSHKey
+                            - STSSessionToken
+                            - UUID
+                            - VaultDynamicSecret
+                            - Webhook
+                            - Grafana
+                            - MFA
+                          type: string
+                        name:
+                          description: Specify the name of the generator resource
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                      required:
+                        - kind
+                        - name
+                      type: object
+                    secret:
+                      description: Select a Secret to Push.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the Secret.
+                            The Secret must exist in the same namespace as the PushSecret manifest.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        selector:
+                          description: Selector chooses secrets using a labelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  type: object
+                template:
+                  description: Template defines a blueprint for the created Secret resource.
+                  properties:
+                    data:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    engineVersion:
+                      default: v2
+                      description: |-
+                        EngineVersion specifies the template engine version
+                        that should be used to compile/execute the
+                        template specified in .data and .templateFrom[].
+                      enum:
+                        - v2
+                      type: string
+                    mergePolicy:
+                      default: Replace
+                      description: TemplateMergePolicy defines how the rendered template should be merged with the existing Secret data.
+                      enum:
+                        - Replace
+                        - Merge
+                      type: string
+                    metadata:
+                      description: ExternalSecretTemplateMetadata defines metadata fields for the Secret blueprint.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        finalizers:
+                          items:
+                            type: string
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    templateFrom:
+                      items:
+                        description: |-
+                          TemplateFrom specifies a source for templates.
+                          Each item in the list can either reference a ConfigMap or a Secret resource.
+                        properties:
+                          configMap:
+                            description: TemplateRef specifies a reference to either a ConfigMap or a Secret resource.
+                            properties:
+                              items:
+                                description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                items:
+                                  description: TemplateRefItem specifies a key in the ConfigMap/Secret to use as a template for Secret data.
+                                  properties:
+                                    key:
+                                      description: A key in the ConfigMap/Secret
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    templateAs:
+                                      default: Values
+                                      description: TemplateScope specifies how the template keys should be interpreted.
+                                      enum:
+                                        - Values
+                                        - KeysAndValues
+                                      type: string
+                                  required:
+                                    - key
+                                  type: object
+                                type: array
+                              name:
+                                description: The name of the ConfigMap/Secret resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            required:
+                              - items
+                              - name
+                            type: object
+                          literal:
+                            type: string
+                          secret:
+                            description: TemplateRef specifies a reference to either a ConfigMap or a Secret resource.
+                            properties:
+                              items:
+                                description: A list of keys in the ConfigMap/Secret to use as templates for Secret data
+                                items:
+                                  description: TemplateRefItem specifies a key in the ConfigMap/Secret to use as a template for Secret data.
+                                  properties:
+                                    key:
+                                      description: A key in the ConfigMap/Secret
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    templateAs:
+                                      default: Values
+                                      description: TemplateScope specifies how the template keys should be interpreted.
+                                      enum:
+                                        - Values
+                                        - KeysAndValues
+                                      type: string
+                                  required:
+                                    - key
+                                  type: object
+                                type: array
+                              name:
+                                description: The name of the ConfigMap/Secret resource
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                type: string
+                            required:
+                              - items
+                              - name
+                            type: object
+                          target:
+                            default: Data
+                            description: |-
+                              Target specifies where to place the template result.
+                              For Secret resources, common values are: "Data", "Annotations", "Labels".
+                              For custom resources (when spec.target.manifest is set), this supports
+                              nested paths like "spec.database.config" or "data".
+                            type: string
+                          valuesDecodingStrategy:
+                            default: None
+                            description: Used to define a decoding Strategy for the rendered template values.
+                            enum:
+                              - Auto
+                              - Base64
+                              - Base64URL
+                              - None
+                            type: string
+                        type: object
+                      type: array
+                    type:
+                      type: string
+                  type: object
+                updatePolicy:
+                  default: Replace
+                  description: UpdatePolicy to handle Secrets in the provider.
+                  enum:
+                    - Replace
+                    - IfNotExists
+                  type: string
+              required:
+                - secretStoreRefs
+                - selector
+              type: object
+            status:
+              description: PushSecretStatus indicates the history of the status of PushSecret.
+              properties:
+                conditions:
+                  items:
+                    description: PushSecretStatusCondition indicates the status of the PushSecret.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: PushSecretConditionType indicates the condition of the PushSecret.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+                refreshTime:
+                  description: |-
+                    refreshTime is the time and date the external secret was fetched and
+                    the target secret updated
+                  format: date-time
+                  nullable: true
+                  type: string
+                syncedPushSecrets:
+                  additionalProperties:
+                    additionalProperties:
+                      description: PushSecretData defines data to be pushed to the provider and associated metadata.
+                      properties:
+                        conversionStrategy:
+                          default: None
+                          description: Used to define a conversion Strategy for the secret keys
+                          enum:
+                            - None
+                            - ReverseUnicode
+                          type: string
+                        match:
+                          description: Match a given Secret Key to be pushed to the provider.
+                          properties:
+                            remoteRef:
+                              description: Remote Refs to push to providers.
+                              properties:
+                                property:
+                                  description: Name of the property in the resulting secret
+                                  type: string
+                                remoteKey:
+                                  description: Name of the resulting provider secret.
+                                  type: string
+                              required:
+                                - remoteKey
+                              type: object
+                            secretKey:
+                              description: Secret Key to be pushed
+                              type: string
+                          required:
+                            - remoteRef
+                          type: object
+                        metadata:
+                          description: |-
+                            Metadata is metadata attached to the secret.
+                            The structure of metadata is provider specific, please look it up in the provider documentation.
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                        - match
+                      type: object
+                    type: object
+                  description: |-
+                    Synced PushSecrets, including secrets that already exist in provider.
+                    Matches secret stores to PushSecretData that was stored to that secret store.
+                  type: object
+                syncedResourceVersion:
+                  description: SyncedResourceVersion keeps track of the last synced version.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-quayaccesstokens-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-quayaccesstokens-generators-external-secrets-io.yaml
@@ -1,0 +1,88 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: quayaccesstokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: QuayAccessToken
+    listKind: QuayAccessTokenList
+    plural: quayaccesstokens
+    singular: quayaccesstoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: QuayAccessToken generates Quay oauth token for pulling/pushing images
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: QuayAccessTokenSpec defines the desired state to generate a Quay access token.
+              properties:
+                robotAccount:
+                  description: Name of the robot account you are federating with
+                  type: string
+                serviceAccountRef:
+                  description: Name of the service account you are federating with
+                  properties:
+                    audiences:
+                      description: |-
+                        Audience specifies the `aud` claim for the service account token
+                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                        then this audiences will be appended to the list
+                      items:
+                        type: string
+                      type: array
+                    name:
+                      description: The name of the ServiceAccount resource being referred to.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the resource being referred to.
+                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                    - name
+                  type: object
+                url:
+                  description: URL configures the Quay instance URL. Defaults to quay.io.
+                  type: string
+              required:
+                - robotAccount
+                - serviceAccountRef
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-secretstores-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-secretstores-external-secrets-io.yaml
@@ -1,0 +1,11140 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: secretstores.external-secrets.io
+spec:
+  group: external-secrets.io
+  names:
+    categories:
+      - external-secrets
+    kind: SecretStore
+    listKind: SecretStoreList
+    plural: secretstores
+    shortNames:
+      - ss
+    singular: secretstore
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.capabilities
+          name: Capabilities
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: SecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SecretStoreSpec defines the desired state of SecretStore.
+              properties:
+                conditions:
+                  description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
+                  items:
+                    description: |-
+                      ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
+                      for a ClusterSecretStore instance.
+                    properties:
+                      namespaceRegexes:
+                        description: Choose namespaces by using regex matching
+                        items:
+                          type: string
+                        type: array
+                      namespaceSelector:
+                        description: Choose namespace using a labelSelector
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaces:
+                        description: Choose namespaces by name
+                        items:
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                controller:
+                  description: |-
+                    Used to select the correct ESO controller (think: ingress.ingressClassName)
+                    The ESO controller is instantiated with a specific controller name and filters ES based on this property
+                  type: string
+                provider:
+                  description: Used to configure the provider. Only one provider may be set
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    akeyless:
+                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      properties:
+                        akeylessGWApiURL:
+                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          type: string
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Akeyless.
+                          properties:
+                            kubernetesAuth:
+                              description: |-
+                                Kubernetes authenticates with Akeyless by passing the ServiceAccount
+                                token stored in the named Secret resource.
+                              properties:
+                                accessID:
+                                  description: the Akeyless Kubernetes auth-method access-id
+                                  type: string
+                                k8sConfName:
+                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                    for authenticating with Akeyless. If a name is specified without a key,
+                                    `token` is the default. If one is not specified, the one bound to
+                                    the controller will be used.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional service account field containing the name of a kubernetes ServiceAccount.
+                                    If the service account is specified, the service account secret token JWT will be used
+                                    for authenticating with Akeyless. If the service account selector is not supplied,
+                                    the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - accessID
+                                - k8sConfName
+                              type: object
+                            secretRef:
+                              description: |-
+                                Reference to a Secret that contains the details
+                                to authenticate with Akeyless.
+                              properties:
+                                accessID:
+                                  description: The SecretAccessID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessType:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessTypeParam:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccountRef:
+                              description: |-
+                                ServiceAccountRef specifies a Kubernetes ServiceAccount used for azure_ad
+                                authentication on AKS Workload Identity. The operator obtains a federated
+                                identity token from this ServiceAccount via the TokenRequest API instead
+                                of using the ESO controller pod identity. Ignored for other access types.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used
+                            if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        ignoreCache:
+                          description: |-
+                            IgnoreCache bypasses the Gateway cache for secret reads when true.
+                            Only relevant when akeylessGWApiURL points to an Akeyless Gateway.
+                          type: boolean
+                      required:
+                        - akeylessGWApiURL
+                        - authSecretRef
+                      type: object
+                    aws:
+                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      properties:
+                        additionalRoles:
+                          description: AdditionalRoles is a chained list of Role ARNs which the provider will sequentially assume before assuming the Role
+                          items:
+                            type: string
+                          type: array
+                        auth:
+                          description: |-
+                            Auth defines the information necessary to authenticate against AWS
+                            if not set aws sdk will infer credentials from your environment
+                            see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                          properties:
+                            jwt:
+                              description: AWSJWTAuth stores reference to Authenticate against AWS using service account tokens.
+                              properties:
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: |-
+                                AWSAuthSecretRef holds secret references for AWS credentials
+                                both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                sessionTokenSecretRef:
+                                  description: |-
+                                    The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                    see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        customSessionTags:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            CustomSessionTags defines additional STS session tags to include when SessionTagsPolicy is Custom.
+                            These are merged with the automatically injected esoNamespace, esoStoreName, and esoStoreKind tags.
+                          type: object
+                          x-kubernetes-validations:
+                            - message: 'customSessionTags cannot contain automatically injected reserved keys: esoNamespace, esoStoreName, esoStoreKind'
+                              rule: '!(''esoNamespace'' in self) && !(''esoStoreName'' in self) && !(''esoStoreKind'' in self)'
+                        externalID:
+                          description: AWS External ID set on assumed IAM roles
+                          type: string
+                        prefix:
+                          description: Prefix adds a prefix to all retrieved values.
+                          type: string
+                        region:
+                          description: AWS Region to be used for the provider
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the provider will assume
+                          type: string
+                        secretsManager:
+                          description: SecretsManager defines how the provider behaves when interacting with AWS SecretsManager
+                          properties:
+                            forceDeleteWithoutRecovery:
+                              description: |-
+                                Specifies whether to delete the secret without any recovery window. You
+                                can't use both this parameter and RecoveryWindowInDays in the same call.
+                                If you don't use either, then by default Secrets Manager uses a 30 day
+                                recovery window.
+                                see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-ForceDeleteWithoutRecovery
+                              type: boolean
+                            recoveryWindowInDays:
+                              description: |-
+                                The number of days from 7 to 30 that Secrets Manager waits before
+                                permanently deleting the secret. You can't use both this parameter and
+                                ForceDeleteWithoutRecovery in the same call. If you don't use either,
+                                then by default Secrets Manager uses a 30-day recovery window.
+                                see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-RecoveryWindowInDays
+                              format: int64
+                              type: integer
+                          type: object
+                        service:
+                          description: Service defines which service should be used to fetch the secrets
+                          enum:
+                            - SecretsManager
+                            - ParameterStore
+                            - CertificateManager
+                          type: string
+                        sessionTags:
+                          description: AWS STS assume role session tags
+                          items:
+                            description: |-
+                              Tag is a key-value pair that can be attached to an AWS resource.
+                              see: https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          type: array
+                        sessionTagsPolicy:
+                          default: None
+                          description: |-
+                            SessionTagsPolicy controls whether and how STS session tags are added when assuming roles.
+                            None (default): no tags are added.
+                            Simple: automatically adds esoNamespace (from the ExternalSecret), esoStoreName, and esoStoreKind tags.
+                            Custom: adds esoNamespace, esoStoreName, and esoStoreKind plus any tags defined in CustomSessionTags.
+                            Note: the IAM role must have sts:TagSession permission when using Simple or Custom.
+                          enum:
+                            - None
+                            - Simple
+                            - Custom
+                          type: string
+                        transitiveTagKeys:
+                          description: AWS STS assume role transitive session tags. Required when multiple rules are used with the provider
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - region
+                        - service
+                      type: object
+                    azurekv:
+                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      properties:
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type. Optional for WorkloadIdentity.
+                          properties:
+                            clientCertificate:
+                              description: The Azure ClientCertificate of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            clientId:
+                              description: The Azure clientId of the service principle or managed identity used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            tenantId:
+                              description: The Azure tenantId of the managed identity used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        authType:
+                          default: ServicePrincipal
+                          description: |-
+                            Auth type defines how to authenticate to the keyvault service.
+                            Valid values are:
+                            - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret)
+                            - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)
+                            - "WorkloadIdentity": Using a Kubernetes ServiceAccount federated with Entra ID
+                          enum:
+                            - ServicePrincipal
+                            - ManagedIdentity
+                            - WorkloadIdentity
+                          type: string
+                        customCloudConfig:
+                          description: |-
+                            CustomCloudConfig defines custom Azure endpoints for non-standard clouds.
+                            Required when EnvironmentType is AzureStackCloud.
+                            Optional for other environment types - useful for Azure China when using Workload Identity
+                            with AKS, where the OIDC issuer (login.partner.microsoftonline.cn) differs from the
+                            standard China Cloud endpoint (login.chinacloudapi.cn).
+                            IMPORTANT: This feature REQUIRES UseAzureSDK to be set to true. Custom cloud
+                            configuration is not supported with the legacy go-autorest SDK.
+                          properties:
+                            activeDirectoryEndpoint:
+                              description: |-
+                                ActiveDirectoryEndpoint is the AAD endpoint for authentication
+                                Required when using custom cloud configuration
+                              type: string
+                            keyVaultDNSSuffix:
+                              description: KeyVaultDNSSuffix is the DNS suffix for Key Vault URLs
+                              type: string
+                            keyVaultEndpoint:
+                              description: KeyVaultEndpoint is the Key Vault service endpoint
+                              type: string
+                            resourceManagerEndpoint:
+                              description: ResourceManagerEndpoint is the Azure Resource Manager endpoint
+                              type: string
+                          required:
+                            - activeDirectoryEndpoint
+                          type: object
+                        environmentType:
+                          default: PublicCloud
+                          description: |-
+                            EnvironmentType specifies the Azure cloud environment endpoints to use for
+                            connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint.
+                            The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                            PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud, AzureStackCloud
+                            Use AzureStackCloud when you need to configure custom Azure Stack Hub or Azure Stack Edge endpoints.
+                          enum:
+                            - PublicCloud
+                            - USGovernmentCloud
+                            - ChinaCloud
+                            - GermanCloud
+                            - AzureStackCloud
+                          type: string
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tenantId:
+                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type. Optional for WorkloadIdentity.
+                          type: string
+                        useAzureSDK:
+                          default: false
+                          description: |-
+                            UseAzureSDK enables the use of the new Azure SDK for Go (azcore-based) instead of the legacy go-autorest SDK.
+                            This is experimental and may have behavioral differences. Defaults to false (legacy SDK).
+                          type: boolean
+                        vaultUrl:
+                          description: Vault Url from which the secrets to be fetched from.
+                          type: string
+                      required:
+                        - vaultUrl
+                      type: object
+                    barbican:
+                      description: Barbican configures this store to sync secrets using the OpenStack Barbican provider
+                      properties:
+                        auth:
+                          description: BarbicanAuth contains the authentication information for Barbican.
+                          properties:
+                            password:
+                              description: BarbicanProviderPasswordRef defines a reference to a secret containing password for the Barbican provider.
+                              properties:
+                                secretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - secretRef
+                              type: object
+                            username:
+                              description: BarbicanProviderUsernameRef defines a reference to a secret containing username for the Barbican provider.
+                              maxProperties: 1
+                              minProperties: 1
+                              properties:
+                                secretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  type: string
+                              type: object
+                          required:
+                            - password
+                            - username
+                          type: object
+                        authURL:
+                          type: string
+                        domainName:
+                          type: string
+                        region:
+                          type: string
+                        tenantName:
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    beyondtrust:
+                      description: Beyondtrust configures this store to sync secrets using Password Safe provider.
+                      properties:
+                        auth:
+                          description: Auth configures how the operator authenticates with Beyondtrust.
+                          properties:
+                            apiKey:
+                              description: APIKey If not provided then ClientID/ClientSecret become required.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            certificate:
+                              description: Certificate (cert.pem) for use when authenticating with an OAuth client Id using a Client Certificate.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            certificateKey:
+                              description: Certificate private key (key.pem). For use when authenticating with an OAuth client Id
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            clientId:
+                              description: ClientID is the API OAuth Client ID.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: ClientSecret is the API OAuth Client Secret.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                          type: object
+                        server:
+                          description: Auth configures how API server works.
+                          properties:
+                            apiUrl:
+                              type: string
+                            apiVersion:
+                              type: string
+                            clientTimeOutSeconds:
+                              description: Timeout specifies a time limit for requests made by this Client. The timeout includes connection time, any redirects, and reading the response body. Defaults to 45 seconds.
+                              type: integer
+                            decrypt:
+                              default: true
+                              description: 'When true, the response includes the decrypted password. When false, the password field is omitted. This option only applies to the SECRET retrieval type. Default: true.'
+                              type: boolean
+                            retrievalType:
+                              description: The secret retrieval type. SECRET = Secrets Safe (credential, text, file). MANAGED_ACCOUNT = Password Safe account associated with a system.
+                              type: string
+                            separator:
+                              description: A character that separates the folder names.
+                              type: string
+                            verifyCA:
+                              type: boolean
+                          required:
+                            - apiUrl
+                            - verifyCA
+                          type: object
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    beyondtrustworkloadcredentials:
+                      description: BeyondtrustWorkloadCredentials configures this store to sync secrets using the BeyondTrust Workload Credentials provider.
+                      properties:
+                        auth:
+                          description: |-
+                            Auth configures how the Operator authenticates with the BeyondTrust Workload Credentials API.
+                            Currently supports API key authentication via Kubernetes secret reference.
+                            For authentication setup, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                          properties:
+                            apikey:
+                              description: |-
+                                APIKey configures API token authentication for BeyondTrust Workload Credentials.
+                                The token is retrieved from a Kubernetes secret and used as a Bearer token for API requests.
+                              properties:
+                                token:
+                                  description: |-
+                                    Token references the Kubernetes secret containing the BeyondTrust Workload Credentials API token.
+                                    The secret should contain the API key used to authenticate with BeyondTrust Workload Credentials.
+                                    Create an API token in your BeyondTrust Workload Credentials console and store it in a Kubernetes secret.
+                                    For details on creating API tokens, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - token
+                              type: object
+                          required:
+                            - apikey
+                          type: object
+                        caBundle:
+                          description: |-
+                            CABundle is a base64-encoded CA certificate used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                            Use this when your BeyondTrust instance uses a self-signed certificate or internal CA.
+                            If not set, the system's trusted root certificates are used.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: |-
+                            CAProvider points to a Secret or ConfigMap containing a PEM-encoded CA certificate.
+                            This is used to validate the BeyondTrust Workload Credentials API TLS certificate.
+                            Use this as an alternative to CABundle when you want to reference an existing Kubernetes resource.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        folderPath:
+                          description: |-
+                            FolderPath specifies the default folder path for secret retrieval.
+                            Secrets will be fetched from this folder unless overridden in the ExternalSecret spec.
+                            Example: "production/database" or "dev/api-keys"
+                            Leave empty to retrieve secrets from the root folder.
+                            For folder organization, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#folders
+                          type: string
+                        server:
+                          description: |-
+                            Server configures the BeyondTrust Workload Credentials server connection details.
+                            Includes the API URL and Site ID for your BeyondTrust instance.
+                            For API reference, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                          properties:
+                            apiUrl:
+                              description: |-
+                                APIURL is the base URL of your BeyondTrust Workload Credentials API server.
+                                This should be the full URL to your BeyondTrust instance.
+                                Example: https://api.beyondtrust.io/siie
+                                For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api#base-url
+                              type: string
+                            siteId:
+                              description: |-
+                                SiteID is your BeyondTrust Workload Credentials site identifier (UUID format).
+                                This identifier is unique to your BeyondTrust Workload Credentials instance.
+                                You can find your Site ID in the BeyondTrust Workload Credentials admin console.
+                                Example: a1b2c3d4-e5f6-4890-abcd-ef1234567890
+                                For more information, see: https://docs.beyondtrust.com/bt-docs/docs/secrets-api
+                              type: string
+                          required:
+                            - apiUrl
+                            - siteId
+                          type: object
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    bitwardensecretsmanager:
+                      description: BitwardenSecretsManager configures this store to sync secrets using BitwardenSecretsManager provider
+                      properties:
+                        apiURL:
+                          type: string
+                        auth:
+                          description: |-
+                            Auth configures how secret-manager authenticates with a bitwarden machine account instance.
+                            Make sure that the token being used has permissions on the given secret.
+                          properties:
+                            secretRef:
+                              description: BitwardenSecretsManagerSecretRef contains the credential ref to the bitwarden instance.
+                              properties:
+                                credentials:
+                                  description: AccessToken used for the bitwarden instance.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - credentials
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        bitwardenServerSDKURL:
+                          type: string
+                        caBundle:
+                          description: |-
+                            Base64 encoded certificate for the bitwarden server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                            can be performed.
+                          type: string
+                        caProvider:
+                          description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        identityURL:
+                          type: string
+                        organizationID:
+                          description: OrganizationID determines which organization this secret store manages.
+                          type: string
+                        projectID:
+                          description: ProjectID determines which project this secret store manages.
+                          type: string
+                      required:
+                        - auth
+                        - organizationID
+                        - projectID
+                      type: object
+                    chef:
+                      description: Chef configures this store to sync secrets with chef server
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against chef Server
+                          properties:
+                            secretRef:
+                              description: ChefAuthSecretRef holds secret references for chef server login credentials.
+                              properties:
+                                privateKeySecretRef:
+                                  description: SecretKey is the Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - privateKeySecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        serverUrl:
+                          description: ServerURL is the chef server URL used to connect to. If using orgs you should include your org in the url and terminate the url with a "/"
+                          type: string
+                        username:
+                          description: UserName should be the user ID on the chef server
+                          type: string
+                      required:
+                        - auth
+                        - serverUrl
+                        - username
+                      type: object
+                    cloudrusm:
+                      description: CloudruSM configures this store to sync secrets using the Cloud.ru Secret Manager provider
+                      properties:
+                        auth:
+                          description: CSMAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: CSMAuthSecretRef holds secret references for Cloud.ru credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          type: object
+                        projectID:
+                          description: ProjectID is the project, which the secrets are stored in.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    conjur:
+                      description: Conjur configures this store to sync secrets using conjur provider
+                      properties:
+                        auth:
+                          description: Defines authentication settings for connecting to Conjur.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            apikey:
+                              description: Authenticates with Conjur using an API key.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                apiKeyRef:
+                                  description: |-
+                                    A reference to a specific 'key' containing the Conjur API key
+                                    within a Secret resource. In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                userRef:
+                                  description: |-
+                                    A reference to a specific 'key' containing the Conjur username
+                                    within a Secret resource. In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - account
+                                - apiKeyRef
+                                - userRef
+                              type: object
+                            cert:
+                              description: Cert enables certificate-based authentication using a client certificate and key.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                clientCertRef:
+                                  description: |-
+                                    ClientCertRef is a reference to a specific 'key' containing the client certificate
+                                    within a Secret resource. The certificate must be PEM-encoded.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientKeyRef:
+                                  description: |-
+                                    ClientKeyRef is a reference to a specific 'key' containing the private RSA client key
+                                    within a Secret resource. The key must be PEM-encoded.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                hostId:
+                                  description: Optional HostID for cert authentication (can be omitted when using 'spiffe' mode).
+                                  type: string
+                                serviceID:
+                                  description: The conjur authn cert webservice id
+                                  type: string
+                              required:
+                                - account
+                                - clientCertRef
+                                - clientKeyRef
+                                - serviceID
+                              type: object
+                            jwt:
+                              description: Jwt enables JWT authentication using Kubernetes service account tokens.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                hostId:
+                                  description: |-
+                                    Optional HostID for JWT authentication. This may be used depending
+                                    on how the Conjur JWT authenticator policy is configured.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                    authenticate with Conjur using the JWT authentication method.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional ServiceAccountRef specifies the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceID:
+                                  description: The conjur authn jwt webservice id
+                                  type: string
+                              required:
+                                - account
+                                - serviceID
+                              type: object
+                          type: object
+                        caBundle:
+                          description: CABundle is a PEM encoded CA bundle that will be used to validate the Conjur server certificate.
+                          type: string
+                        caProvider:
+                          description: |-
+                            Used to provide custom certificate authority (CA) certificates
+                            for a secret store. The CAProvider points to a Secret or ConfigMap resource
+                            that contains a PEM-encoded certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        url:
+                          description: URL is the endpoint of the Conjur instance.
+                          type: string
+                      required:
+                        - auth
+                        - url
+                      type: object
+                    crd:
+                      description: |-
+                        CRD configures this store to sync secrets from arbitrary Kubernetes resources,
+                        including both custom resources (CRDs) and core API resources. Resources are
+                        selected by API group, version and kind, where group can be "" (empty string)
+                        for core resources such as ConfigMap. Reading the core v1 Secret is
+                        intentionally blocked — use the Kubernetes provider for that.
+                      properties:
+                        auth:
+                          description: |-
+                            Auth configures authentication to the Kubernetes API, same as the
+                            Kubernetes provider. Required when Server.URL is set (unless using AuthRef).
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - clientCert
+                                - clientKey
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - bearerToken
+                              type: object
+                          type: object
+                        authRef:
+                          description: |-
+                            AuthRef references a Secret containing a kubeconfig. Same semantics as the
+                            Kubernetes provider.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        resource:
+                          description: Resource identifies the CRD by its API group, version and kind.
+                          properties:
+                            group:
+                              description: |-
+                                Group is the API group of the resource. Use "" (empty string) for core
+                                Kubernetes resources such as ConfigMap; use e.g. "config.example.io"
+                                for a CRD. The field is required to be present in the manifest — write
+                                `group: ""` explicitly for core resources so typos fail at admission
+                                time rather than later at discovery.
+                              type: string
+                            kind:
+                              description: Kind is the Kubernetes resource kind (e.g. "MyCustomResource").
+                              minLength: 1
+                              type: string
+                            version:
+                              description: Version is the API version of the resource (e.g. "v1alpha1").
+                              minLength: 1
+                              type: string
+                          required:
+                            - group
+                            - kind
+                            - version
+                          type: object
+                        server:
+                          description: |-
+                            Server configures the Kubernetes API address and TLS trust, same as the
+                            Kubernetes provider. When omitted, the URL defaults to the in-cluster API.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                        whitelist:
+                          description: |-
+                            Whitelist optionally restricts which object names and requested properties
+                            are allowed to be read.
+                          properties:
+                            rules:
+                              description: |-
+                                Rules is a list of allow rules. If rules are set, at least one rule must
+                                match for a request to be allowed.
+                              items:
+                                description: CRDProviderWhitelistRule defines a single allow rule for CRD reads.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name is an optional regular expression matched against the bare object name.
+                                      For both SecretStore and ClusterSecretStore this is always the object name
+                                      without any namespace prefix (e.g. "my-db-spec", not "prod/my-db-spec").
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace is an optional regular expression matched against the namespace of
+                                      the object. Applies only when a ClusterSecretStore is used; it is ignored
+                                      for SecretStore (where the namespace is fixed to the store namespace).
+                                    type: string
+                                  properties:
+                                    description: |-
+                                      Properties is an optional list of regular expressions matched against
+                                      requested property keys (for example: "spec.secretValue").
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                      required:
+                        - resource
+                      type: object
+                      x-kubernetes-validations:
+                        - message: one of auth or authRef is required
+                          rule: has(self.auth) || has(self.authRef)
+                        - message: at most one of the fields in [auth authRef] may be set
+                          rule: '[has(self.auth),has(self.authRef)].filter(x,x==true).size() <= 1'
+                    delinea:
+                      description: |-
+                        Delinea DevOps Secrets Vault
+                        https://docs.delinea.com/online-help/products/devops-secrets-vault/current
+                      properties:
+                        clientId:
+                          description: ClientID is the non-secret part of the credential.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        clientSecret:
+                          description: ClientSecret is the secret part of the credential.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        tenant:
+                          description: Tenant is the chosen hostname / site name.
+                          type: string
+                        tld:
+                          description: |-
+                            TLD is based on the server location that was chosen during provisioning.
+                            If unset, defaults to "com".
+                          type: string
+                        urlTemplate:
+                          description: |-
+                            URLTemplate
+                            If unset, defaults to "https://%s.secretsvaultcloud.%s/v1/%s%s".
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tenant
+                      type: object
+                    doppler:
+                      description: Doppler configures this store to sync secrets using the Doppler provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Doppler API
+                          properties:
+                            oidcConfig:
+                              description: OIDCConfig authenticates using Kubernetes ServiceAccount tokens via OIDC.
+                              properties:
+                                expirationSeconds:
+                                  default: 600
+                                  description: |-
+                                    ExpirationSeconds sets the ServiceAccount token validity duration.
+                                    Defaults to 10 minutes.
+                                  format: int64
+                                  type: integer
+                                identity:
+                                  description: Identity is the Doppler Service Account Identity ID configured for OIDC authentication.
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountRef specifies the Kubernetes ServiceAccount to use for authentication.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - identity
+                                - serviceAccountRef
+                              type: object
+                            secretRef:
+                              description: SecretRef authenticates using a Doppler service token stored in a Kubernetes Secret.
+                              properties:
+                                dopplerToken:
+                                  description: |-
+                                    The DopplerToken is used for authentication.
+                                    See https://docs.doppler.com/reference/api#authentication for auth token types.
+                                    The Key attribute defaults to dopplerToken if not specified.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - dopplerToken
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Exactly one of 'secretRef' or 'oidcConfig' must be specified
+                              rule: (has(self.secretRef) && !has(self.oidcConfig)) || (!has(self.secretRef) && has(self.oidcConfig))
+                        config:
+                          description: Doppler config (required if not using a Service Token)
+                          type: string
+                        format:
+                          description: Format enables the downloading of secrets as a file (string)
+                          enum:
+                            - json
+                            - dotnet-json
+                            - env
+                            - yaml
+                            - docker
+                          type: string
+                        nameTransformer:
+                          description: Environment variable compatible name transforms that change secret names to a different format
+                          enum:
+                            - upper-camel
+                            - camel
+                            - lower-snake
+                            - tf-var
+                            - dotnet-env
+                            - lower-kebab
+                          type: string
+                        project:
+                          description: Doppler project (required if not using a Service Token)
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    dvls:
+                      description: DVLS configures this store to sync secrets using Devolutions Server provider
+                      properties:
+                        auth:
+                          description: Auth defines the authentication method to use.
+                          properties:
+                            secretRef:
+                              description: SecretRef contains the Application ID and Application Secret for authentication.
+                              properties:
+                                appId:
+                                  description: AppID is the reference to the secret containing the Application ID.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                appSecret:
+                                  description: AppSecret is the reference to the secret containing the Application Secret.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - appId
+                                - appSecret
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        insecure:
+                          description: |-
+                            Insecure allows connecting to DVLS over plain HTTP.
+                            This is NOT RECOMMENDED for production use.
+                            Set to true only if you understand the security implications.
+                          type: boolean
+                        serverUrl:
+                          description: ServerURL is the DVLS instance URL (e.g., https://dvls.example.com).
+                          type: string
+                        vault:
+                          description: |-
+                            Vault is the name or UUID of the vault to fetch secrets from.
+                            When omitted, the vault must be specified in the secret key using the legacy format "<vault-id>/<entry-id>".
+                          type: string
+                      required:
+                        - auth
+                        - serverUrl
+                      type: object
+                    fake:
+                      description: Fake configures a store with static key/value pairs
+                      properties:
+                        data:
+                          items:
+                            description: FakeProviderData defines a key-value pair with optional version for the fake provider.
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          type: array
+                        validationResult:
+                          description: ValidationResult is defined type for the number of validation results.
+                          type: integer
+                      required:
+                        - data
+                      type: object
+                    fortanix:
+                      description: Fortanix configures this store to sync secrets using the Fortanix provider
+                      properties:
+                        apiKey:
+                          description: APIKey is the API token to access SDKMS Applications.
+                          properties:
+                            secretRef:
+                              description: SecretRef is a reference to a secret containing the SDKMS API Key.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        apiUrl:
+                          description: APIURL is the URL of SDKMS API. Defaults to `sdkms.fortanix.com`.
+                          type: string
+                      type: object
+                    gcpsm:
+                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against GCP
+                          properties:
+                            secretRef:
+                              description: GCPSMAuthSecretRef contains the secret references for GCP Secret Manager authentication.
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            workloadIdentity:
+                              description: GCPWorkloadIdentity defines configuration for workload identity authentication to GCP.
+                              properties:
+                                clusterLocation:
+                                  description: |-
+                                    ClusterLocation is the location of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterName:
+                                  description: |-
+                                    ClusterName is the name of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterProjectID:
+                                  description: |-
+                                    ClusterProjectID is the project ID of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - serviceAccountRef
+                              type: object
+                            workloadIdentityFederation:
+                              description: GCPWorkloadIdentityFederation holds the configurations required for generating federated access tokens.
+                              properties:
+                                audience:
+                                  description: |-
+                                    audience is the Secure Token Service (STS) audience which contains the resource name for the workload identity pool and the provider identifier in that pool.
+                                    If specified, Audience found in the external account credential config will be overridden with the configured value.
+                                    audience must be provided when serviceAccountRef or awsSecurityCredentials is configured.
+                                  type: string
+                                awsSecurityCredentials:
+                                  description: |-
+                                    awsSecurityCredentials is for configuring AWS region and credentials to use for obtaining the access token,
+                                    when using the AWS metadata server is not an option.
+                                  properties:
+                                    awsCredentialsSecretRef:
+                                      description: |-
+                                        awsCredentialsSecretRef is the reference to the secret which holds the AWS credentials.
+                                        Secret should be created with below names for keys
+                                        - aws_access_key_id: Access Key ID, which is the unique identifier for the AWS account or the IAM user.
+                                        - aws_secret_access_key: Secret Access Key, which is used to authenticate requests made to AWS services.
+                                        - aws_session_token: Session Token, is the short-lived token to authenticate requests made to AWS services.
+                                      properties:
+                                        name:
+                                          description: name of the secret.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: namespace in which the secret exists. If empty, secret will looked up in local namespace.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    region:
+                                      description: region is for configuring the AWS region to be used.
+                                      example: ap-south-1
+                                      maxLength: 50
+                                      minLength: 1
+                                      pattern: ^[a-z0-9-]+$
+                                      type: string
+                                  required:
+                                    - awsCredentialsSecretRef
+                                    - region
+                                  type: object
+                                credConfig:
+                                  description: |-
+                                    credConfig holds the configmap reference containing the GCP external account credential configuration in JSON format and the key name containing the json data.
+                                    For using Kubernetes cluster as the identity provider, use serviceAccountRef instead. Operators mounted serviceaccount token cannot be used as the token source, instead
+                                    serviceAccountRef must be used by providing operators service account details.
+                                  properties:
+                                    key:
+                                      description: key name holding the external account credential config.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: name of the configmap.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: namespace in which the configmap exists. If empty, configmap will looked up in local namespace.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - key
+                                    - name
+                                  type: object
+                                externalTokenEndpoint:
+                                  description: |-
+                                    externalTokenEndpoint is the endpoint explicitly set up to provide tokens, which will be matched against the
+                                    credential_source.url in the provided credConfig. This field is merely to double-check the external token source
+                                    URL is having the expected value.
+                                  type: string
+                                gcpServiceAccountEmail:
+                                  description: |-
+                                    GCPServiceAccountEmail is the email of the Google Cloud service account to impersonate
+                                    after Workload Identity Federation. Use this to grant access through the service account's
+                                    IAM bindings (for example roles/secretmanager.secretAccessor). When set, it overrides
+                                    service_account_impersonation_url in the external account JSON from credConfig;
+                                    when serviceAccountRef is set, it also overrides the "iam.gke.io/gcp-service-account" annotation
+                                    on that ServiceAccount.
+                                  example: my-gsa@my-project.iam.gserviceaccount.com
+                                  minLength: 1
+                                  pattern: ^.*@.*\.iam\.gserviceaccount\.com$
+                                  type: string
+                                serviceAccountRef:
+                                  description: |-
+                                    serviceAccountRef is the reference to the kubernetes ServiceAccount to be used for obtaining the tokens,
+                                    when Kubernetes is configured as provider in workload identity pool.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                          type: object
+                        location:
+                          description: Location optionally defines a location for a secret
+                          type: string
+                        projectID:
+                          description: ProjectID project where secret is located
+                          type: string
+                        secretVersionSelectionPolicy:
+                          default: LatestOrFail
+                          description: |-
+                            SecretVersionSelectionPolicy specifies how the provider selects a secret version
+                            when "latest" is disabled or destroyed.
+                            Possible values are:
+                            - LatestOrFail: the provider always uses "latest", or fails if that version is disabled/destroyed.
+                            - LatestOrFetch: the provider falls back to fetching the latest version if the version is DESTROYED or DISABLED
+                          type: string
+                      type: object
+                    github:
+                      description: |-
+                        Github configures this store to push GitHub Actions secrets using the GitHub API provider.
+                        Note: This provider only supports write operations (PushSecret) and cannot fetch secrets from GitHub
+                      properties:
+                        appID:
+                          description: appID specifies the Github APP that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        auth:
+                          description: auth configures how secret-manager authenticates with a Github instance.
+                          properties:
+                            privateKey:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - privateKey
+                          type: object
+                        environment:
+                          description: environment will be used to fetch secrets from a particular environment within a github repository
+                          type: string
+                        installationID:
+                          description: installationID specifies the Github APP installation that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        orgSecretVisibility:
+                          description: |-
+                            orgSecretVisibility controls the visibility of organization secrets pushed via PushSecret.
+                            Valid values are "all" or "private".
+                            When unset, new secrets are created with visibility "all" and existing secrets preserve
+                            whatever visibility they already have in GitHub.
+                          enum:
+                            - all
+                            - private
+                          type: string
+                        organization:
+                          description: organization will be used to fetch secrets from the Github organization
+                          type: string
+                        repository:
+                          description: repository will be used to fetch secrets from the Github repository within an organization
+                          type: string
+                        uploadURL:
+                          description: Upload URL for enterprise instances. Default to URL.
+                          type: string
+                        url:
+                          default: https://github.com/
+                          description: URL configures the Github instance URL. Defaults to https://github.com/.
+                          type: string
+                      required:
+                        - appID
+                        - auth
+                        - installationID
+                        - organization
+                      type: object
+                    gitlab:
+                      description: GitLab configures this store to sync secrets using GitLab Variables provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          properties:
+                            SecretRef:
+                              description: GitlabSecretRef contains the secret reference for GitLab authentication credentials.
+                              properties:
+                                accessToken:
+                                  description: AccessToken is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - SecretRef
+                          type: object
+                        caBundle:
+                          description: |-
+                            Base64 encoded certificate for the GitLab server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                            can be performed.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        environment:
+                          description: Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)
+                          type: string
+                        groupIDs:
+                          description: GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.
+                          items:
+                            type: string
+                          type: array
+                        inheritFromGroups:
+                          description: InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.
+                          type: boolean
+                        projectID:
+                          description: ProjectID specifies a project where secrets are located.
+                          type: string
+                        url:
+                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    ibm:
+                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            containerAuth:
+                              description: IBMAuthContainerAuth defines container-based authentication with IAM Trusted Profile.
+                              properties:
+                                iamEndpoint:
+                                  type: string
+                                profile:
+                                  description: the IBM Trusted Profile
+                                  type: string
+                                tokenLocation:
+                                  description: Location the token is mounted on the pod
+                                  type: string
+                              required:
+                                - profile
+                              type: object
+                            secretRef:
+                              description: IBMAuthSecretRef contains the secret reference for IBM Cloud API key authentication.
+                              properties:
+                                iamEndpoint:
+                                  description: The IAM endpoint used to obain a token
+                                  type: string
+                                secretApiKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        serviceUrl:
+                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    infisical:
+                      description: Infisical configures this store to sync secrets using the Infisical provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Infisical API
+                          properties:
+                            awsAuthCredentials:
+                              description: AwsAuthCredentials represents the credentials for AWS authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                              type: object
+                            azureAuthCredentials:
+                              description: AzureAuthCredentials represents the credentials for Azure authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                resource:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                              type: object
+                            gcpIamAuthCredentials:
+                              description: GcpIamAuthCredentials represents the credentials for GCP IAM authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountKeyFilePath:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                                - serviceAccountKeyFilePath
+                              type: object
+                            gcpIdTokenAuthCredentials:
+                              description: GcpIDTokenAuthCredentials represents the credentials for GCP ID token authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                              type: object
+                            jwtAuthCredentials:
+                              description: JwtAuthCredentials represents the credentials for JWT authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                jwt:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                                - jwt
+                              type: object
+                            kubernetesAuthCredentials:
+                              description: KubernetesAuthCredentials represents the credentials for Kubernetes authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountTokenPath:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                              type: object
+                            ldapAuthCredentials:
+                              description: LdapAuthCredentials represents the credentials for LDAP authentication.
+                              properties:
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                ldapPassword:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                ldapUsername:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - identityId
+                                - ldapPassword
+                                - ldapUsername
+                              type: object
+                            ociAuthCredentials:
+                              description: OciAuthCredentials represents the credentials for OCI authentication.
+                              properties:
+                                fingerprint:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                identityId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                privateKey:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                privateKeyPassphrase:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                region:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                tenancyId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                userId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - identityId
+                                - privateKey
+                                - region
+                                - tenancyId
+                                - userId
+                              type: object
+                            tokenAuthCredentials:
+                              description: TokenAuthCredentials represents the credentials for access token-based authentication.
+                              properties:
+                                accessToken:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessToken
+                              type: object
+                            universalAuthCredentials:
+                              description: UniversalAuthCredentials represents the client credentials for universal authentication.
+                              properties:
+                                clientId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - clientId
+                                - clientSecret
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            CABundle is a PEM-encoded CA certificate bundle used to validate
+                            the Infisical server's TLS certificate. Mutually exclusive with CAProvider.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: |-
+                            CAProvider is a reference to a Secret or ConfigMap that contains a CA certificate.
+                            The certificate is used to validate the Infisical server's TLS certificate.
+                            Mutually exclusive with CABundle.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        hostAPI:
+                          default: https://app.infisical.com/api
+                          description: HostAPI specifies the base URL of the Infisical API. If not provided, it defaults to "https://app.infisical.com/api".
+                          type: string
+                        secretsScope:
+                          description: SecretsScope defines the scope of the secrets within the workspace
+                          properties:
+                            environmentSlug:
+                              description: EnvironmentSlug is the required slug identifier for the environment.
+                              type: string
+                            expandSecretReferences:
+                              default: true
+                              description: ExpandSecretReferences indicates whether secret references should be expanded. Defaults to true if not provided.
+                              type: boolean
+                            organizationSlug:
+                              description: |-
+                                OrganizationSlug is the optional slug that identifies the organization that will be used
+                                during authentication. Useful for sub-organization setups
+                              type: string
+                            projectSlug:
+                              description: ProjectSlug is the required slug identifier for the project.
+                              type: string
+                            recursive:
+                              default: false
+                              description: Recursive indicates whether the secrets should be fetched recursively. Defaults to false if not provided.
+                              type: boolean
+                            secretsPath:
+                              default: /
+                              description: SecretsPath specifies the path to the secrets within the workspace. Defaults to "/" if not provided.
+                              type: string
+                          required:
+                            - environmentSlug
+                            - projectSlug
+                          type: object
+                      required:
+                        - auth
+                        - secretsScope
+                      type: object
+                    keepersecurity:
+                      description: KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider
+                      properties:
+                        authRef:
+                          description: |-
+                            SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                            In some instances, `key` is a required field.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        folderID:
+                          type: string
+                        getByTitleFallback:
+                          type: boolean
+                      required:
+                        - authRef
+                        - folderID
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - clientCert
+                                - clientKey
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - bearerToken
+                              type: object
+                          type: object
+                        authRef:
+                          description: A reference to a secret that contains the auth information.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        remoteNamespace:
+                          default: default
+                          description: Remote namespace to fetch the secrets from
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        server:
+                          description: configures the Kubernetes server Address.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                      type: object
+                    nebiusmysterybox:
+                      description: NebiusMysterybox configures this store to sync secrets using NebiusMysterybox provider
+                      properties:
+                        apiDomain:
+                          description: NebiusMysterybox API endpoint
+                          type: string
+                        auth:
+                          description: Auth defines parameters to authenticate in MysteryBox
+                          properties:
+                            serviceAccountCredsSecretRef:
+                              description: |-
+                                ServiceAccountCreds references a Kubernetes Secret key that contains a JSON
+                                document with service account credentials used to get an IAM token.
+
+                                Expected JSON structure:
+                                {
+                                  "subject-credentials": {
+                                    "alg": "RS256",
+                                    "private-key": "-----BEGIN PRIVATE KEY-----\n<private-key>\n-----END PRIVATE KEY-----\n",
+                                    "kid": "<public-key-id>",
+                                    "iss": "<issuer-service-account-id>",
+                                    "sub": "<subject-service-account-id>"
+                                  }
+                                }
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            tokenSecretRef:
+                              description: Token authenticates with Nebius Mysterybox by presenting a token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: either serviceAccountCredsSecretRef or tokenSecretRef must be set
+                              rule: has(self.serviceAccountCredsSecretRef) || has(self.tokenSecretRef)
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate NebiusMysterybox server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - apiDomain
+                        - auth
+                      type: object
+                    ngrok:
+                      description: Ngrok configures this store to sync secrets using the ngrok provider.
+                      properties:
+                        apiUrl:
+                          default: https://api.ngrok.com
+                          description: APIURL is the URL of the ngrok API.
+                          type: string
+                        auth:
+                          description: Auth configures how the ngrok provider authenticates with the ngrok API.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            apiKey:
+                              description: APIKey is the API Key used to authenticate with ngrok. See https://ngrok.com/docs/api/#authentication
+                              properties:
+                                secretRef:
+                                  description: SecretRef is a reference to a secret containing the ngrok API key.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        vault:
+                          description: Vault configures the ngrok vault to sync secrets with.
+                          properties:
+                            name:
+                              description: Name is the name of the ngrok vault to sync secrets with.
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      required:
+                        - auth
+                        - vault
+                      type: object
+                    onboardbase:
+                      description: Onboardbase configures this store to sync secrets using the Onboardbase provider
+                      properties:
+                        apiHost:
+                          default: https://public.onboardbase.com/api/v1/
+                          description: APIHost use this to configure the host url for the API for selfhosted installation, default is https://public.onboardbase.com/api/v1/
+                          type: string
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Onboardbase API
+                          properties:
+                            apiKeyRef:
+                              description: |-
+                                OnboardbaseAPIKey is the APIKey generated by an admin account.
+                                It is used to recognize and authorize access to a project and environment within onboardbase
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            passcodeRef:
+                              description: OnboardbasePasscode is the passcode attached to the API Key
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - apiKeyRef
+                            - passcodeRef
+                          type: object
+                        environment:
+                          default: development
+                          description: Environment is the name of an environmnent within a project to pull the secrets from
+                          type: string
+                        project:
+                          default: development
+                          description: Project is an onboardbase project that the secrets should be pulled from
+                          type: string
+                      required:
+                        - apiHost
+                        - auth
+                        - environment
+                        - project
+                      type: object
+                    onepassword:
+                      description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against OnePassword Connect Server
+                          properties:
+                            secretRef:
+                              description: OnePasswordAuthSecretRef holds secret references for 1Password credentials.
+                              properties:
+                                connectTokenSecretRef:
+                                  description: The ConnectToken is used for authentication to a 1Password Connect Server.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - connectTokenSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        connectHost:
+                          description: ConnectHost defines the OnePassword Connect Server to connect to
+                          type: string
+                        vaults:
+                          additionalProperties:
+                            type: integer
+                          description: Vaults defines which OnePassword vaults to search in which order
+                          type: object
+                      required:
+                        - auth
+                        - connectHost
+                        - vaults
+                      type: object
+                    onepasswordSDK:
+                      description: OnePasswordSDK configures this store to use 1Password's new Go SDK to sync secrets.
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against OnePassword API.
+                          properties:
+                            serviceAccountSecretRef:
+                              description: ServiceAccountSecretRef points to the secret containing the token to access 1Password vault.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - serviceAccountSecretRef
+                          type: object
+                        cache:
+                          description: |-
+                            Cache configures client-side caching for read operations (GetSecret, GetSecretMap).
+                            When enabled, secrets are cached with the specified TTL.
+                            Write operations (PushSecret, DeleteSecret) automatically invalidate relevant cache entries.
+                            If omitted, caching is disabled (default).
+                            cache: {} is a valid option to set.
+                          properties:
+                            maxSize:
+                              default: 100
+                              description: |-
+                                MaxSize is the maximum number of secrets to cache.
+                                When the cache is full, least-recently-used entries are evicted.
+                              minimum: 1
+                              type: integer
+                            ttl:
+                              default: 5m
+                              description: |-
+                                TTL is the time-to-live for cached secrets.
+                                Format: duration string (e.g., "5m", "1h", "30s")
+                              type: string
+                          type: object
+                        integrationInfo:
+                          description: |-
+                            IntegrationInfo specifies the name and version of the integration built using the 1Password Go SDK.
+                            If you don't know which name and version to use, use `DefaultIntegrationName` and `DefaultIntegrationVersion`, respectively.
+                          properties:
+                            name:
+                              default: 1Password SDK
+                              description: Name defaults to "1Password SDK".
+                              type: string
+                            version:
+                              default: v1.0.0
+                              description: Version defaults to "v1.0.0".
+                              type: string
+                          type: object
+                        vault:
+                          description: Vault defines the vault's name or uuid to access. Do NOT add op:// prefix. This will be done automatically.
+                          type: string
+                      required:
+                        - auth
+                        - vault
+                      type: object
+                    openBao:
+                      description: OpenBao configures this store to sync secrets using the OpenBao provider.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the OpenBao server.
+                          properties:
+                            appRole:
+                              description: |-
+                                AppRole authenticates with OpenBao using the [App Role auth mechanism],
+                                with the role and secret stored in a Kubernetes Secret resource.
+
+                                [App Role auth mechanism]: https://openbao.org/docs/auth/approle/
+                              properties:
+                                path:
+                                  default: approle
+                                  description: |-
+                                    Path where the App Role authentication backend is mounted
+                                    in OpenBao, e.g: "approle"
+                                  type: string
+                                roleId:
+                                  description: |-
+                                    RoleID configured in the App Role authentication backend when setting
+                                    up the authentication backend in OpenBao.
+                                  minLength: 1
+                                  type: string
+                                roleRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role ID used
+                                    to authenticate with OpenBao.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role id.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role secret used
+                                    to authenticate with OpenBao.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - secretRef
+                              type: object
+                              x-kubernetes-validations:
+                                - message: exactly one of the fields in [roleId roleRef] must be set
+                                  rule: '[has(self.roleId),has(self.roleRef)].filter(x,x==true).size() == 1'
+                            namespace:
+                              description: |-
+                                Name of the [OpenBao Namespace] to authenticate to. This can be different
+                                than the namespace your secret is in. Namespaces is a set of features
+                                within OpenBao that allows OpenBao environments to support secure
+                                multi-tenancy. e.g: "ns1". This will default to OpenBao.Namespace field
+                                if set, or empty otherwise
+
+                                [OpenBao Namespace]: https://openbao.org/docs/concepts/namespaces/
+                              type: string
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with OpenBao by presenting a token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            userPass:
+                              description: UserPass authenticates with OpenBao by passing a username/password pair
+                              properties:
+                                path:
+                                  default: userpass
+                                  description: |-
+                                    Path where the UserPassword authentication backend is mounted
+                                    in OpenBao, e.g: "userpass"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the user
+                                    used to authenticate with OpenBao using the [UserPass authentication
+                                    method]
+
+                                    [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is a username used to authenticate using the [UserPass
+                                    authentication method]
+
+                                    [UserPass authentication method]: https://openbao.org/docs/auth/userpass/
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exactly one of the fields in [appRole tokenSecretRef userPass] must be set
+                              rule: '[has(self.appRole),has(self.tokenSecretRef),has(self.userPass)].filter(x,x==true).size() == 1'
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate the OpenBao server certificate. If
+                            this and `caProvider` are not set the system root certificates are used
+                            to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: |-
+                            The provider for the CA bundle to use to validate OpenBao server
+                            certificate. If this and `caBundle` are not set the system root
+                            certificates are used to validate the TLS connection.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        namespace:
+                          description: |-
+                            Name of the [OpenBao Namespace]. Namespaces is a set of features within
+                            OpenBao that allows OpenBao environments to support secure multi-tenancy.
+                            e.g: "ns1".
+
+                            [OpenBao Namespace]: https://openbao.org/docs/concepts/namespaces/
+                          type: string
+                        path:
+                          description: |-
+                            Path is the mount path of the OpenBao KV backend endpoint, e.g:
+                            "secret". The v2 KV secret engine version specific "/data" path suffix
+                            for fetching secrets from OpenBao is optional and will be appended
+                            if not present in specified path.
+                          type: string
+                        server:
+                          description: 'Server is the connection address for the OpenBao server, e.g: `https://openbao.example.com:8200`.'
+                          type: string
+                        version:
+                          default: v2
+                          description: |-
+                            Version is the OpenBao KV secret engine version. This can be either "v1" or
+                            "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - server
+                      type: object
+                      x-kubernetes-validations:
+                        - message: at most one of the fields in [caBundle caProvider] may be set
+                          rule: '[has(self.caBundle),has(self.caProvider)].filter(x,x==true).size() <= 1'
+                    oracle:
+                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      properties:
+                        auth:
+                          description: |-
+                            Auth configures how secret-manager authenticates with the Oracle Vault.
+                            If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          properties:
+                            secretRef:
+                              description: SecretRef to pass through sensitive information.
+                              properties:
+                                fingerprint:
+                                  description: Fingerprint is the fingerprint of the API private key.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                privatekey:
+                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - privatekey
+                              type: object
+                            tenancy:
+                              description: Tenancy is the tenancy OCID where user is located.
+                              type: string
+                            user:
+                              description: User is an access OCID specific to the account.
+                              type: string
+                          required:
+                            - secretRef
+                            - tenancy
+                            - user
+                          type: object
+                        compartment:
+                          description: |-
+                            Compartment is the vault compartment OCID.
+                            Required for PushSecret
+                          type: string
+                        encryptionKey:
+                          description: |-
+                            EncryptionKey is the OCID of the encryption key within the vault.
+                            Required for PushSecret
+                          type: string
+                        principalType:
+                          description: |-
+                            The type of principal to use for authentication. If left blank, the Auth struct will
+                            determine the principal type. This optional field must be specified if using
+                            workload identity.
+                          enum:
+                            - ""
+                            - UserPrincipal
+                            - InstancePrincipal
+                            - Workload
+                          type: string
+                        region:
+                          description: Region is the region where vault is located.
+                          type: string
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        vault:
+                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          type: string
+                      required:
+                        - region
+                        - vault
+                      type: object
+                    ovh:
+                      description: OVHcloud configures this store to sync secrets using the OVHcloud provider.
+                      properties:
+                        auth:
+                          description: Authentication method (mtls or token).
+                          properties:
+                            mtls:
+                              description: OvhClientMTLS defines the configuration required to authenticate to OVHcloud's Secret Manager using mTLS.
+                              properties:
+                                caBundle:
+                                  format: byte
+                                  type: string
+                                caProvider:
+                                  description: |-
+                                    CAProvider provides a custom certificate authority for accessing the provider's store.
+                                    The CAProvider points to a Secret or ConfigMap resource that contains a PEM-encoded certificate.
+                                  properties:
+                                    key:
+                                      description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the object located at the provider type.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace the Provider type is in.
+                                        Can only be defined when used in a ClusterSecretStore.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    type:
+                                      description: The type of provider to use such as "Secret", or "ConfigMap".
+                                      enum:
+                                        - Secret
+                                        - ConfigMap
+                                      type: string
+                                  required:
+                                    - name
+                                    - type
+                                  type: object
+                                certSecretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                keySecretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - certSecretRef
+                                - keySecretRef
+                              type: object
+                            token:
+                              description: OvhClientToken defines the configuration required to authenticate to OVHcloud's Secret Manager using a token.
+                              properties:
+                                tokenSecretRef:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - tokenSecretRef
+                              type: object
+                          type: object
+                        casRequired:
+                          description: 'Enables or disables check-and-set (CAS) (default: false).'
+                          type: boolean
+                        okmsTimeout:
+                          default: 30
+                          description: 'Setup a timeout in seconds when requests to the KMS are made (default: 30).'
+                          format: int32
+                          minimum: 1
+                          type: integer
+                        okmsid:
+                          description: specifies the OKMS ID.
+                          type: string
+                        server:
+                          description: specifies the OKMS server endpoint.
+                          type: string
+                      required:
+                        - auth
+                        - okmsid
+                        - server
+                      type: object
+                    passbolt:
+                      description: |-
+                        PassboltProvider provides access to Passbolt secrets manager.
+                        See: https://www.passbolt.com.
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Passbolt Server
+                          properties:
+                            passwordSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            privateKeySecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - passwordSecretRef
+                            - privateKeySecretRef
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate Passbolt server certificate. Only used
+                            if the Host URL is using HTTPS protocol. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Passbolt server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        host:
+                          description: Host defines the Passbolt Server to connect to
+                          type: string
+                      required:
+                        - auth
+                        - host
+                      type: object
+                    passworddepot:
+                      description: PasswordDepotProvider configures a store to sync secrets with a Password Depot instance.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Password Depot instance.
+                          properties:
+                            secretRef:
+                              description: PasswordDepotSecretRef contains the secret reference for Password Depot authentication.
+                              properties:
+                                credentials:
+                                  description: Username / Password is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        database:
+                          description: Database to use as source
+                          type: string
+                        host:
+                          description: URL configures the Password Depot instance URL.
+                          type: string
+                      required:
+                        - auth
+                        - database
+                        - host
+                      type: object
+                    previder:
+                      description: Previder configures this store to sync secrets using the Previder provider
+                      properties:
+                        auth:
+                          description: PreviderAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: PreviderAuthSecretRef holds secret references for Previder Vault credentials.
+                              properties:
+                                accessToken:
+                                  description: The AccessToken is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessToken
+                              type: object
+                          type: object
+                        baseUri:
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    pulumi:
+                      description: Pulumi configures this store to sync secrets using the Pulumi provider
+                      properties:
+                        accessToken:
+                          description: |-
+                            AccessToken is the access tokens to sign in to the Pulumi Cloud Console.
+
+                            Deprecated: Use auth.accessToken instead.
+                          properties:
+                            secretRef:
+                              description: SecretRef is a reference to a secret containing the Pulumi API token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        apiUrl:
+                          default: https://api.pulumi.com/api/esc
+                          description: APIURL is the URL of the Pulumi API.
+                          type: string
+                        auth:
+                          description: |-
+                            Auth configures how the Operator authenticates with the Pulumi API.
+                            Either auth or the deprecated accessToken field must be specified.
+                          properties:
+                            accessToken:
+                              description: AccessToken authenticates using a Pulumi access token stored in a Kubernetes Secret.
+                              properties:
+                                secretRef:
+                                  description: SecretRef is a reference to a secret containing the Pulumi API token.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            oidcConfig:
+                              description: OIDCConfig authenticates using Kubernetes ServiceAccount tokens via OIDC.
+                              properties:
+                                expirationSeconds:
+                                  default: 600
+                                  description: |-
+                                    ExpirationSeconds sets the token validity duration for service account and OIDC token.
+                                    Defaults to 10 minutes.
+                                  format: int64
+                                  minimum: 600
+                                  type: integer
+                                organization:
+                                  description: Organization is the name of the Pulumi organization configured for OIDC authentication.
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountRef specifies the Kubernetes ServiceAccount to use for authentication.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - organization
+                                - serviceAccountRef
+                              type: object
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Exactly one of 'accessToken' or 'oidcConfig' must be specified
+                              rule: (has(self.accessToken) && !has(self.oidcConfig)) || (!has(self.accessToken) && has(self.oidcConfig))
+                        environment:
+                          description: |-
+                            Environment are YAML documents composed of static key-value pairs, programmatic expressions,
+                            dynamically retrieved values from supported providers including all major clouds,
+                            and other Pulumi ESC environments.
+                            To create a new environment, visit https://www.pulumi.com/docs/esc/environments/ for more information.
+                          type: string
+                        organization:
+                          description: |-
+                            Organization are a space to collaborate on shared projects and stacks.
+                            To create a new organization, visit https://app.pulumi.com/ and click "New Organization".
+                          type: string
+                        project:
+                          description: Project is the name of the Pulumi ESC project the environment belongs to.
+                          type: string
+                      required:
+                        - environment
+                        - organization
+                        - project
+                      type: object
+                      x-kubernetes-validations:
+                        - message: Exactly one of 'auth' or deprecated 'accessToken' must be specified
+                          rule: (has(self.auth) && !has(self.accessToken)) || (!has(self.auth) && has(self.accessToken))
+                    scaleway:
+                      description: Scaleway configures this store to sync secrets using the Scaleway provider.
+                      properties:
+                        accessKey:
+                          description: AccessKey is the non-secret part of the api key.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        apiUrl:
+                          description: APIURL is the url of the api to use. Defaults to https://api.scaleway.com
+                          type: string
+                        projectId:
+                          description: 'ProjectID is the id of your project, which you can find in the console: https://console.scaleway.com/project/settings'
+                          type: string
+                        region:
+                          description: 'Region where your secrets are located: https://developers.scaleway.com/en/quickstart/#region-and-zone'
+                          type: string
+                        secretKey:
+                          description: SecretKey is the non-secret part of the api key.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                      required:
+                        - accessKey
+                        - projectId
+                        - region
+                        - secretKey
+                      type: object
+                    secretserver:
+                      description: |-
+                        SecretServer configures this store to sync secrets using SecretServer provider
+                        https://docs.delinea.com/online-help/secret-server/start.htm
+                      properties:
+                        caBundle:
+                          description: |-
+                            PEM/base64 encoded CA bundle used to validate Secret ServerURL. Only used
+                            if the ServerURL URL is using HTTPS protocol. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Secret ServerURL certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        domain:
+                          description: Domain is the secret server domain.
+                          type: string
+                        password:
+                          description: |-
+                            Password is the secret server account password.
+                            Required unless Token is set.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              minLength: 1
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exactly one of value or secretRef must be set
+                              rule: has(self.value) != has(self.secretRef)
+                        serverURL:
+                          description: |-
+                            ServerURL
+                            URL to your secret server installation
+                          type: string
+                        token:
+                          description: |-
+                            Token is an access token used to authenticate to the secret server,
+                            as an alternative to Username and Password. When set, Username and
+                            Password are not required and are ignored.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              minLength: 1
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exactly one of value or secretRef must be set
+                              rule: has(self.value) != has(self.secretRef)
+                        username:
+                          description: |-
+                            Username is the secret server account username.
+                            Required unless Token is set.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              minLength: 1
+                              type: string
+                          type: object
+                          x-kubernetes-validations:
+                            - message: exactly one of value or secretRef must be set
+                              rule: has(self.value) != has(self.secretRef)
+                      required:
+                        - serverURL
+                      type: object
+                      x-kubernetes-validations:
+                        - message: either token, or both username and password, must be set
+                          rule: has(self.token) || (has(self.username) && has(self.password))
+                    senhasegura:
+                      description: Senhasegura configures this store to sync secrets using senhasegura provider
+                      properties:
+                        auth:
+                          description: Auth defines parameters to authenticate in senhasegura
+                          properties:
+                            clientId:
+                              type: string
+                            clientSecretSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - clientId
+                            - clientSecretSecretRef
+                          type: object
+                        ignoreSslCertificate:
+                          default: false
+                          description: IgnoreSslCertificate defines if SSL certificate must be ignored
+                          type: boolean
+                        module:
+                          description: Module defines which senhasegura module should be used to get secrets
+                          type: string
+                        url:
+                          description: URL of senhasegura
+                          type: string
+                      required:
+                        - auth
+                        - module
+                        - url
+                      type: object
+                    vault:
+                      description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          properties:
+                            appRole:
+                              description: |-
+                                AppRole authenticates with Vault using the App Role auth mechanism,
+                                with the role and secret stored in a Kubernetes Secret resource.
+                              properties:
+                                path:
+                                  default: approle
+                                  description: |-
+                                    Path where the App Role authentication backend is mounted
+                                    in Vault, e.g: "approle"
+                                  type: string
+                                roleId:
+                                  description: |-
+                                    RoleID configured in the App Role authentication backend when setting
+                                    up the authentication backend in Vault.
+                                  type: string
+                                roleRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role ID used
+                                    to authenticate with Vault.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role id.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role secret used
+                                    to authenticate with Vault.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - secretRef
+                              type: object
+                            cert:
+                              description: |-
+                                Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate
+                                Cert authentication method
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    ClientCert is a certificate to authenticate using the Cert Vault
+                                    authentication method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                path:
+                                  default: cert
+                                  description: |-
+                                    Path where the Certificate authentication backend is mounted
+                                    in Vault, e.g: "cert"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing client private key to
+                                    authenticate with Vault using the Cert authentication method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                vaultRole:
+                                  description: VaultRole specifies the Vault role to use for TLS certificate authentication.
+                                  type: string
+                              type: object
+                            gcp:
+                              description: |-
+                                Gcp authenticates with Vault using Google Cloud Platform authentication method
+                                GCP authentication method
+                              properties:
+                                location:
+                                  description: Location optionally defines a location/region for the secret
+                                  type: string
+                                path:
+                                  default: gcp
+                                  description: 'Path where the GCP auth method is enabled in Vault, e.g: "gcp"'
+                                  type: string
+                                projectID:
+                                  description: Project ID of the Google Cloud Platform project
+                                  type: string
+                                role:
+                                  description: Vault Role. In Vault, a role describes an identity with a set of permissions, groups, or policies you want to attach to a user of the secrets engine.
+                                  type: string
+                                secretRef:
+                                  description: Specify credentials in a Secret object
+                                  properties:
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  type: object
+                                serviceAccountRef:
+                                  description: ServiceAccountRef to a service account for impersonation
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                workloadIdentity:
+                                  description: Specify a service account with Workload Identity
+                                  properties:
+                                    clusterLocation:
+                                      description: |-
+                                        ClusterLocation is the location of the cluster
+                                        If not specified, it fetches information from the metadata server
+                                      type: string
+                                    clusterName:
+                                      description: |-
+                                        ClusterName is the name of the cluster
+                                        If not specified, it fetches information from the metadata server
+                                      type: string
+                                    clusterProjectID:
+                                      description: |-
+                                        ClusterProjectID is the project ID of the cluster
+                                        If not specified, it fetches information from the metadata server
+                                      type: string
+                                    serviceAccountRef:
+                                      description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                              required:
+                                - role
+                              type: object
+                            iam:
+                              description: |-
+                                Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials
+                                AWS IAM authentication method
+                              properties:
+                                externalID:
+                                  description: AWS External ID set on assumed IAM roles
+                                  type: string
+                                jwt:
+                                  description: Specify a service account with IRSA enabled
+                                  properties:
+                                    serviceAccountRef:
+                                      description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  type: object
+                                path:
+                                  description: 'Path where the AWS auth method is enabled in Vault, e.g: "aws"'
+                                  type: string
+                                region:
+                                  description: AWS region
+                                  type: string
+                                role:
+                                  description: This is the AWS role to be assumed before talking to vault
+                                  type: string
+                                secretRef:
+                                  description: Specify credentials in a Secret object
+                                  properties:
+                                    accessKeyIDSecretRef:
+                                      description: The AccessKeyID is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    sessionTokenSecretRef:
+                                      description: |-
+                                        The SessionToken used for authentication
+                                        This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                        see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  type: object
+                                vaultAwsIamServerID:
+                                  description: 'X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws'
+                                  type: string
+                                vaultRole:
+                                  description: Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine
+                                  type: string
+                              required:
+                                - vaultRole
+                              type: object
+                            jwt:
+                              description: |-
+                                Jwt authenticates with Vault by passing role and JWT token using the
+                                JWT/OIDC authentication method
+                              properties:
+                                kubernetesServiceAccountToken:
+                                  description: |-
+                                    Optional ServiceAccountToken specifies the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Optional audiences field that will be used to request a temporary Kubernetes service
+                                        account token for the service account referenced by `serviceAccountRef`.
+                                        Defaults to a single audience `vault` it not specified.
+
+                                        Deprecated: use serviceAccountRef.Audiences instead
+                                      items:
+                                        type: string
+                                      type: array
+                                    expirationSeconds:
+                                      description: |-
+                                        Optional expiration time in seconds that will be used to request a temporary
+                                        Kubernetes service account token for the service account referenced by
+                                        `serviceAccountRef`.
+
+                                        Deprecated: this will be removed in the future.
+                                        Defaults to 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    serviceAccountRef:
+                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                                path:
+                                  default: jwt
+                                  description: |-
+                                    Path where the JWT authentication backend is mounted
+                                    in Vault, e.g: "jwt"
+                                  type: string
+                                role:
+                                  description: |-
+                                    Role is a JWT role to authenticate using the JWT/OIDC Vault
+                                    authentication method
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                    authenticate with Vault using the JWT/OIDC authentication method.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                              type: object
+                            kubernetes:
+                              description: |-
+                                Kubernetes authenticates with Vault by passing the ServiceAccount
+                                token stored in the named Secret resource to the Vault server.
+                              properties:
+                                mountPath:
+                                  default: kubernetes
+                                  description: |-
+                                    Path where the Kubernetes authentication backend is mounted in Vault, e.g:
+                                    "kubernetes"
+                                  type: string
+                                role:
+                                  description: |-
+                                    A required field containing the Vault Role to assume. A Role binds a
+                                    Kubernetes ServiceAccount with a set of Vault policies.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                    for authenticating with Vault. If a name is specified without a key,
+                                    `token` is the default. If one is not specified, the one bound to
+                                    the controller will be used.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional service account field containing the name of a kubernetes ServiceAccount.
+                                    If the service account is specified, the service account secret token JWT will be used
+                                    for authenticating with Vault. If the service account selector is not supplied,
+                                    the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - mountPath
+                                - role
+                              type: object
+                            ldap:
+                              description: |-
+                                Ldap authenticates with Vault by passing username/password pair using
+                                the LDAP authentication method
+                              properties:
+                                path:
+                                  default: ldap
+                                  description: |-
+                                    Path where the LDAP authentication backend is mounted
+                                    in Vault, e.g: "ldap"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the LDAP
+                                    user used to authenticate with Vault using the LDAP authentication
+                                    method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is an LDAP username used to authenticate using the LDAP Vault
+                                    authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                            namespace:
+                              description: |-
+                                Name of the vault namespace to authenticate to. This can be different than the namespace your secret is in.
+                                Namespaces is a set of features within Vault Enterprise that allows
+                                Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                                More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                                This will default to Vault.Namespace field if set, or empty otherwise
+                              type: string
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            userPass:
+                              description: UserPass authenticates with Vault by passing username/password pair
+                              properties:
+                                path:
+                                  default: userpass
+                                  description: |-
+                                    Path where the UserPassword authentication backend is mounted
+                                    in Vault, e.g: "userpass"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the
+                                    user used to authenticate with Vault using the UserPass authentication
+                                    method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is a username used to authenticate using the UserPass Vault
+                                    authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate Vault server certificate. Only used
+                            if the Server URL is using HTTPS protocol. This parameter is ignored for
+                            plain HTTP protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        checkAndSet:
+                          description: |-
+                            CheckAndSet defines the Check-And-Set (CAS) settings for PushSecret operations.
+                            Only applies to Vault KV v2 stores. When enabled, write operations must include
+                            the current version of the secret to prevent unintentional overwrites.
+                          properties:
+                            required:
+                              description: |-
+                                Required when true, all write operations must include a check-and-set parameter.
+                                This helps prevent unintentional overwrites of secrets.
+                              type: boolean
+                          type: object
+                        forwardInconsistent:
+                          description: |-
+                            ForwardInconsistent tells Vault to forward read-after-write requests to the Vault
+                            leader instead of simply retrying within a loop. This can increase performance if
+                            the option is enabled serverside.
+                            https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          type: boolean
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers to be added in Vault request
+                          type: object
+                        namespace:
+                          description: |-
+                            Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
+                            Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                            More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                          type: string
+                        path:
+                          description: |-
+                            Path is the mount path of the Vault KV backend endpoint, e.g:
+                            "secret". The v2 KV secret engine version specific "/data" path suffix
+                            for fetching secrets from Vault is optional and will be appended
+                            if not present in specified path.
+                          type: string
+                        readYourWrites:
+                          description: |-
+                            ReadYourWrites ensures isolated read-after-write semantics by
+                            providing discovered cluster replication states in each request.
+                            More information about eventual consistency in Vault can be found here
+                            https://www.vaultproject.io/docs/enterprise/consistency
+                          type: boolean
+                        server:
+                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          type: string
+                        tls:
+                          description: |-
+                            The configuration used for client side related TLS communication, when the Vault server
+                            requires mutual authentication. Only used if the Server URL is using HTTPS protocol.
+                            This parameter is ignored for plain HTTP protocol connection.
+                            It's worth noting this configuration is different from the "TLS certificates auth method",
+                            which is available under the `auth.cert` section.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                CertSecretRef is a certificate added to the transport layer
+                                when communicating with the Vault server.
+                                If no key for the Secret is specified, external-secret will default to 'tls.crt'.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            keySecretRef:
+                              description: |-
+                                KeySecretRef to a key in a Secret resource containing client private key
+                                added to the transport layer when communicating with the Vault server.
+                                If no key for the Secret is specified, external-secret will default to 'tls.key'.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        version:
+                          default: v2
+                          description: |-
+                            Version is the Vault KV secret engine version. This can be either "v1" or
+                            "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - server
+                      type: object
+                    volcengine:
+                      description: Volcengine configures this store to sync secrets using the Volcengine provider
+                      properties:
+                        auth:
+                          description: |-
+                            Auth defines the authentication method to use.
+                            If not specified, the provider will try to use IRSA (IAM Role for Service Account).
+                          properties:
+                            secretRef:
+                              description: |-
+                                SecretRef defines the static credentials to use for authentication.
+                                If not set, IRSA is used.
+                              properties:
+                                accessKeyID:
+                                  description: AccessKeyID is the reference to the secret containing the Access Key ID.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretAccessKey:
+                                  description: SecretAccessKey is the reference to the secret containing the Secret Access Key.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                token:
+                                  description: Token is the reference to the secret containing the STS(Security Token Service) Token.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyID
+                                - secretAccessKey
+                              type: object
+                          type: object
+                        region:
+                          description: Region specifies the Volcengine region to connect to.
+                          type: string
+                      required:
+                        - region
+                      type: object
+                    webhook:
+                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      properties:
+                        auth:
+                          description: Auth specifies a authorization protocol. Only one protocol may be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            ntlm:
+                              description: NTLMProtocol configures the store to use NTLM for auth
+                              properties:
+                                passwordSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                usernameSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - passwordSecret
+                                - usernameSecret
+                              type: object
+                          type: object
+                        body:
+                          description: Body
+                          type: string
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate webhook server certificate. Only used
+                            if the Server URL is using HTTPS protocol. This parameter is ignored for
+                            plain HTTP protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers
+                          type: object
+                        method:
+                          description: Webhook Method
+                          type: string
+                        result:
+                          description: Result formatting
+                          properties:
+                            jsonPath:
+                              description: Json path of return value
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets to fill in templates
+                            These secrets will be passed to the templating function as key value pairs under the given name
+                          items:
+                            description: WebhookSecret defines a secret that will be passed to the webhook request.
+                            properties:
+                              name:
+                                description: Name of this secret in templates
+                                type: string
+                              secretRef:
+                                description: Secret ref to fill in credentials
+                                properties:
+                                  key:
+                                    description: |-
+                                      A key in the referenced Secret.
+                                      Some instances of this field may be defaulted, in others it may be required.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[-._a-zA-Z0-9]+$
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being referred to.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      The namespace of the Secret resource being referred to.
+                                      Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                type: object
+                            required:
+                              - name
+                              - secretRef
+                            type: object
+                          type: array
+                        timeout:
+                          description: Timeout
+                          type: string
+                        url:
+                          description: Webhook url to call
+                          type: string
+                      required:
+                        - url
+                      type: object
+                    yandexcertificatemanager:
+                      description: YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex.Cloud
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        fetching:
+                          description: FetchingPolicy configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as certificate ID or certificate name
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            byID:
+                              description: ByID configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret ID.
+                              type: object
+                            byName:
+                              description: ByName configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret name.
+                              properties:
+                                folderID:
+                                  description: The folder to fetch secrets from
+                                  type: string
+                              required:
+                                - folderID
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    yandexlockbox:
+                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex.Cloud
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        fetching:
+                          description: FetchingPolicy configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret ID or secret name
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            byID:
+                              description: ByID configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret ID.
+                              type: object
+                            byName:
+                              description: ByName configures the provider to interpret the `data.secretKey.remoteRef.key` field in ExternalSecret as secret name.
+                              properties:
+                                folderID:
+                                  description: The folder to fetch secrets from
+                                  type: string
+                              required:
+                                - folderID
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                  type: object
+                refreshInterval:
+                  anyOf:
+                    - type: integer
+                    - type: string
+                  description: |-
+                    Used to configure store refresh interval. Accepts either an integer number
+                    of seconds (legacy) or a Go duration string such as "1h" or "5m". Empty or
+                    0 will default to the controller config.
+                  x-kubernetes-int-or-string: true
+                retrySettings:
+                  description: Used to configure HTTP retries on failures.
+                  properties:
+                    maxRetries:
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      type: string
+                  type: object
+              required:
+                - provider
+              type: object
+            status:
+              description: SecretStoreStatus defines the observed state of the SecretStore.
+              properties:
+                capabilities:
+                  description: SecretStoreCapabilities defines the possible operations a SecretStore can do.
+                  type: string
+                conditions:
+                  items:
+                    description: SecretStoreStatusCondition contains condition information for a SecretStore.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: SecretStoreConditionType represents the condition of the SecretStore.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: AGE
+          type: date
+        - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+          name: Status
+          type: string
+        - jsonPath: .status.capabilities
+          name: Capabilities
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Ready")].status
+          name: Ready
+          type: string
+      deprecated: true
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: SecretStore represents a secure external location for storing secrets, which can be referenced as part of `storeRef` fields.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SecretStoreSpec defines the desired state of SecretStore.
+              properties:
+                conditions:
+                  description: Used to constrain a ClusterSecretStore to specific namespaces. Relevant only to ClusterSecretStore.
+                  items:
+                    description: |-
+                      ClusterSecretStoreCondition describes a condition by which to choose namespaces to process ExternalSecrets in
+                      for a ClusterSecretStore instance.
+                    properties:
+                      namespaceRegexes:
+                        description: Choose namespaces by using regex matching
+                        items:
+                          type: string
+                        type: array
+                      namespaceSelector:
+                        description: Choose namespace using a labelSelector
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      namespaces:
+                        description: Choose namespaces by name
+                        items:
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                controller:
+                  description: |-
+                    Used to select the correct ESO controller (think: ingress.ingressClassName)
+                    The ESO controller is instantiated with a specific controller name and filters ES based on this property
+                  type: string
+                provider:
+                  description: Used to configure the provider. Only one provider may be set
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    akeyless:
+                      description: Akeyless configures this store to sync secrets using Akeyless Vault provider
+                      properties:
+                        akeylessGWApiURL:
+                          description: Akeyless GW API Url from which the secrets to be fetched from.
+                          type: string
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Akeyless.
+                          properties:
+                            kubernetesAuth:
+                              description: |-
+                                Kubernetes authenticates with Akeyless by passing the ServiceAccount
+                                token stored in the named Secret resource.
+                              properties:
+                                accessID:
+                                  description: the Akeyless Kubernetes auth-method access-id
+                                  type: string
+                                k8sConfName:
+                                  description: Kubernetes-auth configuration name in Akeyless-Gateway
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                    for authenticating with Akeyless. If a name is specified without a key,
+                                    `token` is the default. If one is not specified, the one bound to
+                                    the controller will be used.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional service account field containing the name of a kubernetes ServiceAccount.
+                                    If the service account is specified, the service account secret token JWT will be used
+                                    for authenticating with Akeyless. If the service account selector is not supplied,
+                                    the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - accessID
+                                - k8sConfName
+                              type: object
+                            secretRef:
+                              description: |-
+                                Reference to a Secret that contains the details
+                                to authenticate with Akeyless.
+                              properties:
+                                accessID:
+                                  description: The SecretAccessID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessType:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessTypeParam:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM/base64 encoded CA bundle used to validate Akeyless Gateway certificate. Only used
+                            if the AkeylessGWApiURL URL is using HTTPS protocol. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Akeyless Gateway certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                      required:
+                        - akeylessGWApiURL
+                        - authSecretRef
+                      type: object
+                    alibaba:
+                      description: Alibaba configures this store to sync secrets using Alibaba Cloud provider
+                      properties:
+                        auth:
+                          description: AlibabaAuth contains a secretRef for credentials.
+                          properties:
+                            rrsa:
+                              description: AlibabaRRSAAuth authenticates against Alibaba using RRSA (Resource-oriented RAM-based Service Authentication).
+                              properties:
+                                oidcProviderArn:
+                                  type: string
+                                oidcTokenFilePath:
+                                  type: string
+                                roleArn:
+                                  type: string
+                                sessionName:
+                                  type: string
+                              required:
+                                - oidcProviderArn
+                                - oidcTokenFilePath
+                                - roleArn
+                                - sessionName
+                              type: object
+                            secretRef:
+                              description: AlibabaAuthSecretRef holds secret references for Alibaba credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          type: object
+                        regionID:
+                          description: Alibaba Region to be used for the provider
+                          type: string
+                      required:
+                        - auth
+                        - regionID
+                      type: object
+                    aws:
+                      description: AWS configures this store to sync secrets using AWS Secret Manager provider
+                      properties:
+                        additionalRoles:
+                          description: AdditionalRoles is a chained list of Role ARNs which the provider will sequentially assume before assuming the Role
+                          items:
+                            type: string
+                          type: array
+                        auth:
+                          description: |-
+                            Auth defines the information necessary to authenticate against AWS
+                            if not set aws sdk will infer credentials from your environment
+                            see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
+                          properties:
+                            jwt:
+                              description: AWSJWTAuth authenticates against AWS using service account tokens from the Kubernetes cluster.
+                              properties:
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            secretRef:
+                              description: |-
+                                AWSAuthSecretRef holds secret references for AWS credentials
+                                both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                sessionTokenSecretRef:
+                                  description: |-
+                                    The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                    see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        externalID:
+                          description: AWS External ID set on assumed IAM roles
+                          type: string
+                        prefix:
+                          description: Prefix adds a prefix to all retrieved values.
+                          type: string
+                        region:
+                          description: AWS Region to be used for the provider
+                          type: string
+                        role:
+                          description: Role is a Role ARN which the provider will assume
+                          type: string
+                        secretsManager:
+                          description: SecretsManager defines how the provider behaves when interacting with AWS SecretsManager
+                          properties:
+                            forceDeleteWithoutRecovery:
+                              description: |-
+                                Specifies whether to delete the secret without any recovery window. You
+                                can't use both this parameter and RecoveryWindowInDays in the same call.
+                                If you don't use either, then by default Secrets Manager uses a 30 day
+                                recovery window.
+                                see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-ForceDeleteWithoutRecovery
+                              type: boolean
+                            recoveryWindowInDays:
+                              description: |-
+                                The number of days from 7 to 30 that Secrets Manager waits before
+                                permanently deleting the secret. You can't use both this parameter and
+                                ForceDeleteWithoutRecovery in the same call. If you don't use either,
+                                then by default Secrets Manager uses a 30 day recovery window.
+                                see: https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_DeleteSecret.html#SecretsManager-DeleteSecret-request-RecoveryWindowInDays
+                              format: int64
+                              type: integer
+                          type: object
+                        service:
+                          description: Service defines which service should be used to fetch the secrets
+                          enum:
+                            - SecretsManager
+                            - ParameterStore
+                          type: string
+                        sessionTags:
+                          description: AWS STS assume role session tags
+                          items:
+                            description: Tag defines a tag key and value for AWS resources.
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          type: array
+                        transitiveTagKeys:
+                          description: AWS STS assume role transitive session tags. Required when multiple rules are used with the provider
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - region
+                        - service
+                      type: object
+                    azurekv:
+                      description: AzureKV configures this store to sync secrets using Azure Key Vault provider
+                      properties:
+                        authSecretRef:
+                          description: Auth configures how the operator authenticates with Azure. Required for ServicePrincipal auth type. Optional for WorkloadIdentity.
+                          properties:
+                            clientCertificate:
+                              description: The Azure ClientCertificate of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            clientId:
+                              description: The Azure clientId of the service principle or managed identity used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: The Azure ClientSecret of the service principle used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            tenantId:
+                              description: The Azure tenantId of the managed identity used for authentication.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        authType:
+                          default: ServicePrincipal
+                          description: |-
+                            Auth type defines how to authenticate to the keyvault service.
+                            Valid values are:
+                            - "ServicePrincipal" (default): Using a service principal (tenantId, clientId, clientSecret)
+                            - "ManagedIdentity": Using Managed Identity assigned to the pod (see aad-pod-identity)
+                          enum:
+                            - ServicePrincipal
+                            - ManagedIdentity
+                            - WorkloadIdentity
+                          type: string
+                        environmentType:
+                          default: PublicCloud
+                          description: |-
+                            EnvironmentType specifies the Azure cloud environment endpoints to use for
+                            connecting and authenticating with Azure. By default it points to the public cloud AAD endpoint.
+                            The following endpoints are available, also see here: https://github.com/Azure/go-autorest/blob/main/autorest/azure/environments.go#L152
+                            PublicCloud, USGovernmentCloud, ChinaCloud, GermanCloud
+                          enum:
+                            - PublicCloud
+                            - USGovernmentCloud
+                            - ChinaCloud
+                            - GermanCloud
+                          type: string
+                        identityId:
+                          description: If multiple Managed Identity is assigned to the pod, you can select the one to be used
+                          type: string
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        tenantId:
+                          description: TenantID configures the Azure Tenant to send requests to. Required for ServicePrincipal auth type. Optional for WorkloadIdentity.
+                          type: string
+                        vaultUrl:
+                          description: Vault Url from which the secrets to be fetched from.
+                          type: string
+                      required:
+                        - vaultUrl
+                      type: object
+                    beyondtrust:
+                      description: Beyondtrust configures this store to sync secrets using Password Safe provider.
+                      properties:
+                        auth:
+                          description: Auth configures how the operator authenticates with Beyondtrust.
+                          properties:
+                            apiKey:
+                              description: APIKey If not provided then ClientID/ClientSecret become required.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            certificate:
+                              description: Certificate (cert.pem) for use when authenticating with an OAuth client Id using a Client Certificate.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            certificateKey:
+                              description: Certificate private key (key.pem). For use when authenticating with an OAuth client Id
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            clientId:
+                              description: ClientID is the API OAuth Client ID.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                            clientSecret:
+                              description: ClientSecret is the API OAuth Client Secret.
+                              properties:
+                                secretRef:
+                                  description: SecretRef references a key in a secret that will be used as value.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                value:
+                                  description: Value can be specified directly to set a value without using a secret.
+                                  type: string
+                              type: object
+                          type: object
+                        server:
+                          description: Auth configures how API server works.
+                          properties:
+                            apiUrl:
+                              type: string
+                            apiVersion:
+                              type: string
+                            clientTimeOutSeconds:
+                              description: Timeout specifies a time limit for requests made by this Client. The timeout includes connection time, any redirects, and reading the response body. Defaults to 45 seconds.
+                              type: integer
+                            decrypt:
+                              default: true
+                              description: 'When true, the response includes the decrypted password. When false, the password field is omitted. This option only applies to the SECRET retrieval type. Default: true.'
+                              type: boolean
+                            retrievalType:
+                              description: The secret retrieval type. SECRET = Secrets Safe (credential, text, file). MANAGED_ACCOUNT = Password Safe account associated with a system.
+                              type: string
+                            separator:
+                              description: A character that separates the folder names.
+                              type: string
+                            verifyCA:
+                              type: boolean
+                          required:
+                            - apiUrl
+                            - verifyCA
+                          type: object
+                      required:
+                        - auth
+                        - server
+                      type: object
+                    bitwardensecretsmanager:
+                      description: BitwardenSecretsManager configures this store to sync secrets using BitwardenSecretsManager provider
+                      properties:
+                        apiURL:
+                          type: string
+                        auth:
+                          description: |-
+                            Auth configures how secret-manager authenticates with a bitwarden machine account instance.
+                            Make sure that the token being used has permissions on the given secret.
+                          properties:
+                            secretRef:
+                              description: BitwardenSecretsManagerSecretRef contains the credential ref to the bitwarden instance.
+                              properties:
+                                credentials:
+                                  description: AccessToken used for the bitwarden instance.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - credentials
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        bitwardenServerSDKURL:
+                          type: string
+                        caBundle:
+                          description: |-
+                            Base64 encoded certificate for the bitwarden server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                            can be performed.
+                          type: string
+                        caProvider:
+                          description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        identityURL:
+                          type: string
+                        organizationID:
+                          description: OrganizationID determines which organization this secret store manages.
+                          type: string
+                        projectID:
+                          description: ProjectID determines which project this secret store manages.
+                          type: string
+                      required:
+                        - auth
+                        - organizationID
+                        - projectID
+                      type: object
+                    chef:
+                      description: Chef configures this store to sync secrets with chef server
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against chef Server
+                          properties:
+                            secretRef:
+                              description: ChefAuthSecretRef holds secret references for chef server login credentials.
+                              properties:
+                                privateKeySecretRef:
+                                  description: SecretKey is the Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - privateKeySecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        serverUrl:
+                          description: ServerURL is the chef server URL used to connect to. If using orgs you should include your org in the url and terminate the url with a "/"
+                          type: string
+                        username:
+                          description: UserName should be the user ID on the chef server
+                          type: string
+                      required:
+                        - auth
+                        - serverUrl
+                        - username
+                      type: object
+                    cloudrusm:
+                      description: CloudruSM configures this store to sync secrets using the Cloud.ru Secret Manager provider
+                      properties:
+                        auth:
+                          description: CSMAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: CSMAuthSecretRef holds secret references for Cloud.ru credentials.
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                accessKeySecretSecretRef:
+                                  description: The AccessKeySecret is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessKeyIDSecretRef
+                                - accessKeySecretSecretRef
+                              type: object
+                          type: object
+                        projectID:
+                          description: ProjectID is the project, which the secrets are stored in.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    conjur:
+                      description: Conjur configures this store to sync secrets using conjur provider
+                      properties:
+                        auth:
+                          description: Defines authentication settings for connecting to Conjur.
+                          properties:
+                            apikey:
+                              description: Authenticates with Conjur using an API key.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                apiKeyRef:
+                                  description: |-
+                                    A reference to a specific 'key' containing the Conjur API key
+                                    within a Secret resource. In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                userRef:
+                                  description: |-
+                                    A reference to a specific 'key' containing the Conjur username
+                                    within a Secret resource. In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - account
+                                - apiKeyRef
+                                - userRef
+                              type: object
+                            jwt:
+                              description: Jwt enables JWT authentication using Kubernetes service account tokens.
+                              properties:
+                                account:
+                                  description: Account is the Conjur organization account name.
+                                  type: string
+                                hostId:
+                                  description: |-
+                                    Optional HostID for JWT authentication. This may be used depending
+                                    on how the Conjur JWT authenticator policy is configured.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                    authenticate with Conjur using the JWT authentication method.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional ServiceAccountRef specifies the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                serviceID:
+                                  description: The conjur authn jwt webservice id
+                                  type: string
+                              required:
+                                - account
+                                - serviceID
+                              type: object
+                          type: object
+                        caBundle:
+                          description: CABundle is a PEM encoded CA bundle that will be used to validate the Conjur server certificate.
+                          type: string
+                        caProvider:
+                          description: |-
+                            Used to provide custom certificate authority (CA) certificates
+                            for a secret store. The CAProvider points to a Secret or ConfigMap resource
+                            that contains a PEM-encoded certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        url:
+                          description: URL is the endpoint of the Conjur instance.
+                          type: string
+                      required:
+                        - auth
+                        - url
+                      type: object
+                    delinea:
+                      description: |-
+                        Delinea DevOps Secrets Vault
+                        https://docs.delinea.com/online-help/products/devops-secrets-vault/current
+                      properties:
+                        clientId:
+                          description: ClientID is the non-secret part of the credential.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        clientSecret:
+                          description: ClientSecret is the secret part of the credential.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        tenant:
+                          description: Tenant is the chosen hostname / site name.
+                          type: string
+                        tld:
+                          description: |-
+                            TLD is based on the server location that was chosen during provisioning.
+                            If unset, defaults to "com".
+                          type: string
+                        urlTemplate:
+                          description: |-
+                            URLTemplate
+                            If unset, defaults to "https://%s.secretsvaultcloud.%s/v1/%s%s".
+                          type: string
+                      required:
+                        - clientId
+                        - clientSecret
+                        - tenant
+                      type: object
+                    device42:
+                      description: Device42 configures this store to sync secrets using the Device42 provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Device42 instance.
+                          properties:
+                            secretRef:
+                              description: Device42SecretRef defines a reference to a secret containing credentials for the Device42 provider.
+                              properties:
+                                credentials:
+                                  description: Username / Password is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        host:
+                          description: URL configures the Device42 instance URL.
+                          type: string
+                      required:
+                        - auth
+                        - host
+                      type: object
+                    doppler:
+                      description: Doppler configures this store to sync secrets using the Doppler provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Doppler API
+                          properties:
+                            secretRef:
+                              description: DopplerAuthSecretRef defines a reference to a secret containing credentials for the Doppler provider.
+                              properties:
+                                dopplerToken:
+                                  description: |-
+                                    The DopplerToken is used for authentication.
+                                    See https://docs.doppler.com/reference/api#authentication for auth token types.
+                                    The Key attribute defaults to dopplerToken if not specified.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - dopplerToken
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        config:
+                          description: Doppler config (required if not using a Service Token)
+                          type: string
+                        format:
+                          description: Format enables the downloading of secrets as a file (string)
+                          enum:
+                            - json
+                            - dotnet-json
+                            - env
+                            - yaml
+                            - docker
+                          type: string
+                        nameTransformer:
+                          description: Environment variable compatible name transforms that change secret names to a different format
+                          enum:
+                            - upper-camel
+                            - camel
+                            - lower-snake
+                            - tf-var
+                            - dotnet-env
+                            - lower-kebab
+                          type: string
+                        project:
+                          description: Doppler project (required if not using a Service Token)
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    fake:
+                      description: Fake configures a store with static key/value pairs
+                      properties:
+                        data:
+                          items:
+                            description: FakeProviderData defines a key-value pair for the fake provider used in testing.
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                              version:
+                                type: string
+                            required:
+                              - key
+                              - value
+                            type: object
+                          type: array
+                      required:
+                        - data
+                      type: object
+                    fortanix:
+                      description: Fortanix configures this store to sync secrets using the Fortanix provider
+                      properties:
+                        apiKey:
+                          description: APIKey is the API token to access SDKMS Applications.
+                          properties:
+                            secretRef:
+                              description: SecretRef is a reference to a secret containing the SDKMS API Key.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        apiUrl:
+                          description: APIURL is the URL of SDKMS API. Defaults to `sdkms.fortanix.com`.
+                          type: string
+                      type: object
+                    gcpsm:
+                      description: GCPSM configures this store to sync secrets using Google Cloud Platform Secret Manager provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against GCP
+                          properties:
+                            secretRef:
+                              description: GCPSMAuthSecretRef defines a reference to a secret containing credentials for the GCP Secret Manager provider.
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            workloadIdentity:
+                              description: GCPWorkloadIdentity defines configuration for using GCP Workload Identity authentication.
+                              properties:
+                                clusterLocation:
+                                  description: |-
+                                    ClusterLocation is the location of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterName:
+                                  description: |-
+                                    ClusterName is the name of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterProjectID:
+                                  description: |-
+                                    ClusterProjectID is the project ID of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - serviceAccountRef
+                              type: object
+                          type: object
+                        location:
+                          description: Location optionally defines a location for a secret
+                          type: string
+                        projectID:
+                          description: ProjectID project where secret is located
+                          type: string
+                      type: object
+                    github:
+                      description: Github configures this store to push GitHub Actions secrets using the GitHub API provider.
+                      properties:
+                        appID:
+                          description: appID specifies the Github APP that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        auth:
+                          description: auth configures how secret-manager authenticates with a Github instance.
+                          properties:
+                            privateKey:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - privateKey
+                          type: object
+                        environment:
+                          description: environment will be used to fetch secrets from a particular environment within a github repository
+                          type: string
+                        installationID:
+                          description: installationID specifies the Github APP installation that will be used to authenticate the client
+                          format: int64
+                          type: integer
+                        organization:
+                          description: organization will be used to fetch secrets from the Github organization
+                          type: string
+                        repository:
+                          description: repository will be used to fetch secrets from the Github repository within an organization
+                          type: string
+                        uploadURL:
+                          description: Upload URL for enterprise instances. Default to URL.
+                          type: string
+                        url:
+                          default: https://github.com/
+                          description: URL configures the Github instance URL. Defaults to https://github.com/.
+                          type: string
+                      required:
+                        - appID
+                        - auth
+                        - installationID
+                        - organization
+                      type: object
+                    gitlab:
+                      description: GitLab configures this store to sync secrets using GitLab Variables provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a GitLab instance.
+                          properties:
+                            SecretRef:
+                              description: GitlabSecretRef defines a reference to a secret containing credentials for the GitLab provider.
+                              properties:
+                                accessToken:
+                                  description: AccessToken is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - SecretRef
+                          type: object
+                        caBundle:
+                          description: |-
+                            Base64 encoded certificate for the GitLab server sdk. The sdk MUST run with HTTPS to make sure no MITM attack
+                            can be performed.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: 'see: https://external-secrets.io/latest/spec/#external-secrets.io/v1alpha1.CAProvider'
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        environment:
+                          description: Environment environment_scope of gitlab CI/CD variables (Please see https://docs.gitlab.com/ee/ci/environments/#create-a-static-environment on how to create environments)
+                          type: string
+                        groupIDs:
+                          description: GroupIDs specify, which gitlab groups to pull secrets from. Group secrets are read from left to right followed by the project variables.
+                          items:
+                            type: string
+                          type: array
+                        inheritFromGroups:
+                          description: InheritFromGroups specifies whether parent groups should be discovered and checked for secrets.
+                          type: boolean
+                        projectID:
+                          description: ProjectID specifies a project where secrets are located.
+                          type: string
+                        url:
+                          description: URL configures the GitLab instance URL. Defaults to https://gitlab.com/.
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    ibm:
+                      description: IBM configures this store to sync secrets using IBM Cloud provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the IBM secrets manager.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            containerAuth:
+                              description: IBMAuthContainerAuth defines authentication using IBM Container-based auth with IAM Trusted Profile.
+                              properties:
+                                iamEndpoint:
+                                  type: string
+                                profile:
+                                  description: the IBM Trusted Profile
+                                  type: string
+                                tokenLocation:
+                                  description: Location the token is mounted on the pod
+                                  type: string
+                              required:
+                                - profile
+                              type: object
+                            secretRef:
+                              description: IBMAuthSecretRef defines a reference to a secret containing credentials for the IBM provider.
+                              properties:
+                                secretApiKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        serviceUrl:
+                          description: ServiceURL is the Endpoint URL that is specific to the Secrets Manager service instance
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    infisical:
+                      description: Infisical configures this store to sync secrets using the Infisical provider
+                      properties:
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Infisical API
+                          properties:
+                            universalAuthCredentials:
+                              description: UniversalAuthCredentials defines the credentials for Infisical Universal Auth.
+                              properties:
+                                clientId:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - clientId
+                                - clientSecret
+                              type: object
+                          type: object
+                        hostAPI:
+                          default: https://app.infisical.com/api
+                          description: HostAPI specifies the base URL of the Infisical API. If not provided, it defaults to "https://app.infisical.com/api".
+                          type: string
+                        secretsScope:
+                          description: SecretsScope defines the scope of the secrets within the workspace
+                          properties:
+                            environmentSlug:
+                              description: EnvironmentSlug is the required slug identifier for the environment.
+                              type: string
+                            expandSecretReferences:
+                              default: true
+                              description: ExpandSecretReferences indicates whether secret references should be expanded. Defaults to true if not provided.
+                              type: boolean
+                            projectSlug:
+                              description: ProjectSlug is the required slug identifier for the project.
+                              type: string
+                            recursive:
+                              default: false
+                              description: Recursive indicates whether the secrets should be fetched recursively. Defaults to false if not provided.
+                              type: boolean
+                            secretsPath:
+                              default: /
+                              description: SecretsPath specifies the path to the secrets within the workspace. Defaults to "/" if not provided.
+                              type: string
+                          required:
+                            - environmentSlug
+                            - projectSlug
+                          type: object
+                      required:
+                        - auth
+                        - secretsScope
+                      type: object
+                    keepersecurity:
+                      description: KeeperSecurity configures this store to sync secrets using the KeeperSecurity provider
+                      properties:
+                        authRef:
+                          description: |-
+                            SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                            In some instances, `key` is a required field.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        folderID:
+                          type: string
+                      required:
+                        - authRef
+                        - folderID
+                      type: object
+                    kubernetes:
+                      description: Kubernetes configures this store to sync secrets using a Kubernetes cluster provider
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Kubernetes instance.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            cert:
+                              description: has both clientCert and clientKey as secretKeySelector
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                clientKey:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: points to a service account that should be used for authentication
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            token:
+                              description: use static token to authenticate with
+                              properties:
+                                bearerToken:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          type: object
+                        authRef:
+                          description: A reference to a secret that contains the auth information.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        remoteNamespace:
+                          default: default
+                          description: Remote namespace to fetch the secrets from
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        server:
+                          description: configures the Kubernetes server Address.
+                          properties:
+                            caBundle:
+                              description: CABundle is a base64-encoded CA certificate
+                              format: byte
+                              type: string
+                            caProvider:
+                              description: 'see: https://external-secrets.io/v0.4.1/spec/#external-secrets.io/v1alpha1.CAProvider'
+                              properties:
+                                key:
+                                  description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the object located at the provider type.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace the Provider type is in.
+                                    Can only be defined when used in a ClusterSecretStore.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                                type:
+                                  description: The type of provider to use such as "Secret", or "ConfigMap".
+                                  enum:
+                                    - Secret
+                                    - ConfigMap
+                                  type: string
+                              required:
+                                - name
+                                - type
+                              type: object
+                            url:
+                              default: kubernetes.default
+                              description: configures the Kubernetes server Address.
+                              type: string
+                          type: object
+                      type: object
+                    onboardbase:
+                      description: Onboardbase configures this store to sync secrets using the Onboardbase provider
+                      properties:
+                        apiHost:
+                          default: https://public.onboardbase.com/api/v1/
+                          description: APIHost use this to configure the host url for the API for selfhosted installation, default is https://public.onboardbase.com/api/v1/
+                          type: string
+                        auth:
+                          description: Auth configures how the Operator authenticates with the Onboardbase API
+                          properties:
+                            apiKeyRef:
+                              description: |-
+                                OnboardbaseAPIKey is the APIKey generated by an admin account.
+                                It is used to recognize and authorize access to a project and environment within onboardbase
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            passcodeRef:
+                              description: OnboardbasePasscode is the passcode attached to the API Key
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - apiKeyRef
+                            - passcodeRef
+                          type: object
+                        environment:
+                          default: development
+                          description: Environment is the name of an environmnent within a project to pull the secrets from
+                          type: string
+                        project:
+                          default: development
+                          description: Project is an onboardbase project that the secrets should be pulled from
+                          type: string
+                      required:
+                        - apiHost
+                        - auth
+                        - environment
+                        - project
+                      type: object
+                    onepassword:
+                      description: OnePassword configures this store to sync secrets using the 1Password Cloud provider
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against OnePassword Connect Server
+                          properties:
+                            secretRef:
+                              description: OnePasswordAuthSecretRef holds secret references for 1Password credentials.
+                              properties:
+                                connectTokenSecretRef:
+                                  description: The ConnectToken is used for authentication to a 1Password Connect Server.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - connectTokenSecretRef
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        connectHost:
+                          description: ConnectHost defines the OnePassword Connect Server to connect to
+                          type: string
+                        vaults:
+                          additionalProperties:
+                            type: integer
+                          description: Vaults defines which OnePassword vaults to search in which order
+                          type: object
+                      required:
+                        - auth
+                        - connectHost
+                        - vaults
+                      type: object
+                    oracle:
+                      description: Oracle configures this store to sync secrets using Oracle Vault provider
+                      properties:
+                        auth:
+                          description: |-
+                            Auth configures how secret-manager authenticates with the Oracle Vault.
+                            If empty, use the instance principal, otherwise the user credentials specified in Auth.
+                          properties:
+                            secretRef:
+                              description: SecretRef to pass through sensitive information.
+                              properties:
+                                fingerprint:
+                                  description: Fingerprint is the fingerprint of the API private key.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                privatekey:
+                                  description: PrivateKey is the user's API Signing Key in PEM format, used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - fingerprint
+                                - privatekey
+                              type: object
+                            tenancy:
+                              description: Tenancy is the tenancy OCID where user is located.
+                              type: string
+                            user:
+                              description: User is an access OCID specific to the account.
+                              type: string
+                          required:
+                            - secretRef
+                            - tenancy
+                            - user
+                          type: object
+                        compartment:
+                          description: |-
+                            Compartment is the vault compartment OCID.
+                            Required for PushSecret
+                          type: string
+                        encryptionKey:
+                          description: |-
+                            EncryptionKey is the OCID of the encryption key within the vault.
+                            Required for PushSecret
+                          type: string
+                        principalType:
+                          description: |-
+                            The type of principal to use for authentication. If left blank, the Auth struct will
+                            determine the principal type. This optional field must be specified if using
+                            workload identity.
+                          enum:
+                            - ""
+                            - UserPrincipal
+                            - InstancePrincipal
+                            - Workload
+                          type: string
+                        region:
+                          description: Region is the region where vault is located.
+                          type: string
+                        serviceAccountRef:
+                          description: |-
+                            ServiceAccountRef specified the service account
+                            that should be used when authenticating with WorkloadIdentity.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                        vault:
+                          description: Vault is the vault's OCID of the specific vault where secret is located.
+                          type: string
+                      required:
+                        - region
+                        - vault
+                      type: object
+                    passbolt:
+                      description: PassboltProvider defines configuration for the Passbolt provider.
+                      properties:
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Passbolt Server
+                          properties:
+                            passwordSecretRef:
+                              description: PasswordSecretRef is a reference to the secret containing the Passbolt password
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            privateKeySecretRef:
+                              description: PrivateKeySecretRef is a reference to the secret containing the Passbolt private key
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - passwordSecretRef
+                            - privateKeySecretRef
+                          type: object
+                        host:
+                          description: Host defines the Passbolt Server to connect to
+                          type: string
+                      required:
+                        - auth
+                        - host
+                      type: object
+                    passworddepot:
+                      description: PasswordDepotProvider configures a store to sync secrets with a Password Depot instance.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with a Password Depot instance.
+                          properties:
+                            secretRef:
+                              description: PasswordDepotSecretRef defines a reference to a secret containing credentials for the Password Depot provider.
+                              properties:
+                                credentials:
+                                  description: Username / Password is used for authentication.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        database:
+                          description: Database to use as source
+                          type: string
+                        host:
+                          description: URL configures the Password Depot instance URL.
+                          type: string
+                      required:
+                        - auth
+                        - database
+                        - host
+                      type: object
+                    previder:
+                      description: Previder configures this store to sync secrets using the Previder provider
+                      properties:
+                        auth:
+                          description: PreviderAuth contains a secretRef for credentials.
+                          properties:
+                            secretRef:
+                              description: PreviderAuthSecretRef holds secret references for Previder Vault credentials.
+                              properties:
+                                accessToken:
+                                  description: The AccessToken is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - accessToken
+                              type: object
+                          type: object
+                        baseUri:
+                          type: string
+                      required:
+                        - auth
+                      type: object
+                    pulumi:
+                      description: Pulumi configures this store to sync secrets using the Pulumi provider
+                      properties:
+                        accessToken:
+                          description: AccessToken is the access tokens to sign in to the Pulumi Cloud Console.
+                          properties:
+                            secretRef:
+                              description: SecretRef is a reference to a secret containing the Pulumi API token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        apiUrl:
+                          default: https://api.pulumi.com/api/esc
+                          description: APIURL is the URL of the Pulumi API.
+                          type: string
+                        environment:
+                          description: |-
+                            Environment are YAML documents composed of static key-value pairs, programmatic expressions,
+                            dynamically retrieved values from supported providers including all major clouds,
+                            and other Pulumi ESC environments.
+                            To create a new environment, visit https://www.pulumi.com/docs/esc/environments/ for more information.
+                          type: string
+                        organization:
+                          description: |-
+                            Organization are a space to collaborate on shared projects and stacks.
+                            To create a new organization, visit https://app.pulumi.com/ and click "New Organization".
+                          type: string
+                        project:
+                          description: Project is the name of the Pulumi ESC project the environment belongs to.
+                          type: string
+                      required:
+                        - accessToken
+                        - environment
+                        - organization
+                        - project
+                      type: object
+                    scaleway:
+                      description: Scaleway configures this store to sync secrets using the Scaleway provider.
+                      properties:
+                        accessKey:
+                          description: AccessKey is the non-secret part of the api key.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        apiUrl:
+                          description: APIURL is the url of the api to use. Defaults to https://api.scaleway.com
+                          type: string
+                        projectId:
+                          description: 'ProjectID is the id of your project, which you can find in the console: https://console.scaleway.com/project/settings'
+                          type: string
+                        region:
+                          description: 'Region where your secrets are located: https://developers.scaleway.com/en/quickstart/#region-and-zone'
+                          type: string
+                        secretKey:
+                          description: SecretKey is the non-secret part of the api key.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                      required:
+                        - accessKey
+                        - projectId
+                        - region
+                        - secretKey
+                      type: object
+                    secretserver:
+                      description: |-
+                        SecretServer configures this store to sync secrets using SecretServer provider
+                        https://docs.delinea.com/online-help/secret-server/start.htm
+                      properties:
+                        password:
+                          description: Password is the secret server account password.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                        serverURL:
+                          description: |-
+                            ServerURL
+                            URL to your secret server installation
+                          type: string
+                        username:
+                          description: Username is the secret server account username.
+                          properties:
+                            secretRef:
+                              description: SecretRef references a key in a secret that will be used as value.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            value:
+                              description: Value can be specified directly to set a value without using a secret.
+                              type: string
+                          type: object
+                      required:
+                        - password
+                        - serverURL
+                        - username
+                      type: object
+                    senhasegura:
+                      description: Senhasegura configures this store to sync secrets using senhasegura provider
+                      properties:
+                        auth:
+                          description: Auth defines parameters to authenticate in senhasegura
+                          properties:
+                            clientId:
+                              type: string
+                            clientSecretSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - clientId
+                            - clientSecretSecretRef
+                          type: object
+                        ignoreSslCertificate:
+                          default: false
+                          description: IgnoreSslCertificate defines if SSL certificate must be ignored
+                          type: boolean
+                        module:
+                          description: Module defines which senhasegura module should be used to get secrets
+                          type: string
+                        url:
+                          description: URL of senhasegura
+                          type: string
+                      required:
+                        - auth
+                        - module
+                        - url
+                      type: object
+                    vault:
+                      description: Vault configures this store to sync secrets using the HashiCorp Vault provider.
+                      properties:
+                        auth:
+                          description: Auth configures how secret-manager authenticates with the Vault server.
+                          properties:
+                            appRole:
+                              description: |-
+                                AppRole authenticates with Vault using the App Role auth mechanism,
+                                with the role and secret stored in a Kubernetes Secret resource.
+                              properties:
+                                path:
+                                  default: approle
+                                  description: |-
+                                    Path where the App Role authentication backend is mounted
+                                    in Vault, e.g: "approle"
+                                  type: string
+                                roleId:
+                                  description: |-
+                                    RoleID configured in the App Role authentication backend when setting
+                                    up the authentication backend in Vault.
+                                  type: string
+                                roleRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role ID used
+                                    to authenticate with Vault.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role id.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    Reference to a key in a Secret that contains the App Role secret used
+                                    to authenticate with Vault.
+                                    The `key` field must be specified and denotes which entry within the Secret
+                                    resource is used as the app role secret.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                                - secretRef
+                              type: object
+                            cert:
+                              description: |-
+                                Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate
+                                Cert authentication method
+                              properties:
+                                clientCert:
+                                  description: |-
+                                    ClientCert is a certificate to authenticate using the Cert Vault
+                                    authentication method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing client private key to
+                                    authenticate with Vault using the Cert authentication method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            iam:
+                              description: |-
+                                Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials
+                                AWS IAM authentication method
+                              properties:
+                                externalID:
+                                  description: AWS External ID set on assumed IAM roles
+                                  type: string
+                                jwt:
+                                  description: Specify a service account with IRSA enabled
+                                  properties:
+                                    serviceAccountRef:
+                                      description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  type: object
+                                path:
+                                  description: 'Path where the AWS auth method is enabled in Vault, e.g: "aws"'
+                                  type: string
+                                region:
+                                  description: AWS region
+                                  type: string
+                                role:
+                                  description: This is the AWS role to be assumed before talking to vault
+                                  type: string
+                                secretRef:
+                                  description: Specify credentials in a Secret object
+                                  properties:
+                                    accessKeyIDSecretRef:
+                                      description: The AccessKeyID is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    secretAccessKeySecretRef:
+                                      description: The SecretAccessKey is used for authentication
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                    sessionTokenSecretRef:
+                                      description: |-
+                                        The SessionToken used for authentication
+                                        This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                        see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                      properties:
+                                        key:
+                                          description: |-
+                                            A key in the referenced Secret.
+                                            Some instances of this field may be defaulted, in others it may be required.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[-._a-zA-Z0-9]+$
+                                          type: string
+                                        name:
+                                          description: The name of the Secret resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            The namespace of the Secret resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      type: object
+                                  type: object
+                                vaultAwsIamServerID:
+                                  description: 'X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws'
+                                  type: string
+                                vaultRole:
+                                  description: Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine
+                                  type: string
+                              required:
+                                - vaultRole
+                              type: object
+                            jwt:
+                              description: |-
+                                Jwt authenticates with Vault by passing role and JWT token using the
+                                JWT/OIDC authentication method
+                              properties:
+                                kubernetesServiceAccountToken:
+                                  description: |-
+                                    Optional ServiceAccountToken specifies the Kubernetes service account for which to request
+                                    a token for with the `TokenRequest` API.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Optional audiences field that will be used to request a temporary Kubernetes service
+                                        account token for the service account referenced by `serviceAccountRef`.
+                                        Defaults to a single audience `vault` it not specified.
+
+                                        Deprecated: use serviceAccountRef.Audiences instead
+                                      items:
+                                        type: string
+                                      type: array
+                                    expirationSeconds:
+                                      description: |-
+                                        Optional expiration time in seconds that will be used to request a temporary
+                                        Kubernetes service account token for the service account referenced by
+                                        `serviceAccountRef`.
+
+                                        Deprecated: this will be removed in the future.
+                                        Defaults to 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    serviceAccountRef:
+                                      description: Service account field containing the name of a kubernetes ServiceAccount.
+                                      properties:
+                                        audiences:
+                                          description: |-
+                                            Audience specifies the `aud` claim for the service account token
+                                            If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                            then this audiences will be appended to the list
+                                          items:
+                                            type: string
+                                          type: array
+                                        name:
+                                          description: The name of the ServiceAccount resource being referred to.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace of the resource being referred to.
+                                            Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                          maxLength: 63
+                                          minLength: 1
+                                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                  required:
+                                    - serviceAccountRef
+                                  type: object
+                                path:
+                                  default: jwt
+                                  description: |-
+                                    Path where the JWT authentication backend is mounted
+                                    in Vault, e.g: "jwt"
+                                  type: string
+                                role:
+                                  description: |-
+                                    Role is a JWT role to authenticate using the JWT/OIDC Vault
+                                    authentication method
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                    authenticate with Vault using the JWT/OIDC authentication method.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - path
+                              type: object
+                            kubernetes:
+                              description: |-
+                                Kubernetes authenticates with Vault by passing the ServiceAccount
+                                token stored in the named Secret resource to the Vault server.
+                              properties:
+                                mountPath:
+                                  default: kubernetes
+                                  description: |-
+                                    Path where the Kubernetes authentication backend is mounted in Vault, e.g:
+                                    "kubernetes"
+                                  type: string
+                                role:
+                                  description: |-
+                                    A required field containing the Vault Role to assume. A Role binds a
+                                    Kubernetes ServiceAccount with a set of Vault policies.
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                    for authenticating with Vault. If a name is specified without a key,
+                                    `token` is the default. If one is not specified, the one bound to
+                                    the controller will be used.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                serviceAccountRef:
+                                  description: |-
+                                    Optional service account field containing the name of a kubernetes ServiceAccount.
+                                    If the service account is specified, the service account secret token JWT will be used
+                                    for authenticating with Vault. If the service account selector is not supplied,
+                                    the secretRef will be used instead.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - mountPath
+                                - role
+                              type: object
+                            ldap:
+                              description: |-
+                                Ldap authenticates with Vault by passing username/password pair using
+                                the LDAP authentication method
+                              properties:
+                                path:
+                                  default: ldap
+                                  description: |-
+                                    Path where the LDAP authentication backend is mounted
+                                    in Vault, e.g: "ldap"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the LDAP
+                                    user used to authenticate with Vault using the LDAP authentication
+                                    method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is an LDAP username used to authenticate using the LDAP Vault
+                                    authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                            namespace:
+                              description: |-
+                                Name of the vault namespace to authenticate to. This can be different than the namespace your secret is in.
+                                Namespaces is a set of features within Vault Enterprise that allows
+                                Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                                More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                                This will default to Vault.Namespace field if set, or empty otherwise
+                              type: string
+                            tokenSecretRef:
+                              description: TokenSecretRef authenticates with Vault by presenting a token.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            userPass:
+                              description: UserPass authenticates with Vault by passing username/password pair
+                              properties:
+                                path:
+                                  default: userpass
+                                  description: |-
+                                    Path where the UserPassword authentication backend is mounted
+                                    in Vault, e.g: "userpass"
+                                  type: string
+                                secretRef:
+                                  description: |-
+                                    SecretRef to a key in a Secret resource containing password for the
+                                    user used to authenticate with Vault using the UserPass authentication
+                                    method
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                username:
+                                  description: |-
+                                    Username is a username used to authenticate using the UserPass Vault
+                                    authentication method
+                                  type: string
+                              required:
+                                - path
+                                - username
+                              type: object
+                          type: object
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate Vault server certificate. Only used
+                            if the Server URL is using HTTPS protocol. This parameter is ignored for
+                            plain HTTP protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Vault server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace the Provider type is in.
+                                Can only be defined when used in a ClusterSecretStore.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        forwardInconsistent:
+                          description: |-
+                            ForwardInconsistent tells Vault to forward read-after-write requests to the Vault
+                            leader instead of simply retrying within a loop. This can increase performance if
+                            the option is enabled serverside.
+                            https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                          type: boolean
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers to be added in Vault request
+                          type: object
+                        namespace:
+                          description: |-
+                            Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
+                            Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                            More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                          type: string
+                        path:
+                          description: |-
+                            Path is the mount path of the Vault KV backend endpoint, e.g:
+                            "secret". The v2 KV secret engine version specific "/data" path suffix
+                            for fetching secrets from Vault is optional and will be appended
+                            if not present in specified path.
+                          type: string
+                        readYourWrites:
+                          description: |-
+                            ReadYourWrites ensures isolated read-after-write semantics by
+                            providing discovered cluster replication states in each request.
+                            More information about eventual consistency in Vault can be found here
+                            https://www.vaultproject.io/docs/enterprise/consistency
+                          type: boolean
+                        server:
+                          description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                          type: string
+                        tls:
+                          description: |-
+                            The configuration used for client side related TLS communication, when the Vault server
+                            requires mutual authentication. Only used if the Server URL is using HTTPS protocol.
+                            This parameter is ignored for plain HTTP protocol connection.
+                            It's worth noting this configuration is different from the "TLS certificates auth method",
+                            which is available under the `auth.cert` section.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                CertSecretRef is a certificate added to the transport layer
+                                when communicating with the Vault server.
+                                If no key for the Secret is specified, external-secret will default to 'tls.crt'.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            keySecretRef:
+                              description: |-
+                                KeySecretRef to a key in a Secret resource containing client private key
+                                added to the transport layer when communicating with the Vault server.
+                                If no key for the Secret is specified, external-secret will default to 'tls.key'.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        version:
+                          default: v2
+                          description: |-
+                            Version is the Vault KV secret engine version. This can be either "v1" or
+                            "v2". Version defaults to "v2".
+                          enum:
+                            - v1
+                            - v2
+                          type: string
+                      required:
+                        - server
+                      type: object
+                    webhook:
+                      description: Webhook configures this store to sync secrets using a generic templated webhook
+                      properties:
+                        auth:
+                          description: Auth specifies a authorization protocol. Only one protocol may be set.
+                          maxProperties: 1
+                          minProperties: 1
+                          properties:
+                            ntlm:
+                              description: NTLMProtocol configures the store to use NTLM for auth
+                              properties:
+                                passwordSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                usernameSecret:
+                                  description: |-
+                                    SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                    In some instances, `key` is a required field.
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              required:
+                                - passwordSecret
+                                - usernameSecret
+                              type: object
+                          type: object
+                        body:
+                          description: Body
+                          type: string
+                        caBundle:
+                          description: |-
+                            PEM encoded CA bundle used to validate webhook server certificate. Only used
+                            if the Server URL is using HTTPS protocol. This parameter is ignored for
+                            plain HTTP protocol connection. If not set the system root certificates
+                            are used to validate the TLS connection.
+                          format: byte
+                          type: string
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate webhook server certificate.
+                          properties:
+                            key:
+                              description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the object located at the provider type.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: The namespace the Provider type is in.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            type:
+                              description: The type of provider to use such as "Secret", or "ConfigMap".
+                              enum:
+                                - Secret
+                                - ConfigMap
+                              type: string
+                          required:
+                            - name
+                            - type
+                          type: object
+                        headers:
+                          additionalProperties:
+                            type: string
+                          description: Headers
+                          type: object
+                        method:
+                          description: Webhook Method
+                          type: string
+                        result:
+                          description: Result formatting
+                          properties:
+                            jsonPath:
+                              description: Json path of return value
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets to fill in templates
+                            These secrets will be passed to the templating function as key value pairs under the given name
+                          items:
+                            description: WebhookSecret defines a secret to be used in webhook templates.
+                            properties:
+                              name:
+                                description: Name of this secret in templates
+                                type: string
+                              secretRef:
+                                description: Secret ref to fill in credentials
+                                properties:
+                                  key:
+                                    description: |-
+                                      A key in the referenced Secret.
+                                      Some instances of this field may be defaulted, in others it may be required.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[-._a-zA-Z0-9]+$
+                                    type: string
+                                  name:
+                                    description: The name of the Secret resource being referred to.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      The namespace of the Secret resource being referred to.
+                                      Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                    maxLength: 63
+                                    minLength: 1
+                                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                    type: string
+                                type: object
+                            required:
+                              - name
+                              - secretRef
+                            type: object
+                          type: array
+                        timeout:
+                          description: Timeout
+                          type: string
+                        url:
+                          description: Webhook url to call
+                          type: string
+                      required:
+                        - result
+                        - url
+                      type: object
+                    yandexcertificatemanager:
+                      description: YandexCertificateManager configures this store to sync secrets using Yandex Certificate Manager provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Certificate Manager
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                    yandexlockbox:
+                      description: YandexLockbox configures this store to sync secrets using Yandex Lockbox provider
+                      properties:
+                        apiEndpoint:
+                          description: Yandex.Cloud API endpoint (e.g. 'api.cloud.yandex.net:443')
+                          type: string
+                        auth:
+                          description: Auth defines the information necessary to authenticate against Yandex Lockbox
+                          properties:
+                            authorizedKeySecretRef:
+                              description: The authorized key used for authentication
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                        caProvider:
+                          description: The provider for the CA bundle to use to validate Yandex.Cloud server certificate.
+                          properties:
+                            certSecretRef:
+                              description: |-
+                                SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                                In some instances, `key` is a required field.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          type: object
+                      required:
+                        - auth
+                      type: object
+                  type: object
+                refreshInterval:
+                  description: Used to configure store refresh interval in seconds. Empty or 0 will default to the controller config.
+                  type: integer
+                retrySettings:
+                  description: Used to configure HTTP retries on failures.
+                  properties:
+                    maxRetries:
+                      description: MaxRetries is the maximum number of retry attempts.
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      description: RetryInterval is the interval between retry attempts.
+                      type: string
+                  type: object
+              required:
+                - provider
+              type: object
+            status:
+              description: SecretStoreStatus defines the observed state of the SecretStore.
+              properties:
+                capabilities:
+                  description: SecretStoreCapabilities defines the possible operations a SecretStore can do.
+                  type: string
+                conditions:
+                  items:
+                    description: SecretStoreStatusCondition defines the observed condition of the SecretStore.
+                    properties:
+                      lastTransitionTime:
+                        format: date-time
+                        type: string
+                      message:
+                        type: string
+                      reason:
+                        type: string
+                      status:
+                        type: string
+                      type:
+                        description: SecretStoreConditionType represents the condition type of the SecretStore.
+                        type: string
+                    required:
+                      - status
+                      - type
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: false
+      storage: false
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-sshkeys-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-sshkeys-generators-external-secrets-io.yaml
@@ -1,0 +1,71 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: sshkeys.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: SSHKey
+    listKind: SSHKeyList
+    plural: sshkeys
+    singular: sshkey
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: SSHKey generates SSH key pairs.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SSHKeySpec controls the behavior of the ssh key generator.
+              properties:
+                comment:
+                  description: Comment specifies an optional comment for the SSH key
+                  type: string
+                keySize:
+                  description: |-
+                    KeySize specifies the key size for RSA keys (default: 2048) and ECDSA keys (default: 256).
+                    For RSA keys: 2048, 3072, 4096
+                    For ECDSA keys: 256, 384, 521
+                    Ignored for ed25519 keys
+                  maximum: 8192
+                  minimum: 256
+                  type: integer
+                keyType:
+                  default: rsa
+                  description: KeyType specifies the SSH key type (rsa, ecdsa, ed25519)
+                  enum:
+                    - rsa
+                    - ecdsa
+                    - ed25519
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-stssessiontokens-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-stssessiontokens-generators-external-secrets-io.yaml
@@ -1,0 +1,205 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: stssessiontokens.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: STSSessionToken
+    listKind: STSSessionTokenList
+    plural: stssessiontokens
+    singular: stssessiontoken
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            STSSessionToken uses the GetSessionToken API to retrieve an authorization token.
+            The authorization token is valid for 12 hours.
+            The authorizationToken returned is a base64 encoded string that can be decoded.
+            For more information, see GetSessionToken (https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html).
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: STSSessionTokenSpec defines the desired state to generate an AWS STS session token.
+              properties:
+                auth:
+                  description: Auth defines how to authenticate with AWS
+                  properties:
+                    jwt:
+                      description: AWSJWTAuth provides configuration to authenticate against AWS using service account tokens.
+                      properties:
+                        serviceAccountRef:
+                          description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                          properties:
+                            audiences:
+                              description: |-
+                                Audience specifies the `aud` claim for the service account token
+                                If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                then this audiences will be appended to the list
+                              items:
+                                type: string
+                              type: array
+                            name:
+                              description: The name of the ServiceAccount resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace of the resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                    secretRef:
+                      description: |-
+                        AWSAuthSecretRef holds secret references for AWS credentials
+                        both AccessKeyID and SecretAccessKey must be defined in order to properly authenticate.
+                      properties:
+                        accessKeyIDSecretRef:
+                          description: The AccessKeyID is used for authentication
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        secretAccessKeySecretRef:
+                          description: The SecretAccessKey is used for authentication
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        sessionTokenSecretRef:
+                          description: |-
+                            The SessionToken used for authentication
+                            This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                            see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                      type: object
+                  type: object
+                region:
+                  description: Region specifies the region to operate in.
+                  type: string
+                requestParameters:
+                  description: RequestParameters contains parameters that can be passed to the STS service.
+                  properties:
+                    serialNumber:
+                      description: |-
+                        SerialNumber is the identification number of the MFA device that is associated with the IAM user who is making
+                        the GetSessionToken call.
+                        Possible values: hardware device (such as GAHT12345678) or an Amazon Resource Name (ARN) for a virtual device
+                        (such as arn:aws:iam::123456789012:mfa/user)
+                      type: string
+                    sessionDuration:
+                      format: int32
+                      type: integer
+                    tokenCode:
+                      description: TokenCode is the value provided by the MFA device, if MFA is required.
+                      type: string
+                  type: object
+                role:
+                  description: |-
+                    You can assume a role before making calls to the
+                    desired AWS service.
+                  type: string
+              required:
+                - region
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-uuids-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-uuids-generators-external-secrets-io.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: uuids.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: UUID
+    listKind: UUIDList
+    plural: uuids
+    singular: uuid
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: UUID generates a version 1 UUID (e56657e3-764f-11ef-a397-65231a88c216).
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: UUIDSpec controls the behavior of the uuid generator.
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-vaultdynamicsecrets-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-vaultdynamicsecrets-generators-external-secrets-io.yaml
@@ -1,0 +1,1016 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: vaultdynamicsecrets.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: VaultDynamicSecret
+    listKind: VaultDynamicSecretList
+    plural: vaultdynamicsecrets
+    singular: vaultdynamicsecret
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: VaultDynamicSecret represents a generator that can create dynamic secrets from HashiCorp Vault.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VaultDynamicSecretSpec defines the desired spec of VaultDynamicSecret.
+              properties:
+                allowEmptyResponse:
+                  default: false
+                  description: Do not fail if no secrets are found. Useful for requests where no data is expected.
+                  type: boolean
+                controller:
+                  description: |-
+                    Used to select the correct ESO controller (think: ingress.ingressClassName)
+                    The ESO controller is instantiated with a specific controller name and filters VDS based on this property
+                  type: string
+                getParameters:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: |-
+                    GetParameters are query-string parameters passed to Vault on GET calls.
+                    Each key may map to multiple values, matching HTTP query-string semantics.
+                    Ignored for non-GET methods; use Parameters for write bodies.
+                  type: object
+                method:
+                  description: Vault API method to use (GET/POST/other)
+                  type: string
+                parameters:
+                  description: Parameters to pass to Vault write (for non-GET methods)
+                  x-kubernetes-preserve-unknown-fields: true
+                path:
+                  description: Vault path to obtain the dynamic secret from
+                  type: string
+                provider:
+                  description: Vault provider common spec
+                  properties:
+                    auth:
+                      description: Auth configures how secret-manager authenticates with the Vault server.
+                      properties:
+                        appRole:
+                          description: |-
+                            AppRole authenticates with Vault using the App Role auth mechanism,
+                            with the role and secret stored in a Kubernetes Secret resource.
+                          properties:
+                            path:
+                              default: approle
+                              description: |-
+                                Path where the App Role authentication backend is mounted
+                                in Vault, e.g: "approle"
+                              type: string
+                            roleId:
+                              description: |-
+                                RoleID configured in the App Role authentication backend when setting
+                                up the authentication backend in Vault.
+                              type: string
+                            roleRef:
+                              description: |-
+                                Reference to a key in a Secret that contains the App Role ID used
+                                to authenticate with Vault.
+                                The `key` field must be specified and denotes which entry within the Secret
+                                resource is used as the app role id.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            secretRef:
+                              description: |-
+                                Reference to a key in a Secret that contains the App Role secret used
+                                to authenticate with Vault.
+                                The `key` field must be specified and denotes which entry within the Secret
+                                resource is used as the app role secret.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - path
+                            - secretRef
+                          type: object
+                        cert:
+                          description: |-
+                            Cert authenticates with TLS Certificates by passing client certificate, private key and ca certificate
+                            Cert authentication method
+                          properties:
+                            clientCert:
+                              description: |-
+                                ClientCert is a certificate to authenticate using the Cert Vault
+                                authentication method
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            path:
+                              default: cert
+                              description: |-
+                                Path where the Certificate authentication backend is mounted
+                                in Vault, e.g: "cert"
+                              type: string
+                            secretRef:
+                              description: |-
+                                SecretRef to a key in a Secret resource containing client private key to
+                                authenticate with Vault using the Cert authentication method
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            vaultRole:
+                              description: VaultRole specifies the Vault role to use for TLS certificate authentication.
+                              type: string
+                          type: object
+                        gcp:
+                          description: |-
+                            Gcp authenticates with Vault using Google Cloud Platform authentication method
+                            GCP authentication method
+                          properties:
+                            location:
+                              description: Location optionally defines a location/region for the secret
+                              type: string
+                            path:
+                              default: gcp
+                              description: 'Path where the GCP auth method is enabled in Vault, e.g: "gcp"'
+                              type: string
+                            projectID:
+                              description: Project ID of the Google Cloud Platform project
+                              type: string
+                            role:
+                              description: Vault Role. In Vault, a role describes an identity with a set of permissions, groups, or policies you want to attach to a user of the secrets engine.
+                              type: string
+                            secretRef:
+                              description: Specify credentials in a Secret object
+                              properties:
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccountRef:
+                              description: ServiceAccountRef to a service account for impersonation
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            workloadIdentity:
+                              description: Specify a service account with Workload Identity
+                              properties:
+                                clusterLocation:
+                                  description: |-
+                                    ClusterLocation is the location of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterName:
+                                  description: |-
+                                    ClusterName is the name of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                clusterProjectID:
+                                  description: |-
+                                    ClusterProjectID is the project ID of the cluster
+                                    If not specified, it fetches information from the metadata server
+                                  type: string
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - serviceAccountRef
+                              type: object
+                          required:
+                            - role
+                          type: object
+                        iam:
+                          description: |-
+                            Iam authenticates with vault by passing a special AWS request signed with AWS IAM credentials
+                            AWS IAM authentication method
+                          properties:
+                            externalID:
+                              description: AWS External ID set on assumed IAM roles
+                              type: string
+                            jwt:
+                              description: Specify a service account with IRSA enabled
+                              properties:
+                                serviceAccountRef:
+                                  description: ServiceAccountSelector is a reference to a ServiceAccount resource.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              type: object
+                            path:
+                              description: 'Path where the AWS auth method is enabled in Vault, e.g: "aws"'
+                              type: string
+                            region:
+                              description: AWS region
+                              type: string
+                            role:
+                              description: This is the AWS role to be assumed before talking to vault
+                              type: string
+                            secretRef:
+                              description: Specify credentials in a Secret object
+                              properties:
+                                accessKeyIDSecretRef:
+                                  description: The AccessKeyID is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                secretAccessKeySecretRef:
+                                  description: The SecretAccessKey is used for authentication
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                                sessionTokenSecretRef:
+                                  description: |-
+                                    The SessionToken used for authentication
+                                    This must be defined if AccessKeyID and SecretAccessKey are temporary credentials
+                                    see: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html
+                                  properties:
+                                    key:
+                                      description: |-
+                                        A key in the referenced Secret.
+                                        Some instances of this field may be defaulted, in others it may be required.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[-._a-zA-Z0-9]+$
+                                      type: string
+                                    name:
+                                      description: The name of the Secret resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        The namespace of the Secret resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  type: object
+                              type: object
+                            vaultAwsIamServerID:
+                              description: 'X-Vault-AWS-IAM-Server-ID is an additional header used by Vault IAM auth method to mitigate against different types of replay attacks. More details here: https://developer.hashicorp.com/vault/docs/auth/aws'
+                              type: string
+                            vaultRole:
+                              description: Vault Role. In vault, a role describes an identity with a set of permissions, groups, or policies you want to attach a user of the secrets engine
+                              type: string
+                          required:
+                            - vaultRole
+                          type: object
+                        jwt:
+                          description: |-
+                            Jwt authenticates with Vault by passing role and JWT token using the
+                            JWT/OIDC authentication method
+                          properties:
+                            kubernetesServiceAccountToken:
+                              description: |-
+                                Optional ServiceAccountToken specifies the Kubernetes service account for which to request
+                                a token for with the `TokenRequest` API.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Optional audiences field that will be used to request a temporary Kubernetes service
+                                    account token for the service account referenced by `serviceAccountRef`.
+                                    Defaults to a single audience `vault` it not specified.
+
+                                    Deprecated: use serviceAccountRef.Audiences instead
+                                  items:
+                                    type: string
+                                  type: array
+                                expirationSeconds:
+                                  description: |-
+                                    Optional expiration time in seconds that will be used to request a temporary
+                                    Kubernetes service account token for the service account referenced by
+                                    `serviceAccountRef`.
+
+                                    Deprecated: this will be removed in the future.
+                                    Defaults to 10 minutes.
+                                  format: int64
+                                  type: integer
+                                serviceAccountRef:
+                                  description: Service account field containing the name of a kubernetes ServiceAccount.
+                                  properties:
+                                    audiences:
+                                      description: |-
+                                        Audience specifies the `aud` claim for the service account token
+                                        If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                        then this audiences will be appended to the list
+                                      items:
+                                        type: string
+                                      type: array
+                                    name:
+                                      description: The name of the ServiceAccount resource being referred to.
+                                      maxLength: 253
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the resource being referred to.
+                                        Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                              required:
+                                - serviceAccountRef
+                              type: object
+                            path:
+                              default: jwt
+                              description: |-
+                                Path where the JWT authentication backend is mounted
+                                in Vault, e.g: "jwt"
+                              type: string
+                            role:
+                              description: |-
+                                Role is a JWT role to authenticate using the JWT/OIDC Vault
+                                authentication method
+                              type: string
+                            secretRef:
+                              description: |-
+                                Optional SecretRef that refers to a key in a Secret resource containing JWT token to
+                                authenticate with Vault using the JWT/OIDC authentication method.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                          required:
+                            - path
+                          type: object
+                        kubernetes:
+                          description: |-
+                            Kubernetes authenticates with Vault by passing the ServiceAccount
+                            token stored in the named Secret resource to the Vault server.
+                          properties:
+                            mountPath:
+                              default: kubernetes
+                              description: |-
+                                Path where the Kubernetes authentication backend is mounted in Vault, e.g:
+                                "kubernetes"
+                              type: string
+                            role:
+                              description: |-
+                                A required field containing the Vault Role to assume. A Role binds a
+                                Kubernetes ServiceAccount with a set of Vault policies.
+                              type: string
+                            secretRef:
+                              description: |-
+                                Optional secret field containing a Kubernetes ServiceAccount JWT used
+                                for authenticating with Vault. If a name is specified without a key,
+                                `token` is the default. If one is not specified, the one bound to
+                                the controller will be used.
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            serviceAccountRef:
+                              description: |-
+                                Optional service account field containing the name of a kubernetes ServiceAccount.
+                                If the service account is specified, the service account secret token JWT will be used
+                                for authenticating with Vault. If the service account selector is not supplied,
+                                the secretRef will be used instead.
+                              properties:
+                                audiences:
+                                  description: |-
+                                    Audience specifies the `aud` claim for the service account token
+                                    If the service account uses a well-known annotation for e.g. IRSA or GCP Workload Identity
+                                    then this audiences will be appended to the list
+                                  items:
+                                    type: string
+                                  type: array
+                                name:
+                                  description: The name of the ServiceAccount resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                          required:
+                            - mountPath
+                            - role
+                          type: object
+                        ldap:
+                          description: |-
+                            Ldap authenticates with Vault by passing username/password pair using
+                            the LDAP authentication method
+                          properties:
+                            path:
+                              default: ldap
+                              description: |-
+                                Path where the LDAP authentication backend is mounted
+                                in Vault, e.g: "ldap"
+                              type: string
+                            secretRef:
+                              description: |-
+                                SecretRef to a key in a Secret resource containing password for the LDAP
+                                user used to authenticate with Vault using the LDAP authentication
+                                method
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            username:
+                              description: |-
+                                Username is an LDAP username used to authenticate using the LDAP Vault
+                                authentication method
+                              type: string
+                          required:
+                            - path
+                            - username
+                          type: object
+                        namespace:
+                          description: |-
+                            Name of the vault namespace to authenticate to. This can be different than the namespace your secret is in.
+                            Namespaces is a set of features within Vault Enterprise that allows
+                            Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                            More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                            This will default to Vault.Namespace field if set, or empty otherwise
+                          type: string
+                        tokenSecretRef:
+                          description: TokenSecretRef authenticates with Vault by presenting a token.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        userPass:
+                          description: UserPass authenticates with Vault by passing username/password pair
+                          properties:
+                            path:
+                              default: userpass
+                              description: |-
+                                Path where the UserPassword authentication backend is mounted
+                                in Vault, e.g: "userpass"
+                              type: string
+                            secretRef:
+                              description: |-
+                                SecretRef to a key in a Secret resource containing password for the
+                                user used to authenticate with Vault using the UserPass authentication
+                                method
+                              properties:
+                                key:
+                                  description: |-
+                                    A key in the referenced Secret.
+                                    Some instances of this field may be defaulted, in others it may be required.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[-._a-zA-Z0-9]+$
+                                  type: string
+                                name:
+                                  description: The name of the Secret resource being referred to.
+                                  maxLength: 253
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    The namespace of the Secret resource being referred to.
+                                    Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              type: object
+                            username:
+                              description: |-
+                                Username is a username used to authenticate using the UserPass Vault
+                                authentication method
+                              type: string
+                          required:
+                            - path
+                            - username
+                          type: object
+                      type: object
+                    caBundle:
+                      description: |-
+                        PEM encoded CA bundle used to validate Vault server certificate. Only used
+                        if the Server URL is using HTTPS protocol. This parameter is ignored for
+                        plain HTTP protocol connection. If not set the system root certificates
+                        are used to validate the TLS connection.
+                      format: byte
+                      type: string
+                    caProvider:
+                      description: The provider for the CA bundle to use to validate Vault server certificate.
+                      properties:
+                        key:
+                          description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[-._a-zA-Z0-9]+$
+                          type: string
+                        name:
+                          description: The name of the object located at the provider type.
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                          type: string
+                        namespace:
+                          description: |-
+                            The namespace the Provider type is in.
+                            Can only be defined when used in a ClusterSecretStore.
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        type:
+                          description: The type of provider to use such as "Secret", or "ConfigMap".
+                          enum:
+                            - Secret
+                            - ConfigMap
+                          type: string
+                      required:
+                        - name
+                        - type
+                      type: object
+                    checkAndSet:
+                      description: |-
+                        CheckAndSet defines the Check-And-Set (CAS) settings for PushSecret operations.
+                        Only applies to Vault KV v2 stores. When enabled, write operations must include
+                        the current version of the secret to prevent unintentional overwrites.
+                      properties:
+                        required:
+                          description: |-
+                            Required when true, all write operations must include a check-and-set parameter.
+                            This helps prevent unintentional overwrites of secrets.
+                          type: boolean
+                      type: object
+                    forwardInconsistent:
+                      description: |-
+                        ForwardInconsistent tells Vault to forward read-after-write requests to the Vault
+                        leader instead of simply retrying within a loop. This can increase performance if
+                        the option is enabled serverside.
+                        https://www.vaultproject.io/docs/configuration/replication#allow_forwarding_via_header
+                      type: boolean
+                    headers:
+                      additionalProperties:
+                        type: string
+                      description: Headers to be added in Vault request
+                      type: object
+                    namespace:
+                      description: |-
+                        Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows
+                        Vault environments to support Secure Multi-tenancy. e.g: "ns1".
+                        More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+                      type: string
+                    path:
+                      description: |-
+                        Path is the mount path of the Vault KV backend endpoint, e.g:
+                        "secret". The v2 KV secret engine version specific "/data" path suffix
+                        for fetching secrets from Vault is optional and will be appended
+                        if not present in specified path.
+                      type: string
+                    readYourWrites:
+                      description: |-
+                        ReadYourWrites ensures isolated read-after-write semantics by
+                        providing discovered cluster replication states in each request.
+                        More information about eventual consistency in Vault can be found here
+                        https://www.vaultproject.io/docs/enterprise/consistency
+                      type: boolean
+                    server:
+                      description: 'Server is the connection address for the Vault server, e.g: "https://vault.example.com:8200".'
+                      type: string
+                    tls:
+                      description: |-
+                        The configuration used for client side related TLS communication, when the Vault server
+                        requires mutual authentication. Only used if the Server URL is using HTTPS protocol.
+                        This parameter is ignored for plain HTTP protocol connection.
+                        It's worth noting this configuration is different from the "TLS certificates auth method",
+                        which is available under the `auth.cert` section.
+                      properties:
+                        certSecretRef:
+                          description: |-
+                            CertSecretRef is a certificate added to the transport layer
+                            when communicating with the Vault server.
+                            If no key for the Secret is specified, external-secret will default to 'tls.crt'.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        keySecretRef:
+                          description: |-
+                            KeySecretRef to a key in a Secret resource containing client private key
+                            added to the transport layer when communicating with the Vault server.
+                            If no key for the Secret is specified, external-secret will default to 'tls.key'.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                      type: object
+                    version:
+                      default: v2
+                      description: |-
+                        Version is the Vault KV secret engine version. This can be either "v1" or
+                        "v2". Version defaults to "v2".
+                      enum:
+                        - v1
+                        - v2
+                      type: string
+                  required:
+                    - server
+                  type: object
+                resultType:
+                  default: Data
+                  description: |-
+                    Result type defines which data is returned from the generator.
+                    By default, it is the "data" section of the Vault API response.
+                    When using e.g. /auth/token/create the "data" section is empty but
+                    the "auth" section contains the generated token.
+                    Please refer to the vault docs regarding the result data structure.
+                    Additionally, accessing the raw response is possibly by using "Raw" result type.
+                  enum:
+                    - Data
+                    - Auth
+                    - Raw
+                  type: string
+                retrySettings:
+                  description: Used to configure http retries if failed
+                  properties:
+                    maxRetries:
+                      format: int32
+                      type: integer
+                    retryInterval:
+                      type: string
+                  type: object
+              required:
+                - path
+                - provider
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/CustomResourceDefinition-webhooks-generators-external-secrets-io.yaml
+++ b/manifests/prd/external-secrets/CustomResourceDefinition-webhooks-generators-external-secrets-io.yaml
@@ -1,0 +1,221 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  labels:
+    external-secrets.io/component: controller
+  name: webhooks.generators.external-secrets.io
+spec:
+  group: generators.external-secrets.io
+  names:
+    categories:
+      - external-secrets
+      - external-secrets-generators
+    kind: Webhook
+    listKind: WebhookList
+    plural: webhooks
+    singular: webhook
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            Webhook connects to a third party API server to handle the secrets generation
+            configuration parameters in spec.
+            You can specify the server, the token, and additional body parameters.
+            See documentation for the full API specification for requests and responses.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: WebhookSpec controls the behavior of the external generator. Any body parameters should be passed to the server through the parameters field.
+              properties:
+                auth:
+                  description: Auth specifies a authorization protocol. Only one protocol may be set.
+                  maxProperties: 1
+                  minProperties: 1
+                  properties:
+                    ntlm:
+                      description: NTLMProtocol configures the store to use NTLM for auth
+                      properties:
+                        passwordSecret:
+                          description: |-
+                            SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                            In some instances, `key` is a required field.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                        usernameSecret:
+                          description: |-
+                            SecretKeySelector is a reference to a specific 'key' within a Secret resource.
+                            In some instances, `key` is a required field.
+                          properties:
+                            key:
+                              description: |-
+                                A key in the referenced Secret.
+                                Some instances of this field may be defaulted, in others it may be required.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[-._a-zA-Z0-9]+$
+                              type: string
+                            name:
+                              description: The name of the Secret resource being referred to.
+                              maxLength: 253
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            namespace:
+                              description: |-
+                                The namespace of the Secret resource being referred to.
+                                Ignored if referent is not cluster-scoped, otherwise defaults to the namespace of the referent.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          type: object
+                      required:
+                        - passwordSecret
+                        - usernameSecret
+                      type: object
+                  type: object
+                body:
+                  description: Body
+                  type: string
+                caBundle:
+                  description: |-
+                    PEM encoded CA bundle used to validate webhook server certificate. Only used
+                    if the Server URL is using HTTPS protocol. This parameter is ignored for
+                    plain HTTP protocol connection. If not set the system root certificates
+                    are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                caProvider:
+                  description: The provider for the CA bundle to use to validate webhook server certificate.
+                  properties:
+                    key:
+                      description: The key where the CA certificate can be found in the Secret or ConfigMap.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[-._a-zA-Z0-9]+$
+                      type: string
+                    name:
+                      description: The name of the object located at the provider type.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    namespace:
+                      description: The namespace the Provider type is in.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    type:
+                      description: The type of provider to use such as "Secret", or "ConfigMap".
+                      enum:
+                        - Secret
+                        - ConfigMap
+                      type: string
+                  required:
+                    - name
+                    - type
+                  type: object
+                headers:
+                  additionalProperties:
+                    type: string
+                  description: Headers
+                  type: object
+                method:
+                  description: Webhook Method
+                  type: string
+                result:
+                  description: Result formatting
+                  properties:
+                    jsonPath:
+                      description: Json path of return value
+                      type: string
+                  type: object
+                secrets:
+                  description: |-
+                    Secrets to fill in templates
+                    These secrets will be passed to the templating function as key value pairs under the given name
+                  items:
+                    description: WebhookSecret defines a secret reference that will be used in webhook templates.
+                    properties:
+                      name:
+                        description: Name of this secret in templates
+                        type: string
+                      secretRef:
+                        description: Secret ref to fill in credentials
+                        properties:
+                          key:
+                            description: The key where the token is found.
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[-._a-zA-Z0-9]+$
+                            type: string
+                          name:
+                            description: The name of the Secret resource being referred to.
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        type: object
+                    required:
+                      - name
+                      - secretRef
+                    type: object
+                  type: array
+                timeout:
+                  description: Timeout
+                  type: string
+                url:
+                  description: Webhook url to call
+                  type: string
+              required:
+                - result
+                - url
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/manifests/prd/external-secrets/Deployment-external-secrets-cert-controller.yaml
+++ b/manifests/prd/external-secrets/Deployment-external-secrets-cert-controller.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-cert-controller
+  name: external-secrets-cert-controller
+  namespace: external-secrets
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: external-secrets
+      app.kubernetes.io/name: external-secrets-cert-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: external-secrets
+        app.kubernetes.io/name: external-secrets-cert-controller
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - certcontroller
+            - --crd-requeue-interval=5m
+            - --service-name=external-secrets-webhook
+            - --service-namespace=external-secrets
+            - --secret-name=external-secrets-webhook
+            - --secret-namespace=external-secrets
+            - --metrics-addr=:8080
+            - --healthz-addr=:8081
+            - --loglevel=info
+            - --zap-time-encoding=epoch
+            - --enable-partial-cache=true
+          image: ghcr.io/external-secrets/external-secrets:v2.8.0
+          imagePullPolicy: IfNotPresent
+          name: cert-controller
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 8081
+              name: ready
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: ready
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+      hostNetwork: false
+      serviceAccountName: external-secrets-cert-controller

--- a/manifests/prd/external-secrets/Deployment-external-secrets-webhook.yaml
+++ b/manifests/prd/external-secrets/Deployment-external-secrets-webhook.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-webhook
+  name: external-secrets-webhook
+  namespace: external-secrets
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: external-secrets
+      app.kubernetes.io/name: external-secrets-webhook
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: external-secrets
+        app.kubernetes.io/name: external-secrets-webhook
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - webhook
+            - --port=10250
+            - --dns-name=external-secrets-webhook.external-secrets.svc
+            - --cert-dir=/tmp/certs
+            - --check-interval=5m
+            - --metrics-addr=:8080
+            - --healthz-addr=:8081
+            - --loglevel=info
+            - --zap-time-encoding=epoch
+          image: ghcr.io/external-secrets/external-secrets:v2.8.0
+          imagePullPolicy: IfNotPresent
+          name: webhook
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+            - containerPort: 10250
+              name: webhook
+              protocol: TCP
+            - containerPort: 8081
+              name: ready
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: ready
+            initialDelaySeconds: 20
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - mountPath: /tmp/certs
+              name: certs
+              readOnly: true
+      hostNetwork: false
+      serviceAccountName: external-secrets-webhook
+      volumes:
+        - name: certs
+          secret:
+            secretName: external-secrets-webhook

--- a/manifests/prd/external-secrets/Deployment-external-secrets.yaml
+++ b/manifests/prd/external-secrets/Deployment-external-secrets.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+  name: external-secrets
+  namespace: external-secrets
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: external-secrets
+      app.kubernetes.io/name: external-secrets
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: external-secrets
+        app.kubernetes.io/name: external-secrets
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - --concurrent=1
+            - --metrics-addr=:8080
+            - --loglevel=info
+            - --zap-time-encoding=epoch
+          image: ghcr.io/external-secrets/external-secrets:v2.8.0
+          imagePullPolicy: IfNotPresent
+          name: external-secrets
+          ports:
+            - containerPort: 8080
+              name: metrics
+              protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+      dnsPolicy: ClusterFirst
+      hostNetwork: false
+      serviceAccountName: external-secrets

--- a/manifests/prd/external-secrets/Namespace-external-secrets.yaml
+++ b/manifests/prd/external-secrets/Namespace-external-secrets.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
+  name: external-secrets

--- a/manifests/prd/external-secrets/Role-external-secrets-leaderelection.yaml
+++ b/manifests/prd/external-secrets/Role-external-secrets-leaderelection.yaml
@@ -1,0 +1,34 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+  name: external-secrets-leaderelection
+  namespace: external-secrets
+rules:
+  - apiGroups:
+      - ""
+    resourceNames:
+      - external-secrets-controller
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+      - patch

--- a/manifests/prd/external-secrets/RoleBinding-external-secrets-leaderelection.yaml
+++ b/manifests/prd/external-secrets/RoleBinding-external-secrets-leaderelection.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+  name: external-secrets-leaderelection
+  namespace: external-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: external-secrets-leaderelection
+subjects:
+  - kind: ServiceAccount
+    name: external-secrets
+    namespace: external-secrets

--- a/manifests/prd/external-secrets/Secret-external-secrets-webhook.yaml
+++ b/manifests/prd/external-secrets/Secret-external-secrets-webhook.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-webhook
+    external-secrets.io/component: webhook
+  name: external-secrets-webhook
+  namespace: external-secrets

--- a/manifests/prd/external-secrets/Service-external-secrets-webhook.yaml
+++ b/manifests/prd/external-secrets/Service-external-secrets-webhook.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-webhook
+    external-secrets.io/component: webhook
+  name: external-secrets-webhook
+  namespace: external-secrets
+spec:
+  ports:
+    - name: webhook
+      port: 443
+      protocol: TCP
+      targetPort: webhook
+  selector:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-webhook
+  type: ClusterIP

--- a/manifests/prd/external-secrets/ServiceAccount-external-secrets-cert-controller.yaml
+++ b/manifests/prd/external-secrets/ServiceAccount-external-secrets-cert-controller.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-cert-controller
+  name: external-secrets-cert-controller
+  namespace: external-secrets

--- a/manifests/prd/external-secrets/ServiceAccount-external-secrets-webhook.yaml
+++ b/manifests/prd/external-secrets/ServiceAccount-external-secrets-webhook.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-webhook
+  name: external-secrets-webhook
+  namespace: external-secrets

--- a/manifests/prd/external-secrets/ServiceAccount-external-secrets.yaml
+++ b/manifests/prd/external-secrets/ServiceAccount-external-secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets
+  name: external-secrets
+  namespace: external-secrets

--- a/manifests/prd/external-secrets/ValidatingWebhookConfiguration-externalsecret-validate.yaml
+++ b/manifests/prd/external-secrets/ValidatingWebhookConfiguration-externalsecret-validate.yaml
@@ -1,0 +1,33 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-webhook
+    external-secrets.io/component: webhook
+  name: externalsecret-validate
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: external-secrets-webhook
+        namespace: external-secrets
+        path: /validate-external-secrets-io-v1-externalsecret
+    failurePolicy: Fail
+    name: validate.externalsecret.external-secrets.io
+    rules:
+      - apiGroups:
+          - external-secrets.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - externalsecrets
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 5

--- a/manifests/prd/external-secrets/ValidatingWebhookConfiguration-secretstore-validate.yaml
+++ b/manifests/prd/external-secrets/ValidatingWebhookConfiguration-secretstore-validate.yaml
@@ -1,0 +1,57 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/instance: external-secrets
+    app.kubernetes.io/name: external-secrets-webhook
+    external-secrets.io/component: webhook
+  name: secretstore-validate
+webhooks:
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: external-secrets-webhook
+        namespace: external-secrets
+        path: /validate-external-secrets-io-v1-secretstore
+    failurePolicy: Fail
+    name: validate.secretstore.external-secrets.io
+    rules:
+      - apiGroups:
+          - external-secrets.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - secretstores
+        scope: Namespaced
+    sideEffects: None
+    timeoutSeconds: 5
+  - admissionReviewVersions:
+      - v1
+      - v1beta1
+    clientConfig:
+      service:
+        name: external-secrets-webhook
+        namespace: external-secrets
+        path: /validate-external-secrets-io-v1-clustersecretstore
+    failurePolicy: Fail
+    name: validate.clustersecretstore.external-secrets.io
+    rules:
+      - apiGroups:
+          - external-secrets.io
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - clustersecretstores
+        scope: Cluster
+    sideEffects: None
+    timeoutSeconds: 5

--- a/modules/clusters/prd.nix
+++ b/modules/clusters/prd.nix
@@ -81,8 +81,9 @@ in
 
   # cert-manager is included only for Cilium's Hubble mTLS
   # (modules/kubernetes/cert-manager/default.nix) — Helm's own cert
-  # generation isn't idempotent across renders. external-secrets/sops-operator
-  # remain out of scope.
+  # generation isn't idempotent across renders. external-secrets reads from
+  # 1Password (modules/kubernetes/external-secrets/default.nix); sops-operator
+  # remains out of scope.
   den.aspects.prd.includes = with den.aspects; [
     gateway-api-crds
     cilium
@@ -91,6 +92,7 @@ in
     coredns
     argocd
     openebs
+    external-secrets
   ];
 
   # Cluster-level BGP instance parameters (den.quirks.bgp, modules/den/

--- a/modules/den/policies/cluster.nix
+++ b/modules/den/policies/cluster.nix
@@ -55,7 +55,44 @@
       }
     ) (lib.unique config.systems);
 
+  # Cluster -> onepassword-items collection policy. Unlike cluster-to-nixidy,
+  # this needs plain Nix data (not a real nixidy module list), so it follows
+  # modules/terragrunt/collect.nix's routeros-device-to-terragrunt technique
+  # instead: a real per-aspect lib.evalModules pass (den also injects an
+  # anonymous, key-less companion module alongside any quirk-requesting
+  # entry — filter on `m ? key`, per that file's own comment). Unlike
+  # terragrunt-stacks, onepassword-items content needs no per-entry key to
+  # disambiguate by (Terraform's own onepassword_item `for_each` keys by
+  # item title) — just a flat list of every included aspect's item spec.
+  den.policies.cluster-to-onepassword-items =
+    { cluster, ... }:
+    [
+      (den.lib.policy.instantiate {
+        name = "${cluster.name}-onepassword-items";
+        class = "onepassword-items";
+        instantiate =
+          { modules, ... }:
+          map (
+            m:
+            (lib.evalModules {
+              modules = [
+                (builtins.head m.imports)
+                { _module.freeformType = lib.types.attrsOf lib.types.raw; }
+              ];
+              specialArgs = {
+                inherit cluster;
+              };
+            }).config
+          ) (builtins.filter (m: m ? key) modules);
+        intoAttr = [
+          "onepasswordItems"
+          cluster.name
+        ];
+      })
+    ];
+
   den.schema.cluster.includes = [
     den.policies.cluster-to-nixidy
+    den.policies.cluster-to-onepassword-items
   ];
 }

--- a/modules/flake/devshell.nix
+++ b/modules/flake/devshell.nix
@@ -1,13 +1,26 @@
 # devShell, carried over from the pre-dendritic flake.nix. treefmt config
 # lives in modules/flake/formatter.nix, git hooks in modules/flake/git-hooks.nix.
-_: {
+{ inputs, ... }: {
   perSystem =
     {
       config,
       pkgs,
+      lib,
+      system,
       ...
     }:
     {
+      # 1password-cli is unfree; flake-parts' own nixpkgs module (module/
+      # nixpkgs.nix) sets perSystem's `pkgs` via `_module.args.pkgs =
+      # mkOptionDefault (...)`, so redefining it here (repo-wide, not just
+      # this file — `pkgs` is a single per-system arg) overrides that
+      # default. Scoped to exactly this one package rather than a blanket
+      # `allowUnfree = true`.
+      _module.args.pkgs = import inputs.nixpkgs {
+        inherit system;
+        config.allowUnfreePredicate = pkg: builtins.elem (lib.getName pkg) [ "1password-cli" ];
+      };
+
       devShells.default = pkgs.mkShell {
         packages =
           with pkgs;
@@ -22,6 +35,8 @@ _: {
             opentofu
             tofu-ls
             terragrunt
+            _1password-cli
+            secretspec
 
             go
             gotestsum

--- a/modules/flake/onepassword-items.nix
+++ b/modules/flake/onepassword-items.nix
@@ -1,0 +1,10 @@
+# Registers "onepassword-items" as a den content class. Collected per-cluster
+# by modules/den/policies/cluster.nix's cluster-to-onepassword-items policy,
+# into config.flake.onepasswordItems.<cluster.name> — the data
+# modules/terragrunt/collect.nix renders into the onepassword-items
+# Terraform stack.
+{
+  den.classes."onepassword-items" = {
+    description = "1Password vault items collected for the onepassword-items Terraform stack";
+  };
+}

--- a/modules/kubernetes/_secrets-lib.nix
+++ b/modules/kubernetes/_secrets-lib.nix
@@ -1,0 +1,46 @@
+# Shared per-app secret-declaration convention: one spec drives both the
+# 1Password item Terraform creates (modules/flake/onepassword-items.nix,
+# tf-modules/onepassword-items/) and the ExternalSecret k8s manifest that
+# reads it (modules/kubernetes/external-secrets/default.nix), so the two can
+# never drift out of sync with each other. Leading underscore: import-tree
+# skips this, same convention as modules/network/_ros-lib.nix. Needs no
+# outside args, so unlike that file this is a plain attrset, not a function.
+{
+  # spec = { title, vault ? "home-ops", category, fields }
+  # field = { name, generate ? false, length ? 32, k8sKey ? name }
+  #   generate = true  -> Terraform mints the value itself (random password/
+  #                        token), fully automated.
+  #   generate = false -> Terraform creates the field empty; a human or
+  #                        secretspec fills the real value in afterward.
+
+  mkOnePasswordItem =
+    {
+      title,
+      vault ? "home-ops",
+      category,
+      fields,
+    }:
+    {
+      inherit title vault category;
+      fields = map (f: {
+        inherit (f) name;
+        generate = f.generate or false;
+        length = f.length or 32;
+      }) fields;
+    };
+
+  # ESO's 1Password SDK provider (onepasswordSDK) matches ExternalSecret
+  # .data[] entries by a single combined "<item>/[section/]<field>"
+  # remoteRef.key — unlike the older Connect provider, there's no separate
+  # `property` field (external-secrets.io/main/provider/1password-sdk).
+  # tf-modules/onepassword-items/main.tf puts every custom field inside one
+  # fixed "fields" section (the provider's onepassword_item resource has no
+  # top-level custom-field slot, only section_map/section) — this "fields"
+  # literal must match that module's section_map key exactly.
+  mkExternalSecretData =
+    { title, fields, ... }:
+    map (f: {
+      secretKey = f.k8sKey or f.name;
+      remoteRef.key = "${title}/fields/${f.name}";
+    }) fields;
+}

--- a/modules/kubernetes/cert-manager/default.nix
+++ b/modules/kubernetes/cert-manager/default.nix
@@ -10,7 +10,23 @@
 # chart gates its CRDs behind crds.enabled (default false, same as the
 # Helm release's own values below), and kindFilter matches nothing if the
 # chart is templated without it.
-_: {
+let
+  secretsLib = import ../_secrets-lib.nix;
+
+  # Prototype for the shared secret-declaration convention
+  # (modules/kubernetes/_secrets-lib.nix): proves a real, externally-sourced
+  # secret flows Terraform -> 1Password -> ESO -> an in-cluster Secret. Not
+  # yet consumed by a ClusterIssuer (ACME DNS-01 is a separate follow-up) —
+  # this only exercises the plumbing.
+  cloudflareDnsApiToken = {
+    title = "cloudflare-dns-api-token";
+    category = "password";
+    fields = [ { name = "token"; } ];
+  };
+in
+{
+  den.aspects.cert-manager."onepassword-items" = secretsLib.mkOnePasswordItem cloudflareDnsApiToken;
+
   den.aspects.cert-manager.k8s-manifests =
     { charts, generators, ... }:
     {
@@ -65,6 +81,15 @@ _: {
         };
 
         resources.clusterIssuers.hubble-ca-issuer.spec.ca.secretName = "hubble-ca-secret";
+
+        resources.externalSecrets.cloudflare-dns-api-token.spec = {
+          secretStoreRef = {
+            kind = "ClusterSecretStore";
+            name = "onepassword";
+          };
+          target.creationPolicy = "Owner";
+          data = secretsLib.mkExternalSecretData cloudflareDnsApiToken;
+        };
       };
     };
 }

--- a/modules/kubernetes/external-secrets/default.nix
+++ b/modules/kubernetes/external-secrets/default.nix
@@ -1,0 +1,63 @@
+# External Secrets Operator, reading from 1Password via ESO's SDK provider
+# (onepasswordSDK) — a direct 1Password-cloud API integration authenticated
+# with a Service Account token, no Connect server deployment needed (fewest
+# new moving pieces for a single-node home cluster). "A store is per vault"
+# (external-secrets.io/main/provider/1password-sdk) — this repo has exactly
+# one 1Password vault (home-ops, matching modules/network/_ros-lib.nix's
+# op_vault) and one matching cluster-scoped ClusterSecretStore.
+#
+# The bootstrap credential this store's auth.serviceAccountSecretRef points
+# at (onepassword-service-account-token/token, in the external-secrets
+# namespace) is delivered onto node1 outside of ArgoCD entirely — see the
+# k3s-external-secrets sops-nix aspect included on node1
+# (modules/hosts/node1.nix) — ESO itself has no way to bootstrap the very
+# credential it needs to talk to 1Password.
+#
+# ExternalSecret/ClusterSecretStore aren't core Kubernetes types, so nixidy
+# has no built-in typed options for them — generators.fromChartCRDModule (the
+# same technique modules/kubernetes/cert-manager/default.nix uses for
+# ClusterIssuer/Certificate) generates them live from the chart's own CRDs.
+# ExternalSecret is included here (not just ClusterSecretStore) so any other
+# app aspect can declare its own `resources.externalSecrets.<name>` — see
+# modules/kubernetes/_secrets-lib.nix's mkExternalSecretData.
+_: {
+  den.aspects.external-secrets.k8s-manifests =
+    { charts, generators, ... }:
+    {
+      nixidy.applicationImports = [
+        (generators.fromChartCRDModule {
+          name = "external-secrets";
+          chart = charts.external-secrets.external-secrets;
+          kindFilter = [
+            "ClusterSecretStore"
+            "ExternalSecret"
+          ];
+          extraOpts = [
+            "--set"
+            "installCRDs=true"
+          ];
+        })
+      ];
+
+      applications.external-secrets = {
+        namespace = "external-secrets";
+        createNamespace = true;
+
+        helm.releases.external-secrets = {
+          chart = charts.external-secrets.external-secrets;
+          values = {
+            installCRDs = true;
+          };
+        };
+
+        resources.clusterSecretStores.onepassword.spec.provider.onepasswordSDK = {
+          vault = "home-ops";
+          auth.serviceAccountSecretRef = {
+            name = "onepassword-service-account-token";
+            key = "token";
+            namespace = "external-secrets";
+          };
+        };
+      };
+    };
+}

--- a/modules/terragrunt/devshell.nix
+++ b/modules/terragrunt/devshell.nix
@@ -1,5 +1,7 @@
-# Renders config.flake.terragruntStacks (modules/terragrunt/collect.nix) to
-# tf-stacks/<env>/network/<routerosDevice>/[<stack>/]terragrunt.hcl, exposed
+# Renders config.flake.terragruntStacks (modules/terragrunt/collect.nix,
+# modules/terragrunt/onepassword-items.nix) to
+# tf-stacks/<env>/network/<routerosDevice>/[<stack>/]terragrunt.hcl or
+# tf-stacks/<env>/<stack>/terragrunt.hcl for cluster-sourced stacks, exposed
 # as `nix run .#write-terragrunt` (mirrors apps.write-manifests/
 # write-terraform elsewhere in the dendritic ecosystem) + `checks.terragrunt`
 # (diffs generated vs. committed, like checks.terraform/checks.cluster-inventory).
@@ -13,16 +15,27 @@ let
   inherit (import ./_render-lib.nix { inherit lib; }) toValue;
 
   routerosDevicesByName = config.den.routerosDevices;
+  clustersByName = config.den.clusters;
 
+  # terragruntStacks is keyed by entity name, mixing routerosDevice-sourced
+  # (network/<device>/[<stack>/]) and cluster-sourced (<stack>/, flat —
+  # there's exactly one stack name per cluster today) leaves. Names never
+  # collide between the two entity kinds (rb5009/crs320 vs. prd).
   leafRelPath =
-    routerosDeviceName: stack:
-    let
-      envName = routerosDevicesByName.${routerosDeviceName}.environment;
-    in
-    if stack == "base" then
-      "tf-stacks/${envName}/network/${routerosDeviceName}/terragrunt.hcl"
+    entityName: stack:
+    if routerosDevicesByName ? ${entityName} then
+      let
+        envName = routerosDevicesByName.${entityName}.environment;
+      in
+      if stack == "base" then
+        "tf-stacks/${envName}/network/${entityName}/terragrunt.hcl"
+      else
+        "tf-stacks/${envName}/network/${entityName}/${stack}/terragrunt.hcl"
     else
-      "tf-stacks/${envName}/network/${routerosDeviceName}/${stack}/terragrunt.hcl";
+      let
+        envName = clustersByName.${entityName}.environment;
+      in
+      "tf-stacks/${envName}/${stack}/terragrunt.hcl";
 
   # Every stack's directory sits one level (base: network/<routerosDevice>/)
   # or two levels (non-base: network/<routerosDevice>/<stack>/) below
@@ -39,7 +52,7 @@ let
     (lib.concatStrings (lib.replicate upLevels "../")) + toRouterosDevice;
 
   renderLeaf =
-    _routerosDeviceName: stack: leaf:
+    _entityName: stack: leaf:
     let
       dependenciesBlock = lib.optionalString (leaf.dependsOn != [ ]) ''
 
@@ -57,6 +70,20 @@ let
           }
         }
       '';
+
+      # localModule (a tf-modules/<name> dir in this repo, e.g. the
+      # onepassword-items stack) vs. the git-catalog-sourced modules every
+      # RouterOS stack uses. get_repo_root() is a Terragrunt function,
+      # evaluated against the real checkout at run time — deliberately not
+      # a Nix interpolation (''${ escapes it), same reasoning _render-lib.nix
+      # documents for hcl.raw.
+      sourceBlock =
+        if leaf ? localModule then
+          ''source                   = "''${get_repo_root()}/tf-modules/${leaf.localModule}"''
+        else
+          ''source                   = "git::git@github.com:kid/terragrunt-infra-catalog//modules/${leaf.moduleSource}?ref=${
+            leaf.moduleRef or "${leaf.moduleSource}/v${leaf.moduleVersion}"
+          }"'';
     in
     ''
       include "root" {
@@ -64,9 +91,7 @@ let
       }
 
       terraform {
-        source                   = "git::git@github.com:kid/terragrunt-infra-catalog//modules/${leaf.moduleSource}?ref=${
-          leaf.moduleRef or "${leaf.moduleSource}/v${leaf.moduleVersion}"
-        }"
+        ${sourceBlock}
         copy_terraform_lock_file = false
       }
       ${dependenciesBlock}
@@ -75,10 +100,10 @@ let
 
   allLeaves = lib.flatten (
     lib.mapAttrsToList (
-      routerosDeviceName: stacks:
+      entityName: stacks:
       lib.mapAttrsToList (stack: leaf: {
-        path = leafRelPath routerosDeviceName stack;
-        content = renderLeaf routerosDeviceName stack leaf;
+        path = leafRelPath entityName stack;
+        content = renderLeaf entityName stack leaf;
       }) stacks
     ) (config.flake.terragruntStacks or { })
   );

--- a/modules/terragrunt/onepassword-items.nix
+++ b/modules/terragrunt/onepassword-items.nix
@@ -1,0 +1,54 @@
+# Folds config.flake.onepasswordItems (modules/den/policies/cluster.nix's
+# cluster-to-onepassword-items policy) into config.flake.terragruntStacks
+# (modules/terragrunt/collect.nix's home, though this policy is defined
+# alongside it rather than in that file, to keep collect.nix's existing
+# routerosDevice-only logic untouched) as one combined leaf per cluster, so
+# modules/terragrunt/devshell.nix's existing write-terragrunt/
+# checks.terragrunt machinery renders and checks it with no further
+# generalization needed — the aspect-includes walking already happened in
+# cluster-to-onepassword-items; this just reshapes its already-collected
+# result into a "terragrunt-stacks"-class leaf via den's own
+# intoAttr mechanism (the only thing that can safely merge into
+# flake.terragruntStacks alongside collect.nix's own routerosDevice
+# contributions — a plain second `flake.terragruntStacks = ...;` module
+# collides, since flake-parts requires undeclared flake outputs to have
+# exactly one definition site).
+#
+# One leaf per cluster, not one per app: every app's 1Password items share a
+# single Terraform state, since each is small and none need an independent
+# apply.
+{
+  config,
+  lib,
+  den,
+  ...
+}:
+{
+  den.policies.cluster-to-onepassword-terragrunt =
+    { cluster, ... }:
+    [
+      (den.lib.policy.instantiate {
+        name = "${cluster.name}-onepassword-items-terragrunt";
+        class = "onepassword-items";
+        instantiate =
+          _:
+          let
+            items = config.flake.onepasswordItems.${cluster.name} or [ ];
+          in
+          lib.optionalAttrs (items != [ ]) {
+            onepassword-items = {
+              stack = "onepassword-items";
+              localModule = "onepassword-items";
+              dependsOn = [ ];
+              inputs.items = items;
+            };
+          };
+        intoAttr = [
+          "terragruntStacks"
+          cluster.name
+        ];
+      })
+    ];
+
+  den.schema.cluster.includes = [ den.policies.cluster-to-onepassword-terragrunt ];
+}

--- a/tf-modules/onepassword-items/main.tf
+++ b/tf-modules/onepassword-items/main.tf
@@ -1,0 +1,83 @@
+# 1Password vault items whose *layout* (title/category/field names) is
+# Nix-declared — modules/kubernetes/_secrets-lib.nix's mkOnePasswordItem,
+# collected by modules/den/policies/cluster.nix's
+# cluster-to-onepassword-items policy, rendered by
+# modules/terragrunt/collect.nix into the `items` variable below. Fixes the
+# vault-layout-drift pain point: the same spec also drives each app's
+# ExternalSecret (mkExternalSecretData), so a field can't exist on one side
+# without the other.
+#
+# `service_account_token` is deliberately absent from the provider block —
+# the 1Password provider reads it from the OP_SERVICE_ACCOUNT_TOKEN
+# environment variable on its own, so it never touches a .tfvars file or
+# Terraform state.
+terraform {
+  required_providers {
+    onepassword = {
+      source  = "1Password/onepassword"
+      version = "~> 3.3"
+    }
+  }
+}
+
+provider "onepassword" {}
+
+variable "items" {
+  description = "1Password items to create/manage, one per app secret spec."
+  type = list(object({
+    title    = string
+    vault    = string
+    category = string
+    fields = list(object({
+      name     = string
+      generate = bool
+      length   = number
+    }))
+  }))
+}
+
+# Only the vault names actually referenced, so a typo'd vault name fails
+# fast with a clear "vault not found" error instead of silently creating a
+# data source no item uses.
+data "onepassword_vault" "vaults" {
+  for_each = toset([for item in var.items : item.vault])
+  name     = each.value
+}
+
+# Every custom field lives in one fixed section ("fields") so ESO's remote
+# reference format (<item>/<section>/<field>, external-secrets.io/main/
+# provider/1password-sdk) stays predictable — mkExternalSecretData builds
+# the exact same "<title>/fields/<name>" path.
+resource "onepassword_item" "items" {
+  for_each = { for item in var.items : item.title => item }
+
+  vault    = data.onepassword_vault.vaults[each.value.vault].uuid
+  title    = each.value.title
+  category = each.value.category
+
+  section_map = {
+    fields = {
+      field_map = {
+        for field in each.value.fields : field.name => {
+          type  = "CONCEALED"
+          value = field.generate ? null : ""
+          password_recipe = field.generate ? {
+            length  = field.length
+            digits  = null
+            symbols = null
+          } : null
+        }
+      }
+    }
+  }
+
+  # Once created, Terraform never touches section_map contents again: a
+  # generate=false field's value is meant to be filled in by hand (or
+  # secretspec) afterward, and re-applying must not reset it back to "".
+  # Trade-off, deliberate: changing a field's shape later (add/rename/
+  # regenerate) needs a manual `terraform taint`/recreate, not a plain
+  # re-apply — acceptable for a home cluster's low change rate.
+  lifecycle {
+    ignore_changes = [section_map]
+  }
+}

--- a/tf-stacks/prd/onepassword-items/terragrunt.hcl
+++ b/tf-stacks/prd/onepassword-items/terragrunt.hcl
@@ -1,0 +1,25 @@
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
+terraform {
+  source                   = "${get_repo_root()}/tf-modules/onepassword-items"
+  copy_terraform_lock_file = false
+}
+
+inputs = {
+  items = [
+    {
+      category = "password"
+      fields = [
+        {
+          generate = false
+          length   = 32
+          name     = "token"
+        },
+      ]
+      title = "cloudflare-dns-api-token"
+      vault = "home-ops"
+    },
+  ]
+}


### PR DESCRIPTION
## Status: draft, not ready to merge — see "Open concern" below

This adds a scaffold for Kubernetes secrets management on the `prd` cluster:
External Secrets Operator (ESO) reading from 1Password, with 1Password vault
item *layout* managed declaratively via Terraform so it can't drift from what
each `ExternalSecret` expects (the pain point from prior ESO+1Password use —
manually creating vault items with the right field names was error-prone).

## Open concern — please read before merging

**I don't like this ESO+1Password design as the final answer, and neither do you.**
1Password's API has hit rate limits before and caused real problems. ESO's
`onepasswordSDK` provider makes live 1Password Cloud API calls on every secret
resolve/refresh, so this PR inherits that exposure. Concretely, before this
merges we should do one of:

- **Mitigate**: wire up the SDK provider's optional client-side cache
  (`cache.ttl`/`cache.maxSize` on the `ClusterSecretStore`, not yet set in
  `modules/kubernetes/external-secrets/default.nix`) and set an explicit,
  longer `refreshInterval` on each `ExternalSecret` (currently using nixidy's
  defaults, whatever those resolve to) to cut request volume.
- **Reconsider the backend**: earlier in this work we compared ESO+1Password
  against Vault/OpenBao (self-hosted, no external API/rate-limit exposure,
  but real added ops burden — unseal, storage, backup) and against 1Password
  Environments (rejected: no Terraform write support today, would reopen the
  layout-drift problem this PR fixes). Worth revisiting Vault/OpenBao now
  that rate limits are a *known* problem, not just a hypothetical trade-off.
- **Scope down**: keep ESO+1Password but for far fewer secrets than a
  general-purpose pattern implies, if the real rate-limit exposure was from
  request *volume* rather than the integration itself.

This PR is a complete, verified scaffold either way — the Terraform-driven
layout mechanism (Phase 1/4 below) is useful regardless of which backend it
ends up pointed at. Opening as draft specifically so this gets decided before
anything real touches the cluster.

## What's done and verified

Every phase below passes `nix flake check --print-build-logs` on this branch.
Phase 4's Terraform module was also validated directly against the real
1Password provider schema (`tofu init && tofu validate`, plus a `tofu plan`
that got past all HCL type-checking and only failed at the expected point —
missing real credentials) and the rendered `inputs.items` leaf was re-validated
against the module a second time after rendering.

1. **`modules/kubernetes/_secrets-lib.nix`** — the shared spec. One
   `{ title, vault, category, fields }` declaration per app drives both
   `mkOnePasswordItem` (Terraform layout) and `mkExternalSecretData`
   (`ExternalSecret.spec.data`, using ESO's `<item>/fields/<field>` remoteRef
   format for the 1Password SDK provider — confirmed against
   `external-secrets/external-secrets`'s actual CRD schema and docs, not
   guessed).
2. **`modules/flake/onepassword-items.nix` + `modules/den/policies/cluster.nix`** —
   new `onepassword-items` den class, collected per-cluster into
   `config.flake.onepasswordItems.<cluster>`.
3. **`modules/kubernetes/external-secrets/default.nix`** — ESO app aspect +
   a `ClusterSecretStore` using ESO's 1Password **SDK** provider
   (`onepasswordSDK`, service-account-token auth) rather than a Connect
   server — one bearer secret, no extra in-cluster server. Wired into
   `modules/clusters/prd.nix`. Deliberately **not** added to
   `modules/den/aspects/services/k3s/bootstrap.nix`'s systemd-oneshot wave —
   follows the existing `openebs` precedent (ArgoCD-sync only), since nothing
   in the bootstrap chain needs a secret.
4. **`tf-modules/onepassword-items/main.tf` + `modules/terragrunt/onepassword-items.nix`** —
   a real, `tofu validate`-checked local Terraform module for
   `onepassword_item` resources, folded into the existing
   `write-terragrunt`/`checks.terragrunt` machinery (generalized
   `modules/terragrunt/devshell.nix` beyond routerosDevice-only). Terraform
   creates each item's shape; fields marked `generate = true` get a
   Terraform-minted value, `generate = false` fields are created empty for a
   human (or `secretspec`) to fill in — `lifecycle.ignore_changes` on
   `section_map` so a filled-in value survives future `terraform apply`.
5. **`op` (1Password CLI) and `secretspec` added to the devshell**
   (`modules/flake/devshell.nix` — also required scoping
   `nixpkgs.config.allowUnfreePredicate` to just `1password-cli`, since it's
   unfree).
6. **Prototype**: `modules/kubernetes/cert-manager/default.nix` declares a
   real `cloudflare-dns-api-token` secret spec (for a future ACME DNS-01
   `ClusterIssuer` — not built here, out of scope) and proves the whole chain
   renders: Terraform item → `ExternalSecret` → both checked into
   `manifests/prd/cert-manager/ExternalSecret-cloudflare-dns-api-token.yaml`
   and `tf-stacks/prd/onepassword-items/terragrunt.hcl`.

## What's not done

**Phase 5 — delivering ESO's own bootstrap credential (a 1Password service
account token) onto `node1`.** This repo has no existing mechanism to deliver
any secret onto a NixOS host (`sops-nix` isn't used anywhere yet; today's SOPS
files decrypt only on two human laptops). The plan is `sops-nix`, encrypted to
an age identity derived from `node1`'s already-persisted SSH host key
(`ssh-to-age`), plus a small standalone systemd oneshot (not joined to the
bootstrap wave) that creates the `external-secrets` namespace and the token
Secret.

Blocked here on two things unavailable from the environment this was built
in: `node1`'s real SSH host public key (host unreachable from that sandbox)
and the real 1Password service account token (shouldn't be typed into a chat
session). Whoever picks this up needs to run, from a machine that can reach
node1:
```
ssh-keyscan -t ed25519 node1
```
convert the result with `ssh-to-age`, add it as a new recipient in
`.sops.yaml`, add `sops-nix` as a flake input, and create
`secrets/prd/eso-1password.sops.yaml` via `sops` with the real token.

Also unproven end-to-end (needs a real cluster + real 1Password account):
ESO actually resolving a secret, and whether the observed rate limits from
prior experience reproduce here or were specific to the earlier setup.

## Decisions made during this session (for context)

- ESO + 1Password only, not Vault/OpenBao — reconsider per the "Open concern"
  section above.
- 1Password Environments considered and rejected: no Terraform write path
  exists today (only a read-only `onepassword_environment` data source), so
  using them would reopen the layout-drift problem this PR fixes. See
  https://github.com/1Password/terraform-provider-onepassword/issues/302.
- `secretspec`'s role kept intentionally minimal: a devshell CLI a human runs
  by hand to fill in a `generate = false` field's value. Not wired into the
  Nix/den model.
- New Terraform module lives repo-local at `tf-modules/onepassword-items/`
  rather than in the private `terragrunt-infra-catalog` catalog repo, to
  avoid bending that repo's RouterOS-device-shaped collection code for one
  cluster-sourced stack.
- `write-terragrunt`/`checks.terragrunt` generalized in place rather than
  adding a second `write-onepassword-items` command.

## How to verify locally

```
nix flake check --print-build-logs   # full check, everything above included
nix run .#write-manifests            # re-render manifests/prd/**, should show no diff
nix run .#write-terragrunt           # re-render tf-stacks/prd/**, should show no diff
```
No `terragrunt apply` or `kubectl apply` has been run against anything real —
this PR only touches the working tree.
