### PR TITLE
Pin Helm charts directly in the repo instead of nixhelm's index

### DIFF
--- a/.github/workflows/update-helm-charts.yaml
+++ b/.github/workflows/update-helm-charts.yaml
@@ -1,0 +1,38 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Update Helm Charts
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Bump pinned chart versions and hashes
+        run: nix develop --command helmupdater update-all
+
+      - name: Regenerate manifests
+        run: nix run .#write-manifests
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+        with:
+          commit-message: "chore(charts): bump pinned helm chart versions"
+          title: "chore(charts): bump pinned helm chart versions"
+          branch: update-helm-charts
+          add-paths: |
+            charts/
+            manifests/prd/

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -52,13 +52,12 @@
     },
   ],
   // Beta: lets Renovate propose a bump PR for individual flake.lock inputs.
-  // Scoped to nixhelm only for now — that's the only lever available for
-  // keeping charts.<repo>.<chart> versions (cilium, cert-manager, coredns,
-  // openebs's own driver) current, since none of those are literal
-  // strings anywhere in this repo. A nixhelm bump changes every chart it
-  // packages at once and, like the customManagers pins above, will fail
-  // checks.manifests until `nix run .#write-manifests` is re-run and
-  // committed alongside it.
+  // Scoped to nixhelm only for now — chart versions themselves
+  // (charts/<org>/<chart>/default.nix) are no longer tracked here at all,
+  // since they're literal strings bumped by the scheduled
+  // .github/workflows/update-helm-charts.yaml job instead. This lever just
+  // keeps nixhelm's own helmupdater CLI (modules/flake/devshell.nix)
+  // current.
   nix: {
     enabled: true,
   },

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,23 @@
+# Pinned Helm charts
+
+Each `charts/<org>/<chart>/default.nix` pins one Helm chart directly in
+this repo — `{ repo; chart; version; chartHash; }` — instead of relying on
+nixhelm's own chart index. `modules/flake/charts.nix` loads this directory
+tree and fetches each entry into a chart derivation, exposed as
+`chartsDerivations.<system>.<org>.<chart>` and consumed by
+`modules/kubernetes/*/default.nix` as `charts.<org>.<chart>`.
+
+Add or update a pin with nixhelm's `helmupdater` CLI, available in the
+devshell:
+
+```console
+helmupdater init "<repo-url>" "<org>/<chart-name>"   # add a new pin
+helmupdater update "<org>/<chart-name>"              # bump one pin's version + hash
+helmupdater update-all                               # bump every pin
+helmupdater rehash "<org>/<chart-name>"               # recompute hash only
+```
+
+After bumping, run `nix run .#write-manifests` and commit both the
+`charts/` change and the regenerated `manifests/prd/` output together —
+`checks.manifests` fails otherwise. `.github/workflows/update-helm-charts.yaml`
+does this on a schedule and opens a PR.

--- a/charts/cilium/cilium/default.nix
+++ b/charts/cilium/cilium/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://helm.cilium.io/";
+  chart = "cilium";
+  version = "1.19.6";
+  chartHash = "sha256-WV+mKdjapuQ7dhus84C2x/0twfz9pb623NVHsfMYEaE=";
+}

--- a/charts/coredns/coredns/default.nix
+++ b/charts/coredns/coredns/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://coredns.github.io/helm";
+  chart = "coredns";
+  version = "1.46.2";
+  chartHash = "sha256-HOFw1qnYU81foPK4UmjgySkQcsrC5YS1V7J98GYifNY=";
+}

--- a/charts/external-secrets/external-secrets/default.nix
+++ b/charts/external-secrets/external-secrets/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://charts.external-secrets.io";
+  chart = "external-secrets";
+  version = "2.8.0";
+  chartHash = "sha256-PPUhkWM5kZSRKwuBLFrEt1cnxtfelj9QGfaEsHUzu5g=";
+}

--- a/charts/jetstack/cert-manager/default.nix
+++ b/charts/jetstack/cert-manager/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://charts.jetstack.io";
+  chart = "cert-manager";
+  version = "v1.21.0";
+  chartHash = "sha256-QRNY61ZvZkC8vtKv5Ng8Zb+vkt109OnUHRB/CYiSYR4=";
+}

--- a/charts/openbao/openbao/default.nix
+++ b/charts/openbao/openbao/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://openbao.github.io/openbao-helm";
+  chart = "openbao";
+  version = "0.28.6";
+  chartHash = "sha256-sxmVXXK71uj/yObhN5I/4Fg/CCZvdmF+QzBqUdN/8o8=";
+}

--- a/charts/openebs/zfs-localpv/default.nix
+++ b/charts/openebs/zfs-localpv/default.nix
@@ -1,0 +1,6 @@
+{
+  repo = "https://openebs.github.io/zfs-localpv";
+  chart = "zfs-localpv";
+  version = "2.10.1";
+  chartHash = "sha256-9/Fw+pA+SEHGZNvdeSJu5XnE0EQ3FxORbgJIzEPhL1U=";
+}

--- a/flake.lock
+++ b/flake.lock
@@ -195,6 +195,27 @@
     "haumea": {
       "inputs": {
         "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1685133229,
+        "narHash": "sha256-FePm/Gi9PBSNwiDFq3N+DWdfxFq0UKsVVTJS3cQPn94=",
+        "owner": "nix-community",
+        "repo": "haumea",
+        "rev": "34dd58385092a23018748b50f9b23de6266dffc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "v0.2.2",
+        "repo": "haumea",
+        "type": "github"
+      }
+    },
+    "haumea_2": {
+      "inputs": {
+        "nixpkgs": [
           "nixhelm",
           "nixpkgs"
         ]
@@ -304,6 +325,21 @@
     },
     "nix-kube-generators_2": {
       "locked": {
+        "lastModified": 1762437901,
+        "narHash": "sha256-5yuJODagAq+aMXQAT2c0gfXKLqapmA6eUHR33jKNHuU=",
+        "owner": "farcaller",
+        "repo": "nix-kube-generators",
+        "rev": "810dcf792081790648ba9ae705b9a2286115ace8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "farcaller",
+        "repo": "nix-kube-generators",
+        "type": "github"
+      }
+    },
+    "nix-kube-generators_3": {
+      "locked": {
         "lastModified": 1748274972,
         "narHash": "sha256-Z8Bh7Y9Rr8PPspfb5M1nNW+zdwdyt43htN1lDqiH09M=",
         "owner": "farcaller",
@@ -341,8 +377,8 @@
     "nixhelm": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "haumea": "haumea",
-        "nix-kube-generators": "nix-kube-generators",
+        "haumea": "haumea_2",
+        "nix-kube-generators": "nix-kube-generators_2",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -367,7 +403,7 @@
     "nixidy": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nix-kube-generators": "nix-kube-generators_2",
+        "nix-kube-generators": "nix-kube-generators_3",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -569,9 +605,11 @@
         "flake-file": "flake-file",
         "flake-parts": "flake-parts",
         "git-hooks-nix": "git-hooks-nix",
+        "haumea": "haumea",
         "impermanence": "impermanence",
         "import-tree": "import-tree",
         "nh": "nh",
+        "nix-kube-generators": "nix-kube-generators",
         "nixhelm": "nixhelm",
         "nixidy": "nixidy",
         "nixos-anywhere": "nixos-anywhere",

--- a/flake.nix
+++ b/flake.nix
@@ -28,9 +28,14 @@
       url = "github:cachix/git-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    haumea = {
+      url = "github:nix-community/haumea/v0.2.2";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     impermanence.url = "github:nix-community/impermanence";
     import-tree.url = "github:vic/import-tree";
     nh.url = "github:nix-community/nh";
+    nix-kube-generators.url = "github:farcaller/nix-kube-generators";
     nixhelm = {
       url = "github:farcaller/nixhelm";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/flake/charts.nix
+++ b/modules/flake/charts.nix
@@ -1,19 +1,50 @@
-# Exposes Helm chart derivations from nixhelm as a flake output, so k8s-
-# manifests aspects can reference `charts.<repo>.<chart>` without depending
-# on the nixhelm input directly.
+# Exposes Helm chart derivations built from local pins under ../../charts
+# (repo/chart/version/chartHash per charts/<org>/<chart>/default.nix) as a
+# flake output, so k8s-manifests aspects can reference `charts.<repo>.<chart>`
+# without depending on any of these inputs directly.
 {
   inputs,
   config,
   lib,
+  withSystem,
   ...
 }:
 {
-  flake-file.inputs.nixhelm = {
-    url = "github:farcaller/nixhelm";
-    inputs.nixpkgs.follows = "nixpkgs";
+  flake-file.inputs = {
+    nix-kube-generators.url = "github:farcaller/nix-kube-generators";
+    haumea = {
+      url = "github:nix-community/haumea/v0.2.2";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    # Chart derivations no longer come from nixhelm's own index — kept only
+    # for its helmupdater CLI (modules/flake/devshell.nix), used to add/bump
+    # entries under ../../charts.
+    nixhelm = {
+      url = "github:farcaller/nixhelm";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  # Plain repo/chart/version/chartHash data, no fetching — helmupdater
+  # reads this via `nix eval .#chartsMetadata.<org>.<chart>` to know what's
+  # currently pinned.
+  flake.chartsMetadata = inputs.haumea.lib.load {
+    src = ../../charts;
+    transformer = inputs.haumea.lib.transformers.liftDefault;
   };
 
   flake.chartsDerivations = lib.genAttrs config.systems (
-    system: inputs.nixhelm.chartsDerivations.${system}
+    system:
+    withSystem system (
+      { pkgs, ... }:
+      let
+        kubelib = inputs.nix-kube-generators.lib { inherit pkgs; };
+      in
+      inputs.haumea.lib.load {
+        src = ../../charts;
+        loader = _: path: kubelib.downloadHelmChart (import path);
+        transformer = inputs.haumea.lib.transformers.liftDefault;
+      }
+    )
   );
 }

--- a/modules/flake/devshell.nix
+++ b/modules/flake/devshell.nix
@@ -5,6 +5,7 @@ _: {
     {
       config,
       pkgs,
+      inputs',
       ...
     }:
     {
@@ -53,6 +54,8 @@ _: {
             config.packages.write-flake
             config.packages.write-lock
             config.packages.write-inputs
+
+            inputs'.nixhelm.packages.helmupdater
           ];
 
         inputsFrom = [

--- a/modules/kubernetes/cilium/gateway-api-crds.nix
+++ b/modules/kubernetes/cilium/gateway-api-crds.nix
@@ -2,8 +2,7 @@
 # install them, and gatewayAPI.enabled (cilium/default.nix) silently no-ops
 # without them. Own applications.gateway-api-crds entry, not folded into
 # applications.cilium, so bumping this doesn't couple to the Cilium chart.
-# v1.4.1 matches what Cilium 1.19.6 (nixhelm's charts.cilium.cilium)
-# requires. `config/crd`, not `config/crd/standard`: the latter has no
+# v1.4.1 matches what Cilium 1.19.6 (charts.cilium.cilium) requires. `config/crd`, not `config/crd/standard`: the latter has no
 # kustomization.yaml of its own.
 #
 # The Renovate annotation below tracks this independently of Cilium's own


### PR DESCRIPTION
## Summary

- Replace nixhelm's chart index with local `charts/<org>/<chart>/default.nix` pins (`repo`/`chart`/`version`/`chartHash`), fetched via `nix-kube-generators`'s `downloadHelmChart` + `haumea` (mirrors github.com/sini/nix-config's pattern). Each chart's version now moves independently instead of all at once via a single nixhelm bump.
- Migrated the 6 charts currently in use — cilium, coredns, cert-manager, openbao, external-secrets, openebs zfs-localpv — at the exact versions already locked via nixhelm, so this is a mechanism swap only, no version changes. (`openbao`/`external-secrets` entries are unused until #231 merges their app aspects — harmless, just data until then.)
- `nixhelm` stays as a flake input, but only for its `helmupdater` CLI (added to the devshell), used to add/bump/rehash pins.
- New scheduled workflow (`.github/workflows/update-helm-charts.yaml`) runs `helmupdater update-all` + `write-manifests` and opens a PR, replacing nixhelm's lock-bump as the update lever.
- `charts.<org>.<chart>` shape and every consumer (`modules/kubernetes/*/default.nix`, `modules/den/policies/cluster.nix`) are unchanged — only what builds `chartsDerivations` changed.

## Test plan

- [x] `nix flake check --print-build-logs` passes (all charts fetch + hash-verify)
- [x] `nix run .#write-manifests` produces no diff against `manifests/prd/` — confirms the swap doesn't change what's deployed
- [x] `nix eval .#chartsMetadata.cilium.cilium.version` → `1.19.6`, matching the previously nixhelm-locked version
- [x] `helmupdater` resolves inside the devshell