### PR TITLE
Install gateway-api's experimental CRD channel, fixing cilium-operator crash

### DIFF
--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-backendtlspolicies-gateway-networking-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-backendtlspolicies-gateway-networking-k8s-io.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.4.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct
   name: backendtlspolicies.gateway.networking.k8s.io
@@ -482,6 +482,18 @@ spec:
                               Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                               generic way to enable any other kind of cross-namespace reference.
 
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
                               Support: Core
                             maxLength: 63
                             minLength: 1
@@ -499,6 +511,12 @@ spec:
                               as opposed to a listener(s) whose port(s) may be changed. When both Port
                               and SectionName are specified, the name and port of the selected listener
                               must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
 
                               Implementations MAY choose to support other parent resources.
                               Implementations supporting other types of parent resources MUST clearly
@@ -1107,6 +1125,18 @@ spec:
                               Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                               generic way to enable any other kind of cross-namespace reference.
 
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
                               Support: Core
                             maxLength: 63
                             minLength: 1
@@ -1124,6 +1154,12 @@ spec:
                               as opposed to a listener(s) whose port(s) may be changed. When both Port
                               and SectionName are specified, the name and port of the selected listener
                               must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
 
                               Implementations MAY choose to support other parent resources.
                               Implementations supporting other types of parent resources MUST clearly
@@ -1269,7 +1305,7 @@ spec:
           required:
             - spec
           type: object
-      served: false
+      served: true
       storage: false
       subresources:
         status: {}

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-gatewayclasses-gateway-networking-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-gatewayclasses-gateway-networking-k8s-io.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.4.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   name: gatewayclasses.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-gateways-gateway-networking-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-gateways-gateway-networking-k8s-io.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.4.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   name: gateways.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -128,6 +128,108 @@ spec:
                       rule: 'self.all(a1, a1.type == ''IPAddress'' && has(a1.value) ? self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value == a1.value) : true )'
                     - message: Hostname values must be unique
                       rule: 'self.all(a1, a1.type == ''Hostname''  && has(a1.value) ? self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value == a1.value) : true )'
+                allowedListeners:
+                  description: |-
+                    AllowedListeners defines which ListenerSets can be attached to this Gateway.
+                    While this feature is experimental, the default value is to allow no ListenerSets.
+                  properties:
+                    namespaces:
+                      default:
+                        from: None
+                      description: |-
+                        Namespaces defines which namespaces ListenerSets can be attached to this Gateway.
+                        While this feature is experimental, the default value is to allow no ListenerSets.
+                      properties:
+                        from:
+                          default: None
+                          description: |-
+                            From indicates where ListenerSets can attach to this Gateway. Possible
+                            values are:
+
+                            * Same: Only ListenerSets in the same namespace may be attached to this Gateway.
+                            * Selector: ListenerSets in namespaces selected by the selector may be attached to this Gateway.
+                            * All: ListenerSets in all namespaces may be attached to this Gateway.
+                            * None: Only listeners defined in the Gateway's spec are allowed
+
+                            While this feature is experimental, the default value None
+                          enum:
+                            - All
+                            - Selector
+                            - Same
+                            - None
+                          type: string
+                        selector:
+                          description: |-
+                            Selector must be specified when From is set to "Selector". In that case,
+                            only ListenerSets in Namespaces matching this Selector will be selected by this
+                            Gateway. This field is ignored for other values of "From".
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  type: object
+                defaultScope:
+                  description: |-
+                    DefaultScope, when set, configures the Gateway as a default Gateway,
+                    meaning it will dynamically and implicitly have Routes (e.g. HTTPRoute)
+                    attached to it, according to the scope configured here.
+
+                    If unset (the default) or set to None, the Gateway will not act as a
+                    default Gateway; if set, the Gateway will claim any Route with a
+                    matching scope set in its UseDefaultGateway field, subject to the usual
+                    rules about which routes the Gateway can attach to.
+
+                    Think carefully before using this functionality! While the normal rules
+                    about which Route can apply are still enforced, it is simply easier for
+                    the wrong Route to be accidentally attached to this Gateway in this
+                    configuration. If the Gateway operator is not also the operator in
+                    control of the scope (e.g. namespace) with tight controls and checks on
+                    what kind of workloads and Routes get added in that scope, we strongly
+                    recommend not using this just because it seems convenient, and instead
+                    stick to direct Route attachment.
+                  enum:
+                    - All
+                    - None
+                  type: string
                 gatewayClassName:
                   description: |-
                     GatewayClassName used for this Gateway. This is the name of a
@@ -799,6 +901,362 @@ spec:
                       rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                     - message: Combination of port, protocol and hostname must be unique for each listener
                       rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+                tls:
+                  description: |-
+                    TLS specifies frontend and backend tls configuration for entire gateway.
+
+                    Support: Extended
+                  properties:
+                    backend:
+                      description: |-
+                        Backend describes TLS configuration for gateway when connecting
+                        to backends.
+
+                        Note that this contains only details for the Gateway as a TLS client,
+                        and does _not_ imply behavior about how to choose which backend should
+                        get a TLS connection. That is determined by the presence of a BackendTLSPolicy.
+
+                        Support: Core
+                      properties:
+                        clientCertificateRef:
+                          description: |-
+                            ClientCertificateRef is a reference to an object that contains a Client
+                            Certificate and the associated private key.
+
+                            References to a resource in different namespace are invalid UNLESS there
+                            is a ReferenceGrant in the target namespace that allows the certificate
+                            to be attached. If a ReferenceGrant does not allow this reference, the
+                            "ResolvedRefs" condition MUST be set to False for this listener with the
+                            "RefNotPermitted" reason.
+
+                            ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                            Secret, or implementation-specific custom resources.
+
+                            Support: Core
+                          properties:
+                            group:
+                              default: ""
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Secret
+                              description: Kind is kind of the referent. For example "Secret".
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the referenced object. When unspecified, the local
+                                namespace is inferred.
+
+                                Note that when a namespace different than the local namespace is specified,
+                                a ReferenceGrant object is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the ReferenceGrant
+                                documentation for details.
+
+                                Support: Core
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                    frontend:
+                      description: |-
+                        Frontend describes TLS config when client connects to Gateway.
+                        Support: Core
+                      properties:
+                        default:
+                          description: |-
+                            Default specifies the default client certificate validation configuration
+                            for all Listeners handling HTTPS traffic, unless a per-port configuration
+                            is defined.
+
+                            support: Core
+                          properties:
+                            validation:
+                              description: |-
+                                Validation holds configuration information for validating the frontend (client).
+                                Setting this field will result in mutual authentication when connecting to the gateway.
+                                In browsers this may result in a dialog appearing
+                                that requests a user to specify the client certificate.
+                                The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                                Support: Core
+                              properties:
+                                caCertificateRefs:
+                                  description: |-
+                                    CACertificateRefs contains one or more references to
+                                    Kubernetes objects that contain TLS certificates of
+                                    the Certificate Authorities that can be used
+                                    as a trust anchor to validate the certificates presented by the client.
+
+                                    A single CA certificate reference to a Kubernetes ConfigMap
+                                    has "Core" support.
+                                    Implementations MAY choose to support attaching multiple CA certificates to
+                                    a Listener, but this behavior is implementation-specific.
+
+                                    Support: Core - A single reference to a Kubernetes ConfigMap
+                                    with the CA certificate in a key named `ca.crt`.
+
+                                    Support: Implementation-specific (More than one certificate in a ConfigMap
+                                    with different keys or more than one reference, or other kinds of resources).
+
+                                    References to a resource in a different namespace are invalid UNLESS there
+                                    is a ReferenceGrant in the target namespace that allows the certificate
+                                    to be attached. If a ReferenceGrant does not allow this reference, the
+                                    "ResolvedRefs" condition MUST be set to False for this listener with the
+                                    "RefNotPermitted" reason.
+                                  items:
+                                    description: |-
+                                      ObjectReference identifies an API object including its namespace.
+
+                                      The API object must be valid in the cluster; the Group and Kind must
+                                      be registered in the cluster for this reference to be valid.
+
+                                      References to objects with invalid Group and Kind are not valid, and must
+                                      be rejected by the implementation, with appropriate Conditions set
+                                      on the containing object.
+                                    properties:
+                                      group:
+                                        description: |-
+                                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                          When set to the empty string, core API group is inferred.
+                                        maxLength: 253
+                                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        type: string
+                                      kind:
+                                        description: Kind is kind of the referent. For example "ConfigMap" or "Service".
+                                        maxLength: 63
+                                        minLength: 1
+                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        type: string
+                                      name:
+                                        description: Name is the name of the referent.
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      namespace:
+                                        description: |-
+                                          Namespace is the namespace of the referenced object. When unspecified, the local
+                                          namespace is inferred.
+
+                                          Note that when a namespace different than the local namespace is specified,
+                                          a ReferenceGrant object is required in the referent namespace to allow that
+                                          namespace's owner to accept the reference. See the ReferenceGrant
+                                          documentation for details.
+
+                                          Support: Core
+                                        maxLength: 63
+                                        minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                    required:
+                                      - group
+                                      - kind
+                                      - name
+                                    type: object
+                                  maxItems: 8
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mode:
+                                  default: AllowValidOnly
+                                  description: |-
+                                    FrontendValidationMode defines the mode for validating the client certificate.
+                                    There are two possible modes:
+
+                                    - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                      the client presents a valid certificate. This certificate must successfully
+                                      pass validation against the CA certificates specified in `CACertificateRefs`.
+                                    - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                      even if the client certificate is not presented or fails verification.
+
+                                      This approach delegates client authorization to the backend and introduce
+                                      a significant security risk. It should be used in testing environments or
+                                      on a temporary basis in non-testing environments.
+
+                                    Defaults to AllowValidOnly.
+
+                                    Support: Core
+                                  enum:
+                                    - AllowValidOnly
+                                    - AllowInsecureFallback
+                                  type: string
+                              required:
+                                - caCertificateRefs
+                              type: object
+                          type: object
+                        perPort:
+                          description: |-
+                            PerPort specifies tls configuration assigned per port.
+                            Per port configuration is optional. Once set this configuration overrides
+                            the default configuration for all Listeners handling HTTPS traffic
+                            that match this port.
+                            Each override port requires a unique TLS configuration.
+
+                            support: Core
+                          items:
+                            properties:
+                              port:
+                                description: |-
+                                  The Port indicates the Port Number to which the TLS configuration will be
+                                  applied. This configuration will be applied to all Listeners handling HTTPS
+                                  traffic that match this port.
+
+                                  Support: Core
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              tls:
+                                description: |-
+                                  TLS store the configuration that will be applied to all Listeners handling
+                                  HTTPS traffic and matching given port.
+
+                                  Support: Core
+                                properties:
+                                  validation:
+                                    description: |-
+                                      Validation holds configuration information for validating the frontend (client).
+                                      Setting this field will result in mutual authentication when connecting to the gateway.
+                                      In browsers this may result in a dialog appearing
+                                      that requests a user to specify the client certificate.
+                                      The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                                      Support: Core
+                                    properties:
+                                      caCertificateRefs:
+                                        description: |-
+                                          CACertificateRefs contains one or more references to
+                                          Kubernetes objects that contain TLS certificates of
+                                          the Certificate Authorities that can be used
+                                          as a trust anchor to validate the certificates presented by the client.
+
+                                          A single CA certificate reference to a Kubernetes ConfigMap
+                                          has "Core" support.
+                                          Implementations MAY choose to support attaching multiple CA certificates to
+                                          a Listener, but this behavior is implementation-specific.
+
+                                          Support: Core - A single reference to a Kubernetes ConfigMap
+                                          with the CA certificate in a key named `ca.crt`.
+
+                                          Support: Implementation-specific (More than one certificate in a ConfigMap
+                                          with different keys or more than one reference, or other kinds of resources).
+
+                                          References to a resource in a different namespace are invalid UNLESS there
+                                          is a ReferenceGrant in the target namespace that allows the certificate
+                                          to be attached. If a ReferenceGrant does not allow this reference, the
+                                          "ResolvedRefs" condition MUST be set to False for this listener with the
+                                          "RefNotPermitted" reason.
+                                        items:
+                                          description: |-
+                                            ObjectReference identifies an API object including its namespace.
+
+                                            The API object must be valid in the cluster; the Group and Kind must
+                                            be registered in the cluster for this reference to be valid.
+
+                                            References to objects with invalid Group and Kind are not valid, and must
+                                            be rejected by the implementation, with appropriate Conditions set
+                                            on the containing object.
+                                          properties:
+                                            group:
+                                              description: |-
+                                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                                When set to the empty string, core API group is inferred.
+                                              maxLength: 253
+                                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            kind:
+                                              description: Kind is kind of the referent. For example "ConfigMap" or "Service".
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                              type: string
+                                            name:
+                                              description: Name is the name of the referent.
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                Namespace is the namespace of the referenced object. When unspecified, the local
+                                                namespace is inferred.
+
+                                                Note that when a namespace different than the local namespace is specified,
+                                                a ReferenceGrant object is required in the referent namespace to allow that
+                                                namespace's owner to accept the reference. See the ReferenceGrant
+                                                documentation for details.
+
+                                                Support: Core
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                          required:
+                                            - group
+                                            - kind
+                                            - name
+                                          type: object
+                                        maxItems: 8
+                                        minItems: 1
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mode:
+                                        default: AllowValidOnly
+                                        description: |-
+                                          FrontendValidationMode defines the mode for validating the client certificate.
+                                          There are two possible modes:
+
+                                          - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                            the client presents a valid certificate. This certificate must successfully
+                                            pass validation against the CA certificates specified in `CACertificateRefs`.
+                                          - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                            even if the client certificate is not presented or fails verification.
+
+                                            This approach delegates client authorization to the backend and introduce
+                                            a significant security risk. It should be used in testing environments or
+                                            on a temporary basis in non-testing environments.
+
+                                          Defaults to AllowValidOnly.
+
+                                          Support: Core
+                                        enum:
+                                          - AllowValidOnly
+                                          - AllowInsecureFallback
+                                        type: string
+                                    required:
+                                      - caCertificateRefs
+                                    type: object
+                                type: object
+                            required:
+                              - port
+                              - tls
+                            type: object
+                          maxItems: 64
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - port
+                          x-kubernetes-list-type: map
+                          x-kubernetes-validations:
+                            - message: Port for TLS configuration must be unique within the Gateway
+                              rule: self.all(t1, self.exists_one(t2, t1.port == t2.port))
+                      required:
+                        - default
+                      type: object
+                  type: object
               required:
                 - gatewayClassName
                 - listeners
@@ -1206,6 +1664,108 @@ spec:
                       rule: 'self.all(a1, a1.type == ''IPAddress'' && has(a1.value) ? self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value == a1.value) : true )'
                     - message: Hostname values must be unique
                       rule: 'self.all(a1, a1.type == ''Hostname''  && has(a1.value) ? self.exists_one(a2, a2.type == a1.type && has(a2.value) && a2.value == a1.value) : true )'
+                allowedListeners:
+                  description: |-
+                    AllowedListeners defines which ListenerSets can be attached to this Gateway.
+                    While this feature is experimental, the default value is to allow no ListenerSets.
+                  properties:
+                    namespaces:
+                      default:
+                        from: None
+                      description: |-
+                        Namespaces defines which namespaces ListenerSets can be attached to this Gateway.
+                        While this feature is experimental, the default value is to allow no ListenerSets.
+                      properties:
+                        from:
+                          default: None
+                          description: |-
+                            From indicates where ListenerSets can attach to this Gateway. Possible
+                            values are:
+
+                            * Same: Only ListenerSets in the same namespace may be attached to this Gateway.
+                            * Selector: ListenerSets in namespaces selected by the selector may be attached to this Gateway.
+                            * All: ListenerSets in all namespaces may be attached to this Gateway.
+                            * None: Only listeners defined in the Gateway's spec are allowed
+
+                            While this feature is experimental, the default value None
+                          enum:
+                            - All
+                            - Selector
+                            - Same
+                            - None
+                          type: string
+                        selector:
+                          description: |-
+                            Selector must be specified when From is set to "Selector". In that case,
+                            only ListenerSets in Namespaces matching this Selector will be selected by this
+                            Gateway. This field is ignored for other values of "From".
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                  - key
+                                  - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  type: object
+                defaultScope:
+                  description: |-
+                    DefaultScope, when set, configures the Gateway as a default Gateway,
+                    meaning it will dynamically and implicitly have Routes (e.g. HTTPRoute)
+                    attached to it, according to the scope configured here.
+
+                    If unset (the default) or set to None, the Gateway will not act as a
+                    default Gateway; if set, the Gateway will claim any Route with a
+                    matching scope set in its UseDefaultGateway field, subject to the usual
+                    rules about which routes the Gateway can attach to.
+
+                    Think carefully before using this functionality! While the normal rules
+                    about which Route can apply are still enforced, it is simply easier for
+                    the wrong Route to be accidentally attached to this Gateway in this
+                    configuration. If the Gateway operator is not also the operator in
+                    control of the scope (e.g. namespace) with tight controls and checks on
+                    what kind of workloads and Routes get added in that scope, we strongly
+                    recommend not using this just because it seems convenient, and instead
+                    stick to direct Route attachment.
+                  enum:
+                    - All
+                    - None
+                  type: string
                 gatewayClassName:
                   description: |-
                     GatewayClassName used for this Gateway. This is the name of a
@@ -1877,6 +2437,362 @@ spec:
                       rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
                     - message: Combination of port, protocol and hostname must be unique for each listener
                       rule: 'self.all(l1, self.exists_one(l2, l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+                tls:
+                  description: |-
+                    TLS specifies frontend and backend tls configuration for entire gateway.
+
+                    Support: Extended
+                  properties:
+                    backend:
+                      description: |-
+                        Backend describes TLS configuration for gateway when connecting
+                        to backends.
+
+                        Note that this contains only details for the Gateway as a TLS client,
+                        and does _not_ imply behavior about how to choose which backend should
+                        get a TLS connection. That is determined by the presence of a BackendTLSPolicy.
+
+                        Support: Core
+                      properties:
+                        clientCertificateRef:
+                          description: |-
+                            ClientCertificateRef is a reference to an object that contains a Client
+                            Certificate and the associated private key.
+
+                            References to a resource in different namespace are invalid UNLESS there
+                            is a ReferenceGrant in the target namespace that allows the certificate
+                            to be attached. If a ReferenceGrant does not allow this reference, the
+                            "ResolvedRefs" condition MUST be set to False for this listener with the
+                            "RefNotPermitted" reason.
+
+                            ClientCertificateRef can reference to standard Kubernetes resources, i.e.
+                            Secret, or implementation-specific custom resources.
+
+                            Support: Core
+                          properties:
+                            group:
+                              default: ""
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Secret
+                              description: Kind is kind of the referent. For example "Secret".
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the referenced object. When unspecified, the local
+                                namespace is inferred.
+
+                                Note that when a namespace different than the local namespace is specified,
+                                a ReferenceGrant object is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the ReferenceGrant
+                                documentation for details.
+
+                                Support: Core
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                          required:
+                            - name
+                          type: object
+                      type: object
+                    frontend:
+                      description: |-
+                        Frontend describes TLS config when client connects to Gateway.
+                        Support: Core
+                      properties:
+                        default:
+                          description: |-
+                            Default specifies the default client certificate validation configuration
+                            for all Listeners handling HTTPS traffic, unless a per-port configuration
+                            is defined.
+
+                            support: Core
+                          properties:
+                            validation:
+                              description: |-
+                                Validation holds configuration information for validating the frontend (client).
+                                Setting this field will result in mutual authentication when connecting to the gateway.
+                                In browsers this may result in a dialog appearing
+                                that requests a user to specify the client certificate.
+                                The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                                Support: Core
+                              properties:
+                                caCertificateRefs:
+                                  description: |-
+                                    CACertificateRefs contains one or more references to
+                                    Kubernetes objects that contain TLS certificates of
+                                    the Certificate Authorities that can be used
+                                    as a trust anchor to validate the certificates presented by the client.
+
+                                    A single CA certificate reference to a Kubernetes ConfigMap
+                                    has "Core" support.
+                                    Implementations MAY choose to support attaching multiple CA certificates to
+                                    a Listener, but this behavior is implementation-specific.
+
+                                    Support: Core - A single reference to a Kubernetes ConfigMap
+                                    with the CA certificate in a key named `ca.crt`.
+
+                                    Support: Implementation-specific (More than one certificate in a ConfigMap
+                                    with different keys or more than one reference, or other kinds of resources).
+
+                                    References to a resource in a different namespace are invalid UNLESS there
+                                    is a ReferenceGrant in the target namespace that allows the certificate
+                                    to be attached. If a ReferenceGrant does not allow this reference, the
+                                    "ResolvedRefs" condition MUST be set to False for this listener with the
+                                    "RefNotPermitted" reason.
+                                  items:
+                                    description: |-
+                                      ObjectReference identifies an API object including its namespace.
+
+                                      The API object must be valid in the cluster; the Group and Kind must
+                                      be registered in the cluster for this reference to be valid.
+
+                                      References to objects with invalid Group and Kind are not valid, and must
+                                      be rejected by the implementation, with appropriate Conditions set
+                                      on the containing object.
+                                    properties:
+                                      group:
+                                        description: |-
+                                          Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                          When set to the empty string, core API group is inferred.
+                                        maxLength: 253
+                                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                        type: string
+                                      kind:
+                                        description: Kind is kind of the referent. For example "ConfigMap" or "Service".
+                                        maxLength: 63
+                                        minLength: 1
+                                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                        type: string
+                                      name:
+                                        description: Name is the name of the referent.
+                                        maxLength: 253
+                                        minLength: 1
+                                        type: string
+                                      namespace:
+                                        description: |-
+                                          Namespace is the namespace of the referenced object. When unspecified, the local
+                                          namespace is inferred.
+
+                                          Note that when a namespace different than the local namespace is specified,
+                                          a ReferenceGrant object is required in the referent namespace to allow that
+                                          namespace's owner to accept the reference. See the ReferenceGrant
+                                          documentation for details.
+
+                                          Support: Core
+                                        maxLength: 63
+                                        minLength: 1
+                                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                        type: string
+                                    required:
+                                      - group
+                                      - kind
+                                      - name
+                                    type: object
+                                  maxItems: 8
+                                  minItems: 1
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mode:
+                                  default: AllowValidOnly
+                                  description: |-
+                                    FrontendValidationMode defines the mode for validating the client certificate.
+                                    There are two possible modes:
+
+                                    - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                      the client presents a valid certificate. This certificate must successfully
+                                      pass validation against the CA certificates specified in `CACertificateRefs`.
+                                    - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                      even if the client certificate is not presented or fails verification.
+
+                                      This approach delegates client authorization to the backend and introduce
+                                      a significant security risk. It should be used in testing environments or
+                                      on a temporary basis in non-testing environments.
+
+                                    Defaults to AllowValidOnly.
+
+                                    Support: Core
+                                  enum:
+                                    - AllowValidOnly
+                                    - AllowInsecureFallback
+                                  type: string
+                              required:
+                                - caCertificateRefs
+                              type: object
+                          type: object
+                        perPort:
+                          description: |-
+                            PerPort specifies tls configuration assigned per port.
+                            Per port configuration is optional. Once set this configuration overrides
+                            the default configuration for all Listeners handling HTTPS traffic
+                            that match this port.
+                            Each override port requires a unique TLS configuration.
+
+                            support: Core
+                          items:
+                            properties:
+                              port:
+                                description: |-
+                                  The Port indicates the Port Number to which the TLS configuration will be
+                                  applied. This configuration will be applied to all Listeners handling HTTPS
+                                  traffic that match this port.
+
+                                  Support: Core
+                                format: int32
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              tls:
+                                description: |-
+                                  TLS store the configuration that will be applied to all Listeners handling
+                                  HTTPS traffic and matching given port.
+
+                                  Support: Core
+                                properties:
+                                  validation:
+                                    description: |-
+                                      Validation holds configuration information for validating the frontend (client).
+                                      Setting this field will result in mutual authentication when connecting to the gateway.
+                                      In browsers this may result in a dialog appearing
+                                      that requests a user to specify the client certificate.
+                                      The maximum depth of a certificate chain accepted in verification is Implementation specific.
+
+                                      Support: Core
+                                    properties:
+                                      caCertificateRefs:
+                                        description: |-
+                                          CACertificateRefs contains one or more references to
+                                          Kubernetes objects that contain TLS certificates of
+                                          the Certificate Authorities that can be used
+                                          as a trust anchor to validate the certificates presented by the client.
+
+                                          A single CA certificate reference to a Kubernetes ConfigMap
+                                          has "Core" support.
+                                          Implementations MAY choose to support attaching multiple CA certificates to
+                                          a Listener, but this behavior is implementation-specific.
+
+                                          Support: Core - A single reference to a Kubernetes ConfigMap
+                                          with the CA certificate in a key named `ca.crt`.
+
+                                          Support: Implementation-specific (More than one certificate in a ConfigMap
+                                          with different keys or more than one reference, or other kinds of resources).
+
+                                          References to a resource in a different namespace are invalid UNLESS there
+                                          is a ReferenceGrant in the target namespace that allows the certificate
+                                          to be attached. If a ReferenceGrant does not allow this reference, the
+                                          "ResolvedRefs" condition MUST be set to False for this listener with the
+                                          "RefNotPermitted" reason.
+                                        items:
+                                          description: |-
+                                            ObjectReference identifies an API object including its namespace.
+
+                                            The API object must be valid in the cluster; the Group and Kind must
+                                            be registered in the cluster for this reference to be valid.
+
+                                            References to objects with invalid Group and Kind are not valid, and must
+                                            be rejected by the implementation, with appropriate Conditions set
+                                            on the containing object.
+                                          properties:
+                                            group:
+                                              description: |-
+                                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                                When set to the empty string, core API group is inferred.
+                                              maxLength: 253
+                                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                              type: string
+                                            kind:
+                                              description: Kind is kind of the referent. For example "ConfigMap" or "Service".
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                              type: string
+                                            name:
+                                              description: Name is the name of the referent.
+                                              maxLength: 253
+                                              minLength: 1
+                                              type: string
+                                            namespace:
+                                              description: |-
+                                                Namespace is the namespace of the referenced object. When unspecified, the local
+                                                namespace is inferred.
+
+                                                Note that when a namespace different than the local namespace is specified,
+                                                a ReferenceGrant object is required in the referent namespace to allow that
+                                                namespace's owner to accept the reference. See the ReferenceGrant
+                                                documentation for details.
+
+                                                Support: Core
+                                              maxLength: 63
+                                              minLength: 1
+                                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                              type: string
+                                          required:
+                                            - group
+                                            - kind
+                                            - name
+                                          type: object
+                                        maxItems: 8
+                                        minItems: 1
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mode:
+                                        default: AllowValidOnly
+                                        description: |-
+                                          FrontendValidationMode defines the mode for validating the client certificate.
+                                          There are two possible modes:
+
+                                          - AllowValidOnly: In this mode, the gateway will accept connections only if
+                                            the client presents a valid certificate. This certificate must successfully
+                                            pass validation against the CA certificates specified in `CACertificateRefs`.
+                                          - AllowInsecureFallback: In this mode, the gateway will accept connections
+                                            even if the client certificate is not presented or fails verification.
+
+                                            This approach delegates client authorization to the backend and introduce
+                                            a significant security risk. It should be used in testing environments or
+                                            on a temporary basis in non-testing environments.
+
+                                          Defaults to AllowValidOnly.
+
+                                          Support: Core
+                                        enum:
+                                          - AllowValidOnly
+                                          - AllowInsecureFallback
+                                        type: string
+                                    required:
+                                      - caCertificateRefs
+                                    type: object
+                                type: object
+                            required:
+                              - port
+                              - tls
+                            type: object
+                          maxItems: 64
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - port
+                          x-kubernetes-list-type: map
+                          x-kubernetes-validations:
+                            - message: Port for TLS configuration must be unique within the Gateway
+                              rule: self.all(t1, self.exists_one(t2, t1.port == t2.port))
+                      required:
+                        - default
+                      type: object
+                  type: object
               required:
                 - gatewayClassName
                 - listeners

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-grpcroutes-gateway-networking-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-grpcroutes-gateway-networking-k8s-io.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.4.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   name: grpcroutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -203,6 +203,17 @@ spec:
                     allowed by something in the namespace they are referring to. For example,
                     Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                     generic way to enable other kinds of cross-namespace reference.
+
+
+                    ParentRefs from a Route to a Service in the same namespace are "producer"
+                    routes, which apply default routing rules to inbound connections from
+                    any namespace to the Service.
+
+                    ParentRefs from a Route to a Service in a different namespace are
+                    "consumer" routes, and these routing rules are only applied to outbound
+                    connections originating from the same namespace as the Route, for which
+                    the intended destination of the connections are a Service targeted as a
+                    ParentRef of the Route.
                   items:
                     description: |-
                       ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -264,6 +275,18 @@ spec:
                           Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                           generic way to enable any other kind of cross-namespace reference.
 
+
+                          ParentRefs from a Route to a Service in the same namespace are "producer"
+                          routes, which apply default routing rules to inbound connections from
+                          any namespace to the Service.
+
+                          ParentRefs from a Route to a Service in a different namespace are
+                          "consumer" routes, and these routing rules are only applied to outbound
+                          connections originating from the same namespace as the Route, for which
+                          the intended destination of the connections are a Service targeted as a
+                          ParentRef of the Route.
+
+
                           Support: Core
                         maxLength: 63
                         minLength: 1
@@ -281,6 +304,12 @@ spec:
                           as opposed to a listener(s) whose port(s) may be changed. When both Port
                           and SectionName are specified, the name and port of the selected listener
                           must match both specified values.
+
+
+                          When the parent resource is a Service, this targets a specific port in the
+                          Service spec. When both Port (experimental) and SectionName are specified,
+                          the name and port of the selected port must match both specified values.
+
 
                           Implementations MAY choose to support other parent resources.
                           Implementations supporting other types of parent resources MUST clearly
@@ -336,10 +365,10 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                   x-kubernetes-validations:
-                    - message: sectionName must be specified when parentRefs includes 2 or more references to the same parent
-                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''')) : true))'
-                    - message: sectionName must be unique when parentRefs includes 2 or more references to the same parent
-                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName))))
+                    - message: sectionName or port must be specified when parentRefs includes 2 or more references to the same parent
+                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port) || p2.port == 0)): true))'
+                    - message: sectionName or port must be unique when parentRefs includes 2 or more references to the same parent
+                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port) || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port == p2.port))))
                 rules:
                   description: Rules are a list of GRPC matchers, filters and actions.
                   items:
@@ -386,6 +415,21 @@ spec:
                             ReferenceGrant object is required in the referent namespace to allow that
                             namespace's owner to accept the reference. See the ReferenceGrant
                             documentation for details.
+
+
+                            When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                            honor the appProtocol field if it is set for the target Service Port.
+
+                            Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                            Standard Application Protocols defined in KEP-3726.
+
+                            If a Service appProtocol isn't specified, an implementation MAY infer the
+                            backend protocol through its own means. Implementations MAY infer the
+                            protocol from the Route type referring to the backend Service.
+
+                            If a Route is not able to send traffic to the backend using the specified
+                            protocol then the backend is considered invalid. Implementations MUST set the
+                            "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
                           properties:
                             filters:
                               description: |-
@@ -1691,6 +1735,93 @@ spec:
                         minLength: 1
                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
+                      sessionPersistence:
+                        description: |-
+                          SessionPersistence defines and configures session persistence
+                          for the route rule.
+
+                          Support: Extended
+                        properties:
+                          absoluteTimeout:
+                            description: |-
+                              AbsoluteTimeout defines the absolute timeout of the persistent
+                              session. Once the AbsoluteTimeout duration has elapsed, the
+                              session becomes invalid.
+
+                              Support: Extended
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                          cookieConfig:
+                            description: |-
+                              CookieConfig provides configuration settings that are specific
+                              to cookie-based session persistence.
+
+                              Support: Core
+                            properties:
+                              lifetimeType:
+                                default: Session
+                                description: |-
+                                  LifetimeType specifies whether the cookie has a permanent or
+                                  session-based lifetime. A permanent cookie persists until its
+                                  specified expiry time, defined by the Expires or Max-Age cookie
+                                  attributes, while a session cookie is deleted when the current
+                                  session ends.
+
+                                  When set to "Permanent", AbsoluteTimeout indicates the
+                                  cookie's lifetime via the Expires or Max-Age cookie attributes
+                                  and is required.
+
+                                  When set to "Session", AbsoluteTimeout indicates the
+                                  absolute lifetime of the cookie tracked by the gateway and
+                                  is optional.
+
+                                  Defaults to "Session".
+
+                                  Support: Core for "Session" type
+
+                                  Support: Extended for "Permanent" type
+                                enum:
+                                  - Permanent
+                                  - Session
+                                type: string
+                            type: object
+                          idleTimeout:
+                            description: |-
+                              IdleTimeout defines the idle timeout of the persistent session.
+                              Once the session has been idle for more than the specified
+                              IdleTimeout duration, the session becomes invalid.
+
+                              Support: Extended
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                          sessionName:
+                            description: |-
+                              SessionName defines the name of the persistent session token
+                              which may be reflected in the cookie or the header. Users
+                              should avoid reusing session names to prevent unintended
+                              consequences, such as rejection or unpredictable behavior.
+
+                              Support: Implementation-specific
+                            maxLength: 128
+                            type: string
+                          type:
+                            default: Cookie
+                            description: |-
+                              Type defines the type of session persistence such as through
+                              the use a header or cookie. Defaults to cookie based session
+                              persistence.
+
+                              Support: Core for "Cookie" type
+
+                              Support: Extended for "Header" type
+                            enum:
+                              - Cookie
+                              - Header
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: AbsoluteTimeout must be specified when cookie lifetimeType is Permanent
+                            rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                     type: object
                   maxItems: 16
                   type: array
@@ -1698,6 +1829,26 @@ spec:
                   x-kubernetes-validations:
                     - message: While 16 rules and 64 matches per rule are allowed, the total number of matches across all rules in a route must be less than 128
                       rule: '(self.size() > 0 ? (has(self[0].matches) ? self[0].matches.size() : 0) : 0) + (self.size() > 1 ? (has(self[1].matches) ? self[1].matches.size() : 0) : 0) + (self.size() > 2 ? (has(self[2].matches) ? self[2].matches.size() : 0) : 0) + (self.size() > 3 ? (has(self[3].matches) ? self[3].matches.size() : 0) : 0) + (self.size() > 4 ? (has(self[4].matches) ? self[4].matches.size() : 0) : 0) + (self.size() > 5 ? (has(self[5].matches) ? self[5].matches.size() : 0) : 0) + (self.size() > 6 ? (has(self[6].matches) ? self[6].matches.size() : 0) : 0) + (self.size() > 7 ? (has(self[7].matches) ? self[7].matches.size() : 0) : 0) + (self.size() > 8 ? (has(self[8].matches) ? self[8].matches.size() : 0) : 0) + (self.size() > 9 ? (has(self[9].matches) ? self[9].matches.size() : 0) : 0) + (self.size() > 10 ? (has(self[10].matches) ? self[10].matches.size() : 0) : 0) + (self.size() > 11 ? (has(self[11].matches) ? self[11].matches.size() : 0) : 0) + (self.size() > 12 ? (has(self[12].matches) ? self[12].matches.size() : 0) : 0) + (self.size() > 13 ? (has(self[13].matches) ? self[13].matches.size() : 0) : 0) + (self.size() > 14 ? (has(self[14].matches) ? self[14].matches.size() : 0) : 0) + (self.size() > 15 ? (has(self[15].matches) ? self[15].matches.size() : 0) : 0) <= 128'
+                    - message: Rule name must be unique within the route
+                      rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name) && l1.name == l2.name))
+                useDefaultGateways:
+                  description: |-
+                    UseDefaultGateways indicates the default Gateway scope to use for this
+                    Route. If unset (the default) or set to None, the Route will not be
+                    attached to any default Gateway; if set, it will be attached to any
+                    default Gateway supporting the named scope, subject to the usual rules
+                    about which Routes a Gateway is allowed to claim.
+
+                    Think carefully before using this functionality! The set of default
+                    Gateways supporting the requested scope can change over time without
+                    any notice to the Route author, and in many situations it will not be
+                    appropriate to request a default Gateway for a given Route -- for
+                    example, a Route with specific security requirements should almost
+                    certainly not use a default Gateway.
+                  enum:
+                    - All
+                    - None
+                  type: string
               type: object
             status:
               description: Status defines the current state of GRPCRoute.
@@ -1873,6 +2024,18 @@ spec:
                               Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                               generic way to enable any other kind of cross-namespace reference.
 
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
                               Support: Core
                             maxLength: 63
                             minLength: 1
@@ -1890,6 +2053,12 @@ spec:
                               as opposed to a listener(s) whose port(s) may be changed. When both Port
                               and SectionName are specified, the name and port of the selected listener
                               must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
 
                               Implementations MAY choose to support other parent resources.
                               Implementations supporting other types of parent resources MUST clearly

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-httproutes-gateway-networking-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-httproutes-gateway-networking-k8s-io.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.4.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   name: httproutes.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io
@@ -183,6 +183,17 @@ spec:
                     allowed by something in the namespace they are referring to. For example,
                     Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                     generic way to enable other kinds of cross-namespace reference.
+
+
+                    ParentRefs from a Route to a Service in the same namespace are "producer"
+                    routes, which apply default routing rules to inbound connections from
+                    any namespace to the Service.
+
+                    ParentRefs from a Route to a Service in a different namespace are
+                    "consumer" routes, and these routing rules are only applied to outbound
+                    connections originating from the same namespace as the Route, for which
+                    the intended destination of the connections are a Service targeted as a
+                    ParentRef of the Route.
                   items:
                     description: |-
                       ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -244,6 +255,18 @@ spec:
                           Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                           generic way to enable any other kind of cross-namespace reference.
 
+
+                          ParentRefs from a Route to a Service in the same namespace are "producer"
+                          routes, which apply default routing rules to inbound connections from
+                          any namespace to the Service.
+
+                          ParentRefs from a Route to a Service in a different namespace are
+                          "consumer" routes, and these routing rules are only applied to outbound
+                          connections originating from the same namespace as the Route, for which
+                          the intended destination of the connections are a Service targeted as a
+                          ParentRef of the Route.
+
+
                           Support: Core
                         maxLength: 63
                         minLength: 1
@@ -261,6 +284,12 @@ spec:
                           as opposed to a listener(s) whose port(s) may be changed. When both Port
                           and SectionName are specified, the name and port of the selected listener
                           must match both specified values.
+
+
+                          When the parent resource is a Service, this targets a specific port in the
+                          Service spec. When both Port (experimental) and SectionName are specified,
+                          the name and port of the selected port must match both specified values.
+
 
                           Implementations MAY choose to support other parent resources.
                           Implementations supporting other types of parent resources MUST clearly
@@ -316,10 +345,10 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                   x-kubernetes-validations:
-                    - message: sectionName must be specified when parentRefs includes 2 or more references to the same parent
-                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''')) : true))'
-                    - message: sectionName must be unique when parentRefs includes 2 or more references to the same parent
-                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName))))
+                    - message: sectionName or port must be specified when parentRefs includes 2 or more references to the same parent
+                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port) || p2.port == 0)): true))'
+                    - message: sectionName or port must be unique when parentRefs includes 2 or more references to the same parent
+                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port) || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port == p2.port))))
                 rules:
                   default:
                     - matches:
@@ -378,6 +407,21 @@ spec:
                             ReferenceGrant object is required in the referent namespace to allow that
                             namespace's owner to accept the reference. See the ReferenceGrant
                             documentation for details.
+
+
+                            When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                            honor the appProtocol field if it is set for the target Service Port.
+
+                            Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                            Standard Application Protocols defined in KEP-3726.
+
+                            If a Service appProtocol isn't specified, an implementation MAY infer the
+                            backend protocol through its own means. Implementations MAY infer the
+                            protocol from the Route type referring to the backend Service.
+
+                            If a Route is not able to send traffic to the backend using the specified
+                            protocol then the backend is considered invalid. Implementations MUST set the
+                            "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
                           properties:
                             filters:
                               description: |-
@@ -395,6 +439,288 @@ spec:
                                   authentication strategies, rate-limiting, and traffic shaping. API
                                   guarantee/conformance is defined based on the type of the filter.
                                 properties:
+                                  cors:
+                                    description: |-
+                                      CORS defines a schema for a filter that responds to the
+                                      cross-origin request based on HTTP response header.
+
+                                      Support: Extended
+                                    properties:
+                                      allowCredentials:
+                                        description: |-
+                                          AllowCredentials indicates whether the actual cross-origin request allows
+                                          to include credentials.
+
+                                          When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                          response header with value true (case-sensitive).
+
+                                          When set to false or omitted the gateway will omit the header
+                                          `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                          behavior).
+
+                                          Support: Extended
+                                        type: boolean
+                                      allowHeaders:
+                                        description: |-
+                                          AllowHeaders indicates which HTTP request headers are supported for
+                                          accessing the requested resource.
+
+                                          Header names are not case sensitive.
+
+                                          Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                          response header are separated by a comma (",").
+
+                                          When the `AllowHeaders` field is configured with one or more headers, the
+                                          gateway must return the `Access-Control-Allow-Headers` response header
+                                          which value is present in the `AllowHeaders` field.
+
+                                          If any header name in the `Access-Control-Request-Headers` request header
+                                          is not included in the list of header names specified by the response
+                                          header `Access-Control-Allow-Headers`, it will present an error on the
+                                          client side.
+
+                                          If any header name in the `Access-Control-Allow-Headers` response header
+                                          does not recognize by the client, it will also occur an error on the
+                                          client side.
+
+                                          A wildcard indicates that the requests with all HTTP headers are allowed.
+                                          The `Access-Control-Allow-Headers` response header can only use `*`
+                                          wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                          When the `AllowCredentials` field is true and `AllowHeaders` field
+                                          specified with the `*` wildcard, the gateway must specify one or more
+                                          HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                          header. The value of the header `Access-Control-Allow-Headers` is same as
+                                          the `Access-Control-Request-Headers` header provided by the client. If
+                                          the header `Access-Control-Request-Headers` is not included in the
+                                          request, the gateway will omit the `Access-Control-Allow-Headers`
+                                          response header, instead of specifying the `*` wildcard. A Gateway
+                                          implementation may choose to add implementation-specific default headers.
+
+                                          Support: Extended
+                                        items:
+                                          description: |-
+                                            HTTPHeaderName is the name of an HTTP header.
+
+                                            Valid values include:
+
+                                            * "Authorization"
+                                            * "Set-Cookie"
+
+                                            Invalid values include:
+
+                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                                headers are not currently supported by this type.
+                                              - "/invalid" - "/ " is an invalid character
+                                          maxLength: 256
+                                          minLength: 1
+                                          pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          type: string
+                                        maxItems: 64
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      allowMethods:
+                                        description: |-
+                                          AllowMethods indicates which HTTP methods are supported for accessing the
+                                          requested resource.
+
+                                          Valid values are any method defined by RFC9110, along with the special
+                                          value `*`, which represents all HTTP methods are allowed.
+
+                                          Method names are case sensitive, so these values are also case-sensitive.
+                                          (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                          Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                          response header are separated by a comma (",").
+
+                                          A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                          (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                          CORS-safelisted methods are always allowed, regardless of whether they
+                                          are specified in the `AllowMethods` field.
+
+                                          When the `AllowMethods` field is configured with one or more methods, the
+                                          gateway must return the `Access-Control-Allow-Methods` response header
+                                          which value is present in the `AllowMethods` field.
+
+                                          If the HTTP method of the `Access-Control-Request-Method` request header
+                                          is not included in the list of methods specified by the response header
+                                          `Access-Control-Allow-Methods`, it will present an error on the client
+                                          side.
+
+                                          The `Access-Control-Allow-Methods` response header can only use `*`
+                                          wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                          When the `AllowCredentials` field is true and `AllowMethods` field
+                                          specified with the `*` wildcard, the gateway must specify one HTTP method
+                                          in the value of the Access-Control-Allow-Methods response header. The
+                                          value of the header `Access-Control-Allow-Methods` is same as the
+                                          `Access-Control-Request-Method` header provided by the client. If the
+                                          header `Access-Control-Request-Method` is not included in the request,
+                                          the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                          instead of specifying the `*` wildcard. A Gateway implementation may
+                                          choose to add implementation-specific default methods.
+
+                                          Support: Extended
+                                        items:
+                                          enum:
+                                            - GET
+                                            - HEAD
+                                            - POST
+                                            - PUT
+                                            - DELETE
+                                            - CONNECT
+                                            - OPTIONS
+                                            - TRACE
+                                            - PATCH
+                                            - '*'
+                                          type: string
+                                        maxItems: 9
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                        x-kubernetes-validations:
+                                          - message: AllowMethods cannot contain '*' alongside other methods
+                                            rule: '!(''*'' in self && self.size() > 1)'
+                                      allowOrigins:
+                                        description: |-
+                                          AllowOrigins indicates whether the response can be shared with requested
+                                          resource from the given `Origin`.
+
+                                          The `Origin` consists of a scheme and a host, with an optional port, and
+                                          takes the form `<scheme>://<host>(:<port>)`.
+
+                                          Valid values for scheme are: `http` and `https`.
+
+                                          Valid values for port are any integer between 1 and 65535 (the list of
+                                          available TCP/UDP ports). Note that, if not included, port `80` is
+                                          assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                          origins. This may affect origin matching.
+
+                                          The host part of the origin may contain the wildcard character `*`. These
+                                          wildcard characters behave as follows:
+
+                                          * `*` is a greedy match to the _left_, including any number of
+                                            DNS labels to the left of its position. This also means that
+                                            `*` will include any number of period `.` characters to the
+                                            left of its position.
+                                          * A wildcard by itself matches all hosts.
+
+                                          An origin value that includes _only_ the `*` character indicates requests
+                                          from all `Origin`s are allowed.
+
+                                          When the `AllowOrigins` field is configured with multiple origins, it
+                                          means the server supports clients from multiple origins. If the request
+                                          `Origin` matches the configured allowed origins, the gateway must return
+                                          the given `Origin` and sets value of the header
+                                          `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                          client.
+
+                                          The status code of a successful response to a "preflight" request is
+                                          always an OK status (i.e., 204 or 200).
+
+                                          If the request `Origin` does not match the configured allowed origins,
+                                          the gateway returns 204/200 response but doesn't set the relevant
+                                          cross-origin response headers. Alternatively, the gateway responds with
+                                          403 status to the "preflight" request is denied, coupled with omitting
+                                          the CORS headers. The cross-origin request fails on the client side.
+                                          Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                          The `Access-Control-Allow-Origin` response header can only use `*`
+                                          wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                          When the `AllowCredentials` field is true and `AllowOrigins` field
+                                          specified with the `*` wildcard, the gateway must return a single origin
+                                          in the value of the `Access-Control-Allow-Origin` response header,
+                                          instead of specifying the `*` wildcard. The value of the header
+                                          `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                          the client.
+
+                                          Support: Extended
+                                        items:
+                                          description: |-
+                                            The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                            encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                            scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                            URIs that include an authority MUST include a fully qualified domain name or
+                                            IP address as the host.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
+                                          type: string
+                                        maxItems: 64
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                        x-kubernetes-validations:
+                                          - message: AllowOrigins cannot contain '*' alongside other origins
+                                            rule: '!(''*'' in self && self.size() > 1)'
+                                      exposeHeaders:
+                                        description: |-
+                                          ExposeHeaders indicates which HTTP response headers can be exposed
+                                          to client-side scripts in response to a cross-origin request.
+
+                                          A CORS-safelisted response header is an HTTP header in a CORS response
+                                          that it is considered safe to expose to the client scripts.
+                                          The CORS-safelisted response headers include the following headers:
+                                          `Cache-Control`
+                                          `Content-Language`
+                                          `Content-Length`
+                                          `Content-Type`
+                                          `Expires`
+                                          `Last-Modified`
+                                          `Pragma`
+                                          (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                          The CORS-safelisted response headers are exposed to client by default.
+
+                                          When an HTTP header name is specified using the `ExposeHeaders` field,
+                                          this additional header will be exposed as part of the response to the
+                                          client.
+
+                                          Header names are not case sensitive.
+
+                                          Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                          response header are separated by a comma (",").
+
+                                          A wildcard indicates that the responses with all HTTP headers are exposed
+                                          to clients. The `Access-Control-Expose-Headers` response header can only
+                                          use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                          Support: Extended
+                                        items:
+                                          description: |-
+                                            HTTPHeaderName is the name of an HTTP header.
+
+                                            Valid values include:
+
+                                            * "Authorization"
+                                            * "Set-Cookie"
+
+                                            Invalid values include:
+
+                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                                headers are not currently supported by this type.
+                                              - "/invalid" - "/ " is an invalid character
+                                          maxLength: 256
+                                          minLength: 1
+                                          pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          type: string
+                                        maxItems: 64
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      maxAge:
+                                        default: 5
+                                        description: |-
+                                          MaxAge indicates the duration (in seconds) for the client to cache the
+                                          results of a "preflight" request.
+
+                                          The information provided by the `Access-Control-Allow-Methods` and
+                                          `Access-Control-Allow-Headers` response headers can be cached by the
+                                          client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                          The default value of `Access-Control-Max-Age` response header is 5
+                                          (seconds).
+                                        format: int32
+                                        minimum: 1
+                                        type: integer
+                                    type: object
                                   extensionRef:
                                     description: |-
                                       ExtensionRef is an optional, implementation-specific extension to the
@@ -429,6 +755,244 @@ spec:
                                       - kind
                                       - name
                                     type: object
+                                  externalAuth:
+                                    description: |-
+                                      ExternalAuth configures settings related to sending request details
+                                      to an external auth service. The external service MUST authenticate
+                                      the request, and MAY authorize the request as well.
+
+                                      If there is any problem communicating with the external service,
+                                      this filter MUST fail closed.
+
+                                      Support: Extended
+                                    properties:
+                                      backendRef:
+                                        description: |-
+                                          BackendRef is a reference to a backend to send authorization
+                                          requests to.
+
+                                          The backend must speak the selected protocol (GRPC or HTTP) on the
+                                          referenced port.
+
+                                          If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                          implementation to supply the TLS details to be used to connect to that
+                                          backend.
+                                        properties:
+                                          group:
+                                            default: ""
+                                            description: |-
+                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                              When unspecified or empty string, core API group is inferred.
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            default: Service
+                                            description: |-
+                                              Kind is the Kubernetes resource kind of the referent. For example
+                                              "Service".
+
+                                              Defaults to "Service" when not specified.
+
+                                              ExternalName services can refer to CNAME DNS records that may live
+                                              outside of the cluster and as such are difficult to reason about in
+                                              terms of conformance. They also may not be safe to forward to (see
+                                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                              support ExternalName Services.
+
+                                              Support: Core (Services with a type other than ExternalName)
+
+                                              Support: Implementation-specific (Services with type ExternalName)
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of the backend. When unspecified, the local
+                                              namespace is inferred.
+
+                                              Note that when a namespace different than the local namespace is specified,
+                                              a ReferenceGrant object is required in the referent namespace to allow that
+                                              namespace's owner to accept the reference. See the ReferenceGrant
+                                              documentation for details.
+
+                                              Support: Core
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                          port:
+                                            description: |-
+                                              Port specifies the destination port number to use for this resource.
+                                              Port is required when the referent is a Kubernetes Service. In this
+                                              case, the port number is the service port number, not the target port.
+                                              For other resources, destination port might be derived from the referent
+                                              resource or this field.
+                                            format: int32
+                                            maximum: 65535
+                                            minimum: 1
+                                            type: integer
+                                        required:
+                                          - name
+                                        type: object
+                                        x-kubernetes-validations:
+                                          - message: Must have port for Service reference
+                                            rule: '(size(self.group) == 0 && self.kind == ''Service'') ? has(self.port) : true'
+                                      forwardBody:
+                                        description: |-
+                                          ForwardBody controls if requests to the authorization server should include
+                                          the body of the client request; and if so, how big that body is allowed
+                                          to be.
+
+                                          It is expected that implementations will buffer the request body up to
+                                          `forwardBody.maxSize` bytes. Bodies over that size must be rejected with a
+                                          4xx series error (413 or 403 are common examples), and fail processing
+                                          of the filter.
+
+                                          If unset, or `forwardBody.maxSize` is set to `0`, then the body will not
+                                          be forwarded.
+
+                                          Feature Name: HTTPRouteExternalAuthForwardBody
+                                        properties:
+                                          maxSize:
+                                            description: |-
+                                              MaxSize specifies how large in bytes the largest body that will be buffered
+                                              and sent to the authorization server. If the body size is larger than
+                                              `maxSize`, then the body sent to the authorization server must be
+                                              truncated to `maxSize` bytes.
+
+                                              Experimental note: This behavior needs to be checked against
+                                              various dataplanes; it may need to be changed.
+                                              See https://github.com/kubernetes-sigs/gateway-api/pull/4001#discussion_r2291405746
+                                              for more.
+
+                                              If 0, the body will not be sent to the authorization server.
+                                            type: integer
+                                        type: object
+                                      grpc:
+                                        description: |-
+                                          GRPCAuthConfig contains configuration for communication with ext_authz
+                                          protocol-speaking backends.
+
+                                          If unset, implementations must assume the default behavior for each
+                                          included field is intended.
+                                        properties:
+                                          allowedHeaders:
+                                            description: |-
+                                              AllowedRequestHeaders specifies what headers from the client request
+                                              will be sent to the authorization server.
+
+                                              If this list is empty, then all headers must be sent.
+
+                                              If the list has entries, only those entries must be sent.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        type: object
+                                      http:
+                                        description: |-
+                                          HTTPAuthConfig contains configuration for communication with HTTP-speaking
+                                          backends.
+
+                                          If unset, implementations must assume the default behavior for each
+                                          included field is intended.
+                                        properties:
+                                          allowedHeaders:
+                                            description: |-
+                                              AllowedRequestHeaders specifies what additional headers from the client request
+                                              will be sent to the authorization server.
+
+                                              The following headers must always be sent to the authorization server,
+                                              regardless of this setting:
+
+                                              * `Host`
+                                              * `Method`
+                                              * `Path`
+                                              * `Content-Length`
+                                              * `Authorization`
+
+                                              If this list is empty, then only those headers must be sent.
+
+                                              Note that `Content-Length` has a special behavior, in that the length
+                                              sent must be correct for the actual request to the external authorization
+                                              server - that is, it must reflect the actual number of bytes sent in the
+                                              body of the request to the authorization server.
+
+                                              So if the `forwardBody` stanza is unset, or `forwardBody.maxSize` is set
+                                              to `0`, then `Content-Length` must be `0`. If `forwardBody.maxSize` is set
+                                              to anything other than `0`, then the `Content-Length` of the authorization
+                                              request must be set to the actual number of bytes forwarded.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          allowedResponseHeaders:
+                                            description: |-
+                                              AllowedResponseHeaders specifies what headers from the authorization response
+                                              will be copied into the request to the backend.
+
+                                              If this list is empty, then all headers from the authorization server
+                                              except Authority or Host must be copied.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          path:
+                                            description: |-
+                                              Path sets the prefix that paths from the client request will have added
+                                              when forwarded to the authorization server.
+
+                                              When empty or unspecified, no prefix is added.
+
+                                              Valid values are the same as the "value" regex for path values in the `match`
+                                              stanza, and the validation regex will screen out invalid paths in the same way.
+                                              Even with the validation, implementations MUST sanitize this input before using it
+                                              directly.
+                                            maxLength: 1024
+                                            pattern: ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$
+                                            type: string
+                                        type: object
+                                      protocol:
+                                        description: |-
+                                          ExternalAuthProtocol describes which protocol to use when communicating with an
+                                          ext_authz authorization server.
+
+                                          When this is set to GRPC, each backend must use the Envoy ext_authz protocol
+                                          on the port specified in `backendRefs`. Requests and responses are defined
+                                          in the protobufs explained at:
+                                          https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
+
+                                          When this is set to HTTP, each backend must respond with a `200` status
+                                          code in on a successful authorization. Any other code is considered
+                                          an authorization failure.
+
+                                          Feature Names:
+                                          GRPC Support - HTTPRouteExternalAuthGRPC
+                                          HTTP Support - HTTPRouteExternalAuthHTTP
+                                        enum:
+                                          - HTTP
+                                          - GRPC
+                                        type: string
+                                    required:
+                                      - backendRef
+                                      - protocol
+                                    type: object
+                                    x-kubernetes-validations:
+                                      - message: grpc must be specified when protocol is set to 'GRPC'
+                                        rule: 'self.protocol == ''GRPC'' ? has(self.grpc) : true'
+                                      - message: protocol must be 'GRPC' when grpc is set
+                                        rule: 'has(self.grpc) ? self.protocol == ''GRPC'' : true'
+                                      - message: http must be specified when protocol is set to 'HTTP'
+                                        rule: 'self.protocol == ''HTTP'' ? has(self.http) : true'
+                                      - message: protocol must be 'HTTP' when http is set
+                                        rule: 'has(self.http) ? self.protocol == ''HTTP'' : true'
                                   requestHeaderModifier:
                                     description: |-
                                       RequestHeaderModifier defines a schema for a filter that modifies request
@@ -1018,6 +1582,8 @@ spec:
                                       - RequestRedirect
                                       - URLRewrite
                                       - ExtensionRef
+                                      - CORS
+                                      - ExternalAuth
                                     type: string
                                   urlRewrite:
                                     description: |-
@@ -1123,6 +1689,14 @@ spec:
                                     rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
                                   - message: filter.extensionRef must be specified for ExtensionRef filter.type
                                     rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                                  - message: filter.cors must be nil if the filter.type is not CORS
+                                    rule: '!(has(self.cors) && self.type != ''CORS'')'
+                                  - message: filter.cors must be specified for CORS filter.type
+                                    rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                                  - message: filter.externalAuth must be nil if the filter.type is not ExternalAuth
+                                    rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
+                                  - message: filter.externalAuth must be specified for ExternalAuth filter.type
+                                    rule: '!(!has(self.externalAuth) && self.type == ''ExternalAuth'')'
                               maxItems: 16
                               type: array
                               x-kubernetes-list-type: atomic
@@ -1273,6 +1847,288 @@ spec:
                             authentication strategies, rate-limiting, and traffic shaping. API
                             guarantee/conformance is defined based on the type of the filter.
                           properties:
+                            cors:
+                              description: |-
+                                CORS defines a schema for a filter that responds to the
+                                cross-origin request based on HTTP response header.
+
+                                Support: Extended
+                              properties:
+                                allowCredentials:
+                                  description: |-
+                                    AllowCredentials indicates whether the actual cross-origin request allows
+                                    to include credentials.
+
+                                    When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                    response header with value true (case-sensitive).
+
+                                    When set to false or omitted the gateway will omit the header
+                                    `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                    behavior).
+
+                                    Support: Extended
+                                  type: boolean
+                                allowHeaders:
+                                  description: |-
+                                    AllowHeaders indicates which HTTP request headers are supported for
+                                    accessing the requested resource.
+
+                                    Header names are not case sensitive.
+
+                                    Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                    response header are separated by a comma (",").
+
+                                    When the `AllowHeaders` field is configured with one or more headers, the
+                                    gateway must return the `Access-Control-Allow-Headers` response header
+                                    which value is present in the `AllowHeaders` field.
+
+                                    If any header name in the `Access-Control-Request-Headers` request header
+                                    is not included in the list of header names specified by the response
+                                    header `Access-Control-Allow-Headers`, it will present an error on the
+                                    client side.
+
+                                    If any header name in the `Access-Control-Allow-Headers` response header
+                                    does not recognize by the client, it will also occur an error on the
+                                    client side.
+
+                                    A wildcard indicates that the requests with all HTTP headers are allowed.
+                                    The `Access-Control-Allow-Headers` response header can only use `*`
+                                    wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                    When the `AllowCredentials` field is true and `AllowHeaders` field
+                                    specified with the `*` wildcard, the gateway must specify one or more
+                                    HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                    header. The value of the header `Access-Control-Allow-Headers` is same as
+                                    the `Access-Control-Request-Headers` header provided by the client. If
+                                    the header `Access-Control-Request-Headers` is not included in the
+                                    request, the gateway will omit the `Access-Control-Allow-Headers`
+                                    response header, instead of specifying the `*` wildcard. A Gateway
+                                    implementation may choose to add implementation-specific default headers.
+
+                                    Support: Extended
+                                  items:
+                                    description: |-
+                                      HTTPHeaderName is the name of an HTTP header.
+
+                                      Valid values include:
+
+                                      * "Authorization"
+                                      * "Set-Cookie"
+
+                                      Invalid values include:
+
+                                        - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                          headers are not currently supported by this type.
+                                        - "/invalid" - "/ " is an invalid character
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  maxItems: 64
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                allowMethods:
+                                  description: |-
+                                    AllowMethods indicates which HTTP methods are supported for accessing the
+                                    requested resource.
+
+                                    Valid values are any method defined by RFC9110, along with the special
+                                    value `*`, which represents all HTTP methods are allowed.
+
+                                    Method names are case sensitive, so these values are also case-sensitive.
+                                    (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                    Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                    response header are separated by a comma (",").
+
+                                    A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                    (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                    CORS-safelisted methods are always allowed, regardless of whether they
+                                    are specified in the `AllowMethods` field.
+
+                                    When the `AllowMethods` field is configured with one or more methods, the
+                                    gateway must return the `Access-Control-Allow-Methods` response header
+                                    which value is present in the `AllowMethods` field.
+
+                                    If the HTTP method of the `Access-Control-Request-Method` request header
+                                    is not included in the list of methods specified by the response header
+                                    `Access-Control-Allow-Methods`, it will present an error on the client
+                                    side.
+
+                                    The `Access-Control-Allow-Methods` response header can only use `*`
+                                    wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                    When the `AllowCredentials` field is true and `AllowMethods` field
+                                    specified with the `*` wildcard, the gateway must specify one HTTP method
+                                    in the value of the Access-Control-Allow-Methods response header. The
+                                    value of the header `Access-Control-Allow-Methods` is same as the
+                                    `Access-Control-Request-Method` header provided by the client. If the
+                                    header `Access-Control-Request-Method` is not included in the request,
+                                    the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                    instead of specifying the `*` wildcard. A Gateway implementation may
+                                    choose to add implementation-specific default methods.
+
+                                    Support: Extended
+                                  items:
+                                    enum:
+                                      - GET
+                                      - HEAD
+                                      - POST
+                                      - PUT
+                                      - DELETE
+                                      - CONNECT
+                                      - OPTIONS
+                                      - TRACE
+                                      - PATCH
+                                      - '*'
+                                    type: string
+                                  maxItems: 9
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - message: AllowMethods cannot contain '*' alongside other methods
+                                      rule: '!(''*'' in self && self.size() > 1)'
+                                allowOrigins:
+                                  description: |-
+                                    AllowOrigins indicates whether the response can be shared with requested
+                                    resource from the given `Origin`.
+
+                                    The `Origin` consists of a scheme and a host, with an optional port, and
+                                    takes the form `<scheme>://<host>(:<port>)`.
+
+                                    Valid values for scheme are: `http` and `https`.
+
+                                    Valid values for port are any integer between 1 and 65535 (the list of
+                                    available TCP/UDP ports). Note that, if not included, port `80` is
+                                    assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                    origins. This may affect origin matching.
+
+                                    The host part of the origin may contain the wildcard character `*`. These
+                                    wildcard characters behave as follows:
+
+                                    * `*` is a greedy match to the _left_, including any number of
+                                      DNS labels to the left of its position. This also means that
+                                      `*` will include any number of period `.` characters to the
+                                      left of its position.
+                                    * A wildcard by itself matches all hosts.
+
+                                    An origin value that includes _only_ the `*` character indicates requests
+                                    from all `Origin`s are allowed.
+
+                                    When the `AllowOrigins` field is configured with multiple origins, it
+                                    means the server supports clients from multiple origins. If the request
+                                    `Origin` matches the configured allowed origins, the gateway must return
+                                    the given `Origin` and sets value of the header
+                                    `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                    client.
+
+                                    The status code of a successful response to a "preflight" request is
+                                    always an OK status (i.e., 204 or 200).
+
+                                    If the request `Origin` does not match the configured allowed origins,
+                                    the gateway returns 204/200 response but doesn't set the relevant
+                                    cross-origin response headers. Alternatively, the gateway responds with
+                                    403 status to the "preflight" request is denied, coupled with omitting
+                                    the CORS headers. The cross-origin request fails on the client side.
+                                    Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                    The `Access-Control-Allow-Origin` response header can only use `*`
+                                    wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                    When the `AllowCredentials` field is true and `AllowOrigins` field
+                                    specified with the `*` wildcard, the gateway must return a single origin
+                                    in the value of the `Access-Control-Allow-Origin` response header,
+                                    instead of specifying the `*` wildcard. The value of the header
+                                    `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                    the client.
+
+                                    Support: Extended
+                                  items:
+                                    description: |-
+                                      The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                      encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                      scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                      URIs that include an authority MUST include a fully qualified domain name or
+                                      IP address as the host.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
+                                    type: string
+                                  maxItems: 64
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - message: AllowOrigins cannot contain '*' alongside other origins
+                                      rule: '!(''*'' in self && self.size() > 1)'
+                                exposeHeaders:
+                                  description: |-
+                                    ExposeHeaders indicates which HTTP response headers can be exposed
+                                    to client-side scripts in response to a cross-origin request.
+
+                                    A CORS-safelisted response header is an HTTP header in a CORS response
+                                    that it is considered safe to expose to the client scripts.
+                                    The CORS-safelisted response headers include the following headers:
+                                    `Cache-Control`
+                                    `Content-Language`
+                                    `Content-Length`
+                                    `Content-Type`
+                                    `Expires`
+                                    `Last-Modified`
+                                    `Pragma`
+                                    (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                    The CORS-safelisted response headers are exposed to client by default.
+
+                                    When an HTTP header name is specified using the `ExposeHeaders` field,
+                                    this additional header will be exposed as part of the response to the
+                                    client.
+
+                                    Header names are not case sensitive.
+
+                                    Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                    response header are separated by a comma (",").
+
+                                    A wildcard indicates that the responses with all HTTP headers are exposed
+                                    to clients. The `Access-Control-Expose-Headers` response header can only
+                                    use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                    Support: Extended
+                                  items:
+                                    description: |-
+                                      HTTPHeaderName is the name of an HTTP header.
+
+                                      Valid values include:
+
+                                      * "Authorization"
+                                      * "Set-Cookie"
+
+                                      Invalid values include:
+
+                                        - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                          headers are not currently supported by this type.
+                                        - "/invalid" - "/ " is an invalid character
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  maxItems: 64
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                maxAge:
+                                  default: 5
+                                  description: |-
+                                    MaxAge indicates the duration (in seconds) for the client to cache the
+                                    results of a "preflight" request.
+
+                                    The information provided by the `Access-Control-Allow-Methods` and
+                                    `Access-Control-Allow-Headers` response headers can be cached by the
+                                    client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                    The default value of `Access-Control-Max-Age` response header is 5
+                                    (seconds).
+                                  format: int32
+                                  minimum: 1
+                                  type: integer
+                              type: object
                             extensionRef:
                               description: |-
                                 ExtensionRef is an optional, implementation-specific extension to the
@@ -1307,6 +2163,244 @@ spec:
                                 - kind
                                 - name
                               type: object
+                            externalAuth:
+                              description: |-
+                                ExternalAuth configures settings related to sending request details
+                                to an external auth service. The external service MUST authenticate
+                                the request, and MAY authorize the request as well.
+
+                                If there is any problem communicating with the external service,
+                                this filter MUST fail closed.
+
+                                Support: Extended
+                              properties:
+                                backendRef:
+                                  description: |-
+                                    BackendRef is a reference to a backend to send authorization
+                                    requests to.
+
+                                    The backend must speak the selected protocol (GRPC or HTTP) on the
+                                    referenced port.
+
+                                    If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                    implementation to supply the TLS details to be used to connect to that
+                                    backend.
+                                  properties:
+                                    group:
+                                      default: ""
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      default: Service
+                                      description: |-
+                                        Kind is the Kubernetes resource kind of the referent. For example
+                                        "Service".
+
+                                        Defaults to "Service" when not specified.
+
+                                        ExternalName services can refer to CNAME DNS records that may live
+                                        outside of the cluster and as such are difficult to reason about in
+                                        terms of conformance. They also may not be safe to forward to (see
+                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                        support ExternalName Services.
+
+                                        Support: Core (Services with a type other than ExternalName)
+
+                                        Support: Implementation-specific (Services with type ExternalName)
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of the backend. When unspecified, the local
+                                        namespace is inferred.
+
+                                        Note that when a namespace different than the local namespace is specified,
+                                        a ReferenceGrant object is required in the referent namespace to allow that
+                                        namespace's owner to accept the reference. See the ReferenceGrant
+                                        documentation for details.
+
+                                        Support: Core
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    port:
+                                      description: |-
+                                        Port specifies the destination port number to use for this resource.
+                                        Port is required when the referent is a Kubernetes Service. In this
+                                        case, the port number is the service port number, not the target port.
+                                        For other resources, destination port might be derived from the referent
+                                        resource or this field.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                  required:
+                                    - name
+                                  type: object
+                                  x-kubernetes-validations:
+                                    - message: Must have port for Service reference
+                                      rule: '(size(self.group) == 0 && self.kind == ''Service'') ? has(self.port) : true'
+                                forwardBody:
+                                  description: |-
+                                    ForwardBody controls if requests to the authorization server should include
+                                    the body of the client request; and if so, how big that body is allowed
+                                    to be.
+
+                                    It is expected that implementations will buffer the request body up to
+                                    `forwardBody.maxSize` bytes. Bodies over that size must be rejected with a
+                                    4xx series error (413 or 403 are common examples), and fail processing
+                                    of the filter.
+
+                                    If unset, or `forwardBody.maxSize` is set to `0`, then the body will not
+                                    be forwarded.
+
+                                    Feature Name: HTTPRouteExternalAuthForwardBody
+                                  properties:
+                                    maxSize:
+                                      description: |-
+                                        MaxSize specifies how large in bytes the largest body that will be buffered
+                                        and sent to the authorization server. If the body size is larger than
+                                        `maxSize`, then the body sent to the authorization server must be
+                                        truncated to `maxSize` bytes.
+
+                                        Experimental note: This behavior needs to be checked against
+                                        various dataplanes; it may need to be changed.
+                                        See https://github.com/kubernetes-sigs/gateway-api/pull/4001#discussion_r2291405746
+                                        for more.
+
+                                        If 0, the body will not be sent to the authorization server.
+                                      type: integer
+                                  type: object
+                                grpc:
+                                  description: |-
+                                    GRPCAuthConfig contains configuration for communication with ext_authz
+                                    protocol-speaking backends.
+
+                                    If unset, implementations must assume the default behavior for each
+                                    included field is intended.
+                                  properties:
+                                    allowedHeaders:
+                                      description: |-
+                                        AllowedRequestHeaders specifies what headers from the client request
+                                        will be sent to the authorization server.
+
+                                        If this list is empty, then all headers must be sent.
+
+                                        If the list has entries, only those entries must be sent.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  type: object
+                                http:
+                                  description: |-
+                                    HTTPAuthConfig contains configuration for communication with HTTP-speaking
+                                    backends.
+
+                                    If unset, implementations must assume the default behavior for each
+                                    included field is intended.
+                                  properties:
+                                    allowedHeaders:
+                                      description: |-
+                                        AllowedRequestHeaders specifies what additional headers from the client request
+                                        will be sent to the authorization server.
+
+                                        The following headers must always be sent to the authorization server,
+                                        regardless of this setting:
+
+                                        * `Host`
+                                        * `Method`
+                                        * `Path`
+                                        * `Content-Length`
+                                        * `Authorization`
+
+                                        If this list is empty, then only those headers must be sent.
+
+                                        Note that `Content-Length` has a special behavior, in that the length
+                                        sent must be correct for the actual request to the external authorization
+                                        server - that is, it must reflect the actual number of bytes sent in the
+                                        body of the request to the authorization server.
+
+                                        So if the `forwardBody` stanza is unset, or `forwardBody.maxSize` is set
+                                        to `0`, then `Content-Length` must be `0`. If `forwardBody.maxSize` is set
+                                        to anything other than `0`, then the `Content-Length` of the authorization
+                                        request must be set to the actual number of bytes forwarded.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    allowedResponseHeaders:
+                                      description: |-
+                                        AllowedResponseHeaders specifies what headers from the authorization response
+                                        will be copied into the request to the backend.
+
+                                        If this list is empty, then all headers from the authorization server
+                                        except Authority or Host must be copied.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    path:
+                                      description: |-
+                                        Path sets the prefix that paths from the client request will have added
+                                        when forwarded to the authorization server.
+
+                                        When empty or unspecified, no prefix is added.
+
+                                        Valid values are the same as the "value" regex for path values in the `match`
+                                        stanza, and the validation regex will screen out invalid paths in the same way.
+                                        Even with the validation, implementations MUST sanitize this input before using it
+                                        directly.
+                                      maxLength: 1024
+                                      pattern: ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$
+                                      type: string
+                                  type: object
+                                protocol:
+                                  description: |-
+                                    ExternalAuthProtocol describes which protocol to use when communicating with an
+                                    ext_authz authorization server.
+
+                                    When this is set to GRPC, each backend must use the Envoy ext_authz protocol
+                                    on the port specified in `backendRefs`. Requests and responses are defined
+                                    in the protobufs explained at:
+                                    https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
+
+                                    When this is set to HTTP, each backend must respond with a `200` status
+                                    code in on a successful authorization. Any other code is considered
+                                    an authorization failure.
+
+                                    Feature Names:
+                                    GRPC Support - HTTPRouteExternalAuthGRPC
+                                    HTTP Support - HTTPRouteExternalAuthHTTP
+                                  enum:
+                                    - HTTP
+                                    - GRPC
+                                  type: string
+                              required:
+                                - backendRef
+                                - protocol
+                              type: object
+                              x-kubernetes-validations:
+                                - message: grpc must be specified when protocol is set to 'GRPC'
+                                  rule: 'self.protocol == ''GRPC'' ? has(self.grpc) : true'
+                                - message: protocol must be 'GRPC' when grpc is set
+                                  rule: 'has(self.grpc) ? self.protocol == ''GRPC'' : true'
+                                - message: http must be specified when protocol is set to 'HTTP'
+                                  rule: 'self.protocol == ''HTTP'' ? has(self.http) : true'
+                                - message: protocol must be 'HTTP' when http is set
+                                  rule: 'has(self.http) ? self.protocol == ''HTTP'' : true'
                             requestHeaderModifier:
                               description: |-
                                 RequestHeaderModifier defines a schema for a filter that modifies request
@@ -1896,6 +2990,8 @@ spec:
                                 - RequestRedirect
                                 - URLRewrite
                                 - ExtensionRef
+                                - CORS
+                                - ExternalAuth
                               type: string
                             urlRewrite:
                               description: |-
@@ -2001,6 +3097,14 @@ spec:
                               rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
                             - message: filter.extensionRef must be specified for ExtensionRef filter.type
                               rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            - message: filter.cors must be nil if the filter.type is not CORS
+                              rule: '!(has(self.cors) && self.type != ''CORS'')'
+                            - message: filter.cors must be specified for CORS filter.type
+                              rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                            - message: filter.externalAuth must be nil if the filter.type is not ExternalAuth
+                              rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
+                            - message: filter.externalAuth must be specified for ExternalAuth filter.type
+                              rule: '!(!has(self.externalAuth) && self.type == ''ExternalAuth'')'
                         maxItems: 16
                         type: array
                         x-kubernetes-list-type: atomic
@@ -2305,6 +3409,181 @@ spec:
                         minLength: 1
                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
+                      retry:
+                        description: |-
+                          Retry defines the configuration for when to retry an HTTP request.
+
+                          Support: Extended
+                        properties:
+                          attempts:
+                            description: |-
+                              Attempts specifies the maximum number of times an individual request
+                              from the gateway to a backend should be retried.
+
+                              If the maximum number of retries has been attempted without a successful
+                              response from the backend, the Gateway MUST return an error.
+
+                              When this field is unspecified, the number of times to attempt to retry
+                              a backend request is implementation-specific.
+
+                              Support: Extended
+                            type: integer
+                          backoff:
+                            description: |-
+                              Backoff specifies the minimum duration a Gateway should wait between
+                              retry attempts and is represented in Gateway API Duration formatting.
+
+                              For example, setting the `rules[].retry.backoff` field to the value
+                              `100ms` will cause a backend request to first be retried approximately
+                              100 milliseconds after timing out or receiving a response code configured
+                              to be retryable.
+
+                              An implementation MAY use an exponential or alternative backoff strategy
+                              for subsequent retry attempts, MAY cap the maximum backoff duration to
+                              some amount greater than the specified minimum, and MAY add arbitrary
+                              jitter to stagger requests, as long as unsuccessful backend requests are
+                              not retried before the configured minimum duration.
+
+                              If a Request timeout (`rules[].timeouts.request`) is configured on the
+                              route, the entire duration of the initial request and any retry attempts
+                              MUST not exceed the Request timeout duration. If any retry attempts are
+                              still in progress when the Request timeout duration has been reached,
+                              these SHOULD be canceled if possible and the Gateway MUST immediately
+                              return a timeout error.
+
+                              If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
+                              configured on the route, any retry attempts which reach the configured
+                              BackendRequest timeout duration without a response SHOULD be canceled if
+                              possible and the Gateway should wait for at least the specified backoff
+                              duration before attempting to retry the backend request again.
+
+                              If a BackendRequest timeout is _not_ configured on the route, retry
+                              attempts MAY time out after an implementation default duration, or MAY
+                              remain pending until a configured Request timeout or implementation
+                              default duration for total request time is reached.
+
+                              When this field is unspecified, the time to wait between retry attempts
+                              is implementation-specific.
+
+                              Support: Extended
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                          codes:
+                            description: |-
+                              Codes defines the HTTP response status codes for which a backend request
+                              should be retried.
+
+                              Support: Extended
+                            items:
+                              description: |-
+                                HTTPRouteRetryStatusCode defines an HTTP response status code for
+                                which a backend request should be retried.
+
+                                Implementations MUST support the following status codes as retryable:
+
+                                * 500
+                                * 502
+                                * 503
+                                * 504
+
+                                Implementations MAY support specifying additional discrete values in the
+                                500-599 range.
+
+                                Implementations MAY support specifying discrete values in the 400-499 range,
+                                which are often inadvisable to retry.
+                              maximum: 599
+                              minimum: 400
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      sessionPersistence:
+                        description: |-
+                          SessionPersistence defines and configures session persistence
+                          for the route rule.
+
+                          Support: Extended
+                        properties:
+                          absoluteTimeout:
+                            description: |-
+                              AbsoluteTimeout defines the absolute timeout of the persistent
+                              session. Once the AbsoluteTimeout duration has elapsed, the
+                              session becomes invalid.
+
+                              Support: Extended
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                          cookieConfig:
+                            description: |-
+                              CookieConfig provides configuration settings that are specific
+                              to cookie-based session persistence.
+
+                              Support: Core
+                            properties:
+                              lifetimeType:
+                                default: Session
+                                description: |-
+                                  LifetimeType specifies whether the cookie has a permanent or
+                                  session-based lifetime. A permanent cookie persists until its
+                                  specified expiry time, defined by the Expires or Max-Age cookie
+                                  attributes, while a session cookie is deleted when the current
+                                  session ends.
+
+                                  When set to "Permanent", AbsoluteTimeout indicates the
+                                  cookie's lifetime via the Expires or Max-Age cookie attributes
+                                  and is required.
+
+                                  When set to "Session", AbsoluteTimeout indicates the
+                                  absolute lifetime of the cookie tracked by the gateway and
+                                  is optional.
+
+                                  Defaults to "Session".
+
+                                  Support: Core for "Session" type
+
+                                  Support: Extended for "Permanent" type
+                                enum:
+                                  - Permanent
+                                  - Session
+                                type: string
+                            type: object
+                          idleTimeout:
+                            description: |-
+                              IdleTimeout defines the idle timeout of the persistent session.
+                              Once the session has been idle for more than the specified
+                              IdleTimeout duration, the session becomes invalid.
+
+                              Support: Extended
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                          sessionName:
+                            description: |-
+                              SessionName defines the name of the persistent session token
+                              which may be reflected in the cookie or the header. Users
+                              should avoid reusing session names to prevent unintended
+                              consequences, such as rejection or unpredictable behavior.
+
+                              Support: Implementation-specific
+                            maxLength: 128
+                            type: string
+                          type:
+                            default: Cookie
+                            description: |-
+                              Type defines the type of session persistence such as through
+                              the use a header or cookie. Defaults to cookie based session
+                              persistence.
+
+                              Support: Core for "Cookie" type
+
+                              Support: Extended for "Header" type
+                            enum:
+                              - Cookie
+                              - Header
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: AbsoluteTimeout must be specified when cookie lifetimeType is Permanent
+                            rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                       timeouts:
                         description: |-
                           Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -2382,6 +3661,26 @@ spec:
                   x-kubernetes-validations:
                     - message: While 16 rules and 64 matches per rule are allowed, the total number of matches across all rules in a route must be less than 128
                       rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size() > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size() : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size() > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size() : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size() > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size() : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size() > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size() : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size() > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size() : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+                    - message: Rule name must be unique within the route
+                      rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name) && l1.name == l2.name))
+                useDefaultGateways:
+                  description: |-
+                    UseDefaultGateways indicates the default Gateway scope to use for this
+                    Route. If unset (the default) or set to None, the Route will not be
+                    attached to any default Gateway; if set, it will be attached to any
+                    default Gateway supporting the named scope, subject to the usual rules
+                    about which Routes a Gateway is allowed to claim.
+
+                    Think carefully before using this functionality! The set of default
+                    Gateways supporting the requested scope can change over time without
+                    any notice to the Route author, and in many situations it will not be
+                    appropriate to request a default Gateway for a given Route -- for
+                    example, a Route with specific security requirements should almost
+                    certainly not use a default Gateway.
+                  enum:
+                    - All
+                    - None
+                  type: string
               type: object
             status:
               description: Status defines the current state of HTTPRoute.
@@ -2557,6 +3856,18 @@ spec:
                               Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                               generic way to enable any other kind of cross-namespace reference.
 
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
                               Support: Core
                             maxLength: 63
                             minLength: 1
@@ -2574,6 +3885,12 @@ spec:
                               as opposed to a listener(s) whose port(s) may be changed. When both Port
                               and SectionName are specified, the name and port of the selected listener
                               must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
 
                               Implementations MAY choose to support other parent resources.
                               Implementations supporting other types of parent resources MUST clearly
@@ -2809,6 +4126,17 @@ spec:
                     allowed by something in the namespace they are referring to. For example,
                     Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                     generic way to enable other kinds of cross-namespace reference.
+
+
+                    ParentRefs from a Route to a Service in the same namespace are "producer"
+                    routes, which apply default routing rules to inbound connections from
+                    any namespace to the Service.
+
+                    ParentRefs from a Route to a Service in a different namespace are
+                    "consumer" routes, and these routing rules are only applied to outbound
+                    connections originating from the same namespace as the Route, for which
+                    the intended destination of the connections are a Service targeted as a
+                    ParentRef of the Route.
                   items:
                     description: |-
                       ParentReference identifies an API object (usually a Gateway) that can be considered
@@ -2870,6 +4198,18 @@ spec:
                           Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                           generic way to enable any other kind of cross-namespace reference.
 
+
+                          ParentRefs from a Route to a Service in the same namespace are "producer"
+                          routes, which apply default routing rules to inbound connections from
+                          any namespace to the Service.
+
+                          ParentRefs from a Route to a Service in a different namespace are
+                          "consumer" routes, and these routing rules are only applied to outbound
+                          connections originating from the same namespace as the Route, for which
+                          the intended destination of the connections are a Service targeted as a
+                          ParentRef of the Route.
+
+
                           Support: Core
                         maxLength: 63
                         minLength: 1
@@ -2887,6 +4227,12 @@ spec:
                           as opposed to a listener(s) whose port(s) may be changed. When both Port
                           and SectionName are specified, the name and port of the selected listener
                           must match both specified values.
+
+
+                          When the parent resource is a Service, this targets a specific port in the
+                          Service spec. When both Port (experimental) and SectionName are specified,
+                          the name and port of the selected port must match both specified values.
+
 
                           Implementations MAY choose to support other parent resources.
                           Implementations supporting other types of parent resources MUST clearly
@@ -2942,10 +4288,10 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                   x-kubernetes-validations:
-                    - message: sectionName must be specified when parentRefs includes 2 or more references to the same parent
-                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''')) : true))'
-                    - message: sectionName must be unique when parentRefs includes 2 or more references to the same parent
-                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || (has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName))))
+                    - message: sectionName or port must be specified when parentRefs includes 2 or more references to the same parent
+                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port) || p2.port == 0)): true))'
+                    - message: sectionName or port must be unique when parentRefs includes 2 or more references to the same parent
+                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port) || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port == p2.port))))
                 rules:
                   default:
                     - matches:
@@ -3004,6 +4350,21 @@ spec:
                             ReferenceGrant object is required in the referent namespace to allow that
                             namespace's owner to accept the reference. See the ReferenceGrant
                             documentation for details.
+
+
+                            When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                            honor the appProtocol field if it is set for the target Service Port.
+
+                            Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                            Standard Application Protocols defined in KEP-3726.
+
+                            If a Service appProtocol isn't specified, an implementation MAY infer the
+                            backend protocol through its own means. Implementations MAY infer the
+                            protocol from the Route type referring to the backend Service.
+
+                            If a Route is not able to send traffic to the backend using the specified
+                            protocol then the backend is considered invalid. Implementations MUST set the
+                            "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
                           properties:
                             filters:
                               description: |-
@@ -3021,6 +4382,288 @@ spec:
                                   authentication strategies, rate-limiting, and traffic shaping. API
                                   guarantee/conformance is defined based on the type of the filter.
                                 properties:
+                                  cors:
+                                    description: |-
+                                      CORS defines a schema for a filter that responds to the
+                                      cross-origin request based on HTTP response header.
+
+                                      Support: Extended
+                                    properties:
+                                      allowCredentials:
+                                        description: |-
+                                          AllowCredentials indicates whether the actual cross-origin request allows
+                                          to include credentials.
+
+                                          When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                          response header with value true (case-sensitive).
+
+                                          When set to false or omitted the gateway will omit the header
+                                          `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                          behavior).
+
+                                          Support: Extended
+                                        type: boolean
+                                      allowHeaders:
+                                        description: |-
+                                          AllowHeaders indicates which HTTP request headers are supported for
+                                          accessing the requested resource.
+
+                                          Header names are not case sensitive.
+
+                                          Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                          response header are separated by a comma (",").
+
+                                          When the `AllowHeaders` field is configured with one or more headers, the
+                                          gateway must return the `Access-Control-Allow-Headers` response header
+                                          which value is present in the `AllowHeaders` field.
+
+                                          If any header name in the `Access-Control-Request-Headers` request header
+                                          is not included in the list of header names specified by the response
+                                          header `Access-Control-Allow-Headers`, it will present an error on the
+                                          client side.
+
+                                          If any header name in the `Access-Control-Allow-Headers` response header
+                                          does not recognize by the client, it will also occur an error on the
+                                          client side.
+
+                                          A wildcard indicates that the requests with all HTTP headers are allowed.
+                                          The `Access-Control-Allow-Headers` response header can only use `*`
+                                          wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                          When the `AllowCredentials` field is true and `AllowHeaders` field
+                                          specified with the `*` wildcard, the gateway must specify one or more
+                                          HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                          header. The value of the header `Access-Control-Allow-Headers` is same as
+                                          the `Access-Control-Request-Headers` header provided by the client. If
+                                          the header `Access-Control-Request-Headers` is not included in the
+                                          request, the gateway will omit the `Access-Control-Allow-Headers`
+                                          response header, instead of specifying the `*` wildcard. A Gateway
+                                          implementation may choose to add implementation-specific default headers.
+
+                                          Support: Extended
+                                        items:
+                                          description: |-
+                                            HTTPHeaderName is the name of an HTTP header.
+
+                                            Valid values include:
+
+                                            * "Authorization"
+                                            * "Set-Cookie"
+
+                                            Invalid values include:
+
+                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                                headers are not currently supported by this type.
+                                              - "/invalid" - "/ " is an invalid character
+                                          maxLength: 256
+                                          minLength: 1
+                                          pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          type: string
+                                        maxItems: 64
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      allowMethods:
+                                        description: |-
+                                          AllowMethods indicates which HTTP methods are supported for accessing the
+                                          requested resource.
+
+                                          Valid values are any method defined by RFC9110, along with the special
+                                          value `*`, which represents all HTTP methods are allowed.
+
+                                          Method names are case sensitive, so these values are also case-sensitive.
+                                          (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                          Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                          response header are separated by a comma (",").
+
+                                          A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                          (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                          CORS-safelisted methods are always allowed, regardless of whether they
+                                          are specified in the `AllowMethods` field.
+
+                                          When the `AllowMethods` field is configured with one or more methods, the
+                                          gateway must return the `Access-Control-Allow-Methods` response header
+                                          which value is present in the `AllowMethods` field.
+
+                                          If the HTTP method of the `Access-Control-Request-Method` request header
+                                          is not included in the list of methods specified by the response header
+                                          `Access-Control-Allow-Methods`, it will present an error on the client
+                                          side.
+
+                                          The `Access-Control-Allow-Methods` response header can only use `*`
+                                          wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                          When the `AllowCredentials` field is true and `AllowMethods` field
+                                          specified with the `*` wildcard, the gateway must specify one HTTP method
+                                          in the value of the Access-Control-Allow-Methods response header. The
+                                          value of the header `Access-Control-Allow-Methods` is same as the
+                                          `Access-Control-Request-Method` header provided by the client. If the
+                                          header `Access-Control-Request-Method` is not included in the request,
+                                          the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                          instead of specifying the `*` wildcard. A Gateway implementation may
+                                          choose to add implementation-specific default methods.
+
+                                          Support: Extended
+                                        items:
+                                          enum:
+                                            - GET
+                                            - HEAD
+                                            - POST
+                                            - PUT
+                                            - DELETE
+                                            - CONNECT
+                                            - OPTIONS
+                                            - TRACE
+                                            - PATCH
+                                            - '*'
+                                          type: string
+                                        maxItems: 9
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                        x-kubernetes-validations:
+                                          - message: AllowMethods cannot contain '*' alongside other methods
+                                            rule: '!(''*'' in self && self.size() > 1)'
+                                      allowOrigins:
+                                        description: |-
+                                          AllowOrigins indicates whether the response can be shared with requested
+                                          resource from the given `Origin`.
+
+                                          The `Origin` consists of a scheme and a host, with an optional port, and
+                                          takes the form `<scheme>://<host>(:<port>)`.
+
+                                          Valid values for scheme are: `http` and `https`.
+
+                                          Valid values for port are any integer between 1 and 65535 (the list of
+                                          available TCP/UDP ports). Note that, if not included, port `80` is
+                                          assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                          origins. This may affect origin matching.
+
+                                          The host part of the origin may contain the wildcard character `*`. These
+                                          wildcard characters behave as follows:
+
+                                          * `*` is a greedy match to the _left_, including any number of
+                                            DNS labels to the left of its position. This also means that
+                                            `*` will include any number of period `.` characters to the
+                                            left of its position.
+                                          * A wildcard by itself matches all hosts.
+
+                                          An origin value that includes _only_ the `*` character indicates requests
+                                          from all `Origin`s are allowed.
+
+                                          When the `AllowOrigins` field is configured with multiple origins, it
+                                          means the server supports clients from multiple origins. If the request
+                                          `Origin` matches the configured allowed origins, the gateway must return
+                                          the given `Origin` and sets value of the header
+                                          `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                          client.
+
+                                          The status code of a successful response to a "preflight" request is
+                                          always an OK status (i.e., 204 or 200).
+
+                                          If the request `Origin` does not match the configured allowed origins,
+                                          the gateway returns 204/200 response but doesn't set the relevant
+                                          cross-origin response headers. Alternatively, the gateway responds with
+                                          403 status to the "preflight" request is denied, coupled with omitting
+                                          the CORS headers. The cross-origin request fails on the client side.
+                                          Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                          The `Access-Control-Allow-Origin` response header can only use `*`
+                                          wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                          When the `AllowCredentials` field is true and `AllowOrigins` field
+                                          specified with the `*` wildcard, the gateway must return a single origin
+                                          in the value of the `Access-Control-Allow-Origin` response header,
+                                          instead of specifying the `*` wildcard. The value of the header
+                                          `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                          the client.
+
+                                          Support: Extended
+                                        items:
+                                          description: |-
+                                            The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                            encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                            scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                            URIs that include an authority MUST include a fully qualified domain name or
+                                            IP address as the host.
+                                          maxLength: 253
+                                          minLength: 1
+                                          pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
+                                          type: string
+                                        maxItems: 64
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                        x-kubernetes-validations:
+                                          - message: AllowOrigins cannot contain '*' alongside other origins
+                                            rule: '!(''*'' in self && self.size() > 1)'
+                                      exposeHeaders:
+                                        description: |-
+                                          ExposeHeaders indicates which HTTP response headers can be exposed
+                                          to client-side scripts in response to a cross-origin request.
+
+                                          A CORS-safelisted response header is an HTTP header in a CORS response
+                                          that it is considered safe to expose to the client scripts.
+                                          The CORS-safelisted response headers include the following headers:
+                                          `Cache-Control`
+                                          `Content-Language`
+                                          `Content-Length`
+                                          `Content-Type`
+                                          `Expires`
+                                          `Last-Modified`
+                                          `Pragma`
+                                          (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                          The CORS-safelisted response headers are exposed to client by default.
+
+                                          When an HTTP header name is specified using the `ExposeHeaders` field,
+                                          this additional header will be exposed as part of the response to the
+                                          client.
+
+                                          Header names are not case sensitive.
+
+                                          Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                          response header are separated by a comma (",").
+
+                                          A wildcard indicates that the responses with all HTTP headers are exposed
+                                          to clients. The `Access-Control-Expose-Headers` response header can only
+                                          use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                          Support: Extended
+                                        items:
+                                          description: |-
+                                            HTTPHeaderName is the name of an HTTP header.
+
+                                            Valid values include:
+
+                                            * "Authorization"
+                                            * "Set-Cookie"
+
+                                            Invalid values include:
+
+                                              - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                                headers are not currently supported by this type.
+                                              - "/invalid" - "/ " is an invalid character
+                                          maxLength: 256
+                                          minLength: 1
+                                          pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                          type: string
+                                        maxItems: 64
+                                        type: array
+                                        x-kubernetes-list-type: set
+                                      maxAge:
+                                        default: 5
+                                        description: |-
+                                          MaxAge indicates the duration (in seconds) for the client to cache the
+                                          results of a "preflight" request.
+
+                                          The information provided by the `Access-Control-Allow-Methods` and
+                                          `Access-Control-Allow-Headers` response headers can be cached by the
+                                          client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                          The default value of `Access-Control-Max-Age` response header is 5
+                                          (seconds).
+                                        format: int32
+                                        minimum: 1
+                                        type: integer
+                                    type: object
                                   extensionRef:
                                     description: |-
                                       ExtensionRef is an optional, implementation-specific extension to the
@@ -3055,6 +4698,244 @@ spec:
                                       - kind
                                       - name
                                     type: object
+                                  externalAuth:
+                                    description: |-
+                                      ExternalAuth configures settings related to sending request details
+                                      to an external auth service. The external service MUST authenticate
+                                      the request, and MAY authorize the request as well.
+
+                                      If there is any problem communicating with the external service,
+                                      this filter MUST fail closed.
+
+                                      Support: Extended
+                                    properties:
+                                      backendRef:
+                                        description: |-
+                                          BackendRef is a reference to a backend to send authorization
+                                          requests to.
+
+                                          The backend must speak the selected protocol (GRPC or HTTP) on the
+                                          referenced port.
+
+                                          If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                          implementation to supply the TLS details to be used to connect to that
+                                          backend.
+                                        properties:
+                                          group:
+                                            default: ""
+                                            description: |-
+                                              Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                              When unspecified or empty string, core API group is inferred.
+                                            maxLength: 253
+                                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                            type: string
+                                          kind:
+                                            default: Service
+                                            description: |-
+                                              Kind is the Kubernetes resource kind of the referent. For example
+                                              "Service".
+
+                                              Defaults to "Service" when not specified.
+
+                                              ExternalName services can refer to CNAME DNS records that may live
+                                              outside of the cluster and as such are difficult to reason about in
+                                              terms of conformance. They also may not be safe to forward to (see
+                                              CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                              support ExternalName Services.
+
+                                              Support: Core (Services with a type other than ExternalName)
+
+                                              Support: Implementation-specific (Services with type ExternalName)
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                            type: string
+                                          name:
+                                            description: Name is the name of the referent.
+                                            maxLength: 253
+                                            minLength: 1
+                                            type: string
+                                          namespace:
+                                            description: |-
+                                              Namespace is the namespace of the backend. When unspecified, the local
+                                              namespace is inferred.
+
+                                              Note that when a namespace different than the local namespace is specified,
+                                              a ReferenceGrant object is required in the referent namespace to allow that
+                                              namespace's owner to accept the reference. See the ReferenceGrant
+                                              documentation for details.
+
+                                              Support: Core
+                                            maxLength: 63
+                                            minLength: 1
+                                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                            type: string
+                                          port:
+                                            description: |-
+                                              Port specifies the destination port number to use for this resource.
+                                              Port is required when the referent is a Kubernetes Service. In this
+                                              case, the port number is the service port number, not the target port.
+                                              For other resources, destination port might be derived from the referent
+                                              resource or this field.
+                                            format: int32
+                                            maximum: 65535
+                                            minimum: 1
+                                            type: integer
+                                        required:
+                                          - name
+                                        type: object
+                                        x-kubernetes-validations:
+                                          - message: Must have port for Service reference
+                                            rule: '(size(self.group) == 0 && self.kind == ''Service'') ? has(self.port) : true'
+                                      forwardBody:
+                                        description: |-
+                                          ForwardBody controls if requests to the authorization server should include
+                                          the body of the client request; and if so, how big that body is allowed
+                                          to be.
+
+                                          It is expected that implementations will buffer the request body up to
+                                          `forwardBody.maxSize` bytes. Bodies over that size must be rejected with a
+                                          4xx series error (413 or 403 are common examples), and fail processing
+                                          of the filter.
+
+                                          If unset, or `forwardBody.maxSize` is set to `0`, then the body will not
+                                          be forwarded.
+
+                                          Feature Name: HTTPRouteExternalAuthForwardBody
+                                        properties:
+                                          maxSize:
+                                            description: |-
+                                              MaxSize specifies how large in bytes the largest body that will be buffered
+                                              and sent to the authorization server. If the body size is larger than
+                                              `maxSize`, then the body sent to the authorization server must be
+                                              truncated to `maxSize` bytes.
+
+                                              Experimental note: This behavior needs to be checked against
+                                              various dataplanes; it may need to be changed.
+                                              See https://github.com/kubernetes-sigs/gateway-api/pull/4001#discussion_r2291405746
+                                              for more.
+
+                                              If 0, the body will not be sent to the authorization server.
+                                            type: integer
+                                        type: object
+                                      grpc:
+                                        description: |-
+                                          GRPCAuthConfig contains configuration for communication with ext_authz
+                                          protocol-speaking backends.
+
+                                          If unset, implementations must assume the default behavior for each
+                                          included field is intended.
+                                        properties:
+                                          allowedHeaders:
+                                            description: |-
+                                              AllowedRequestHeaders specifies what headers from the client request
+                                              will be sent to the authorization server.
+
+                                              If this list is empty, then all headers must be sent.
+
+                                              If the list has entries, only those entries must be sent.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        type: object
+                                      http:
+                                        description: |-
+                                          HTTPAuthConfig contains configuration for communication with HTTP-speaking
+                                          backends.
+
+                                          If unset, implementations must assume the default behavior for each
+                                          included field is intended.
+                                        properties:
+                                          allowedHeaders:
+                                            description: |-
+                                              AllowedRequestHeaders specifies what additional headers from the client request
+                                              will be sent to the authorization server.
+
+                                              The following headers must always be sent to the authorization server,
+                                              regardless of this setting:
+
+                                              * `Host`
+                                              * `Method`
+                                              * `Path`
+                                              * `Content-Length`
+                                              * `Authorization`
+
+                                              If this list is empty, then only those headers must be sent.
+
+                                              Note that `Content-Length` has a special behavior, in that the length
+                                              sent must be correct for the actual request to the external authorization
+                                              server - that is, it must reflect the actual number of bytes sent in the
+                                              body of the request to the authorization server.
+
+                                              So if the `forwardBody` stanza is unset, or `forwardBody.maxSize` is set
+                                              to `0`, then `Content-Length` must be `0`. If `forwardBody.maxSize` is set
+                                              to anything other than `0`, then the `Content-Length` of the authorization
+                                              request must be set to the actual number of bytes forwarded.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          allowedResponseHeaders:
+                                            description: |-
+                                              AllowedResponseHeaders specifies what headers from the authorization response
+                                              will be copied into the request to the backend.
+
+                                              If this list is empty, then all headers from the authorization server
+                                              except Authority or Host must be copied.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                          path:
+                                            description: |-
+                                              Path sets the prefix that paths from the client request will have added
+                                              when forwarded to the authorization server.
+
+                                              When empty or unspecified, no prefix is added.
+
+                                              Valid values are the same as the "value" regex for path values in the `match`
+                                              stanza, and the validation regex will screen out invalid paths in the same way.
+                                              Even with the validation, implementations MUST sanitize this input before using it
+                                              directly.
+                                            maxLength: 1024
+                                            pattern: ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$
+                                            type: string
+                                        type: object
+                                      protocol:
+                                        description: |-
+                                          ExternalAuthProtocol describes which protocol to use when communicating with an
+                                          ext_authz authorization server.
+
+                                          When this is set to GRPC, each backend must use the Envoy ext_authz protocol
+                                          on the port specified in `backendRefs`. Requests and responses are defined
+                                          in the protobufs explained at:
+                                          https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
+
+                                          When this is set to HTTP, each backend must respond with a `200` status
+                                          code in on a successful authorization. Any other code is considered
+                                          an authorization failure.
+
+                                          Feature Names:
+                                          GRPC Support - HTTPRouteExternalAuthGRPC
+                                          HTTP Support - HTTPRouteExternalAuthHTTP
+                                        enum:
+                                          - HTTP
+                                          - GRPC
+                                        type: string
+                                    required:
+                                      - backendRef
+                                      - protocol
+                                    type: object
+                                    x-kubernetes-validations:
+                                      - message: grpc must be specified when protocol is set to 'GRPC'
+                                        rule: 'self.protocol == ''GRPC'' ? has(self.grpc) : true'
+                                      - message: protocol must be 'GRPC' when grpc is set
+                                        rule: 'has(self.grpc) ? self.protocol == ''GRPC'' : true'
+                                      - message: http must be specified when protocol is set to 'HTTP'
+                                        rule: 'self.protocol == ''HTTP'' ? has(self.http) : true'
+                                      - message: protocol must be 'HTTP' when http is set
+                                        rule: 'has(self.http) ? self.protocol == ''HTTP'' : true'
                                   requestHeaderModifier:
                                     description: |-
                                       RequestHeaderModifier defines a schema for a filter that modifies request
@@ -3644,6 +5525,8 @@ spec:
                                       - RequestRedirect
                                       - URLRewrite
                                       - ExtensionRef
+                                      - CORS
+                                      - ExternalAuth
                                     type: string
                                   urlRewrite:
                                     description: |-
@@ -3749,6 +5632,14 @@ spec:
                                     rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
                                   - message: filter.extensionRef must be specified for ExtensionRef filter.type
                                     rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                                  - message: filter.cors must be nil if the filter.type is not CORS
+                                    rule: '!(has(self.cors) && self.type != ''CORS'')'
+                                  - message: filter.cors must be specified for CORS filter.type
+                                    rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                                  - message: filter.externalAuth must be nil if the filter.type is not ExternalAuth
+                                    rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
+                                  - message: filter.externalAuth must be specified for ExternalAuth filter.type
+                                    rule: '!(!has(self.externalAuth) && self.type == ''ExternalAuth'')'
                               maxItems: 16
                               type: array
                               x-kubernetes-list-type: atomic
@@ -3899,6 +5790,288 @@ spec:
                             authentication strategies, rate-limiting, and traffic shaping. API
                             guarantee/conformance is defined based on the type of the filter.
                           properties:
+                            cors:
+                              description: |-
+                                CORS defines a schema for a filter that responds to the
+                                cross-origin request based on HTTP response header.
+
+                                Support: Extended
+                              properties:
+                                allowCredentials:
+                                  description: |-
+                                    AllowCredentials indicates whether the actual cross-origin request allows
+                                    to include credentials.
+
+                                    When set to true, the gateway will include the `Access-Control-Allow-Credentials`
+                                    response header with value true (case-sensitive).
+
+                                    When set to false or omitted the gateway will omit the header
+                                    `Access-Control-Allow-Credentials` entirely (this is the standard CORS
+                                    behavior).
+
+                                    Support: Extended
+                                  type: boolean
+                                allowHeaders:
+                                  description: |-
+                                    AllowHeaders indicates which HTTP request headers are supported for
+                                    accessing the requested resource.
+
+                                    Header names are not case sensitive.
+
+                                    Multiple header names in the value of the `Access-Control-Allow-Headers`
+                                    response header are separated by a comma (",").
+
+                                    When the `AllowHeaders` field is configured with one or more headers, the
+                                    gateway must return the `Access-Control-Allow-Headers` response header
+                                    which value is present in the `AllowHeaders` field.
+
+                                    If any header name in the `Access-Control-Request-Headers` request header
+                                    is not included in the list of header names specified by the response
+                                    header `Access-Control-Allow-Headers`, it will present an error on the
+                                    client side.
+
+                                    If any header name in the `Access-Control-Allow-Headers` response header
+                                    does not recognize by the client, it will also occur an error on the
+                                    client side.
+
+                                    A wildcard indicates that the requests with all HTTP headers are allowed.
+                                    The `Access-Control-Allow-Headers` response header can only use `*`
+                                    wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                    When the `AllowCredentials` field is true and `AllowHeaders` field
+                                    specified with the `*` wildcard, the gateway must specify one or more
+                                    HTTP headers in the value of the `Access-Control-Allow-Headers` response
+                                    header. The value of the header `Access-Control-Allow-Headers` is same as
+                                    the `Access-Control-Request-Headers` header provided by the client. If
+                                    the header `Access-Control-Request-Headers` is not included in the
+                                    request, the gateway will omit the `Access-Control-Allow-Headers`
+                                    response header, instead of specifying the `*` wildcard. A Gateway
+                                    implementation may choose to add implementation-specific default headers.
+
+                                    Support: Extended
+                                  items:
+                                    description: |-
+                                      HTTPHeaderName is the name of an HTTP header.
+
+                                      Valid values include:
+
+                                      * "Authorization"
+                                      * "Set-Cookie"
+
+                                      Invalid values include:
+
+                                        - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                          headers are not currently supported by this type.
+                                        - "/invalid" - "/ " is an invalid character
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  maxItems: 64
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                allowMethods:
+                                  description: |-
+                                    AllowMethods indicates which HTTP methods are supported for accessing the
+                                    requested resource.
+
+                                    Valid values are any method defined by RFC9110, along with the special
+                                    value `*`, which represents all HTTP methods are allowed.
+
+                                    Method names are case sensitive, so these values are also case-sensitive.
+                                    (See https://www.rfc-editor.org/rfc/rfc2616#section-5.1.1)
+
+                                    Multiple method names in the value of the `Access-Control-Allow-Methods`
+                                    response header are separated by a comma (",").
+
+                                    A CORS-safelisted method is a method that is `GET`, `HEAD`, or `POST`.
+                                    (See https://fetch.spec.whatwg.org/#cors-safelisted-method) The
+                                    CORS-safelisted methods are always allowed, regardless of whether they
+                                    are specified in the `AllowMethods` field.
+
+                                    When the `AllowMethods` field is configured with one or more methods, the
+                                    gateway must return the `Access-Control-Allow-Methods` response header
+                                    which value is present in the `AllowMethods` field.
+
+                                    If the HTTP method of the `Access-Control-Request-Method` request header
+                                    is not included in the list of methods specified by the response header
+                                    `Access-Control-Allow-Methods`, it will present an error on the client
+                                    side.
+
+                                    The `Access-Control-Allow-Methods` response header can only use `*`
+                                    wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                    When the `AllowCredentials` field is true and `AllowMethods` field
+                                    specified with the `*` wildcard, the gateway must specify one HTTP method
+                                    in the value of the Access-Control-Allow-Methods response header. The
+                                    value of the header `Access-Control-Allow-Methods` is same as the
+                                    `Access-Control-Request-Method` header provided by the client. If the
+                                    header `Access-Control-Request-Method` is not included in the request,
+                                    the gateway will omit the `Access-Control-Allow-Methods` response header,
+                                    instead of specifying the `*` wildcard. A Gateway implementation may
+                                    choose to add implementation-specific default methods.
+
+                                    Support: Extended
+                                  items:
+                                    enum:
+                                      - GET
+                                      - HEAD
+                                      - POST
+                                      - PUT
+                                      - DELETE
+                                      - CONNECT
+                                      - OPTIONS
+                                      - TRACE
+                                      - PATCH
+                                      - '*'
+                                    type: string
+                                  maxItems: 9
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - message: AllowMethods cannot contain '*' alongside other methods
+                                      rule: '!(''*'' in self && self.size() > 1)'
+                                allowOrigins:
+                                  description: |-
+                                    AllowOrigins indicates whether the response can be shared with requested
+                                    resource from the given `Origin`.
+
+                                    The `Origin` consists of a scheme and a host, with an optional port, and
+                                    takes the form `<scheme>://<host>(:<port>)`.
+
+                                    Valid values for scheme are: `http` and `https`.
+
+                                    Valid values for port are any integer between 1 and 65535 (the list of
+                                    available TCP/UDP ports). Note that, if not included, port `80` is
+                                    assumed for `http` scheme origins, and port `443` is assumed for `https`
+                                    origins. This may affect origin matching.
+
+                                    The host part of the origin may contain the wildcard character `*`. These
+                                    wildcard characters behave as follows:
+
+                                    * `*` is a greedy match to the _left_, including any number of
+                                      DNS labels to the left of its position. This also means that
+                                      `*` will include any number of period `.` characters to the
+                                      left of its position.
+                                    * A wildcard by itself matches all hosts.
+
+                                    An origin value that includes _only_ the `*` character indicates requests
+                                    from all `Origin`s are allowed.
+
+                                    When the `AllowOrigins` field is configured with multiple origins, it
+                                    means the server supports clients from multiple origins. If the request
+                                    `Origin` matches the configured allowed origins, the gateway must return
+                                    the given `Origin` and sets value of the header
+                                    `Access-Control-Allow-Origin` same as the `Origin` header provided by the
+                                    client.
+
+                                    The status code of a successful response to a "preflight" request is
+                                    always an OK status (i.e., 204 or 200).
+
+                                    If the request `Origin` does not match the configured allowed origins,
+                                    the gateway returns 204/200 response but doesn't set the relevant
+                                    cross-origin response headers. Alternatively, the gateway responds with
+                                    403 status to the "preflight" request is denied, coupled with omitting
+                                    the CORS headers. The cross-origin request fails on the client side.
+                                    Therefore, the client doesn't attempt the actual cross-origin request.
+
+                                    The `Access-Control-Allow-Origin` response header can only use `*`
+                                    wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                    When the `AllowCredentials` field is true and `AllowOrigins` field
+                                    specified with the `*` wildcard, the gateway must return a single origin
+                                    in the value of the `Access-Control-Allow-Origin` response header,
+                                    instead of specifying the `*` wildcard. The value of the header
+                                    `Access-Control-Allow-Origin` is same as the `Origin` header provided by
+                                    the client.
+
+                                    Support: Extended
+                                  items:
+                                    description: |-
+                                      The CORSOrigin MUST NOT be a relative URI, and it MUST follow the URI syntax and
+                                      encoding rules specified in RFC3986.  The CORSOrigin MUST include both a
+                                      scheme (e.g., "http" or "spiffe") and a scheme-specific-part, or it should be a single '*' character.
+                                      URIs that include an authority MUST include a fully qualified domain name or
+                                      IP address as the host.
+                                    maxLength: 253
+                                    minLength: 1
+                                    pattern: (^\*$)|(^([a-zA-Z][a-zA-Z0-9+\-.]+):\/\/([^:/?#]+)(:([0-9]{1,5}))?$)
+                                    type: string
+                                  maxItems: 64
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                  x-kubernetes-validations:
+                                    - message: AllowOrigins cannot contain '*' alongside other origins
+                                      rule: '!(''*'' in self && self.size() > 1)'
+                                exposeHeaders:
+                                  description: |-
+                                    ExposeHeaders indicates which HTTP response headers can be exposed
+                                    to client-side scripts in response to a cross-origin request.
+
+                                    A CORS-safelisted response header is an HTTP header in a CORS response
+                                    that it is considered safe to expose to the client scripts.
+                                    The CORS-safelisted response headers include the following headers:
+                                    `Cache-Control`
+                                    `Content-Language`
+                                    `Content-Length`
+                                    `Content-Type`
+                                    `Expires`
+                                    `Last-Modified`
+                                    `Pragma`
+                                    (See https://fetch.spec.whatwg.org/#cors-safelisted-response-header-name)
+                                    The CORS-safelisted response headers are exposed to client by default.
+
+                                    When an HTTP header name is specified using the `ExposeHeaders` field,
+                                    this additional header will be exposed as part of the response to the
+                                    client.
+
+                                    Header names are not case sensitive.
+
+                                    Multiple header names in the value of the `Access-Control-Expose-Headers`
+                                    response header are separated by a comma (",").
+
+                                    A wildcard indicates that the responses with all HTTP headers are exposed
+                                    to clients. The `Access-Control-Expose-Headers` response header can only
+                                    use `*` wildcard as value when the `AllowCredentials` field is false or omitted.
+
+                                    Support: Extended
+                                  items:
+                                    description: |-
+                                      HTTPHeaderName is the name of an HTTP header.
+
+                                      Valid values include:
+
+                                      * "Authorization"
+                                      * "Set-Cookie"
+
+                                      Invalid values include:
+
+                                        - ":method" - ":" is an invalid character. This means that HTTP/2 pseudo
+                                          headers are not currently supported by this type.
+                                        - "/invalid" - "/ " is an invalid character
+                                    maxLength: 256
+                                    minLength: 1
+                                    pattern: ^[A-Za-z0-9!#$%&'*+\-.^_\x60|~]+$
+                                    type: string
+                                  maxItems: 64
+                                  type: array
+                                  x-kubernetes-list-type: set
+                                maxAge:
+                                  default: 5
+                                  description: |-
+                                    MaxAge indicates the duration (in seconds) for the client to cache the
+                                    results of a "preflight" request.
+
+                                    The information provided by the `Access-Control-Allow-Methods` and
+                                    `Access-Control-Allow-Headers` response headers can be cached by the
+                                    client until the time specified by `Access-Control-Max-Age` elapses.
+
+                                    The default value of `Access-Control-Max-Age` response header is 5
+                                    (seconds).
+                                  format: int32
+                                  minimum: 1
+                                  type: integer
+                              type: object
                             extensionRef:
                               description: |-
                                 ExtensionRef is an optional, implementation-specific extension to the
@@ -3933,6 +6106,244 @@ spec:
                                 - kind
                                 - name
                               type: object
+                            externalAuth:
+                              description: |-
+                                ExternalAuth configures settings related to sending request details
+                                to an external auth service. The external service MUST authenticate
+                                the request, and MAY authorize the request as well.
+
+                                If there is any problem communicating with the external service,
+                                this filter MUST fail closed.
+
+                                Support: Extended
+                              properties:
+                                backendRef:
+                                  description: |-
+                                    BackendRef is a reference to a backend to send authorization
+                                    requests to.
+
+                                    The backend must speak the selected protocol (GRPC or HTTP) on the
+                                    referenced port.
+
+                                    If the backend service requires TLS, use BackendTLSPolicy to tell the
+                                    implementation to supply the TLS details to be used to connect to that
+                                    backend.
+                                  properties:
+                                    group:
+                                      default: ""
+                                      description: |-
+                                        Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                        When unspecified or empty string, core API group is inferred.
+                                      maxLength: 253
+                                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                      type: string
+                                    kind:
+                                      default: Service
+                                      description: |-
+                                        Kind is the Kubernetes resource kind of the referent. For example
+                                        "Service".
+
+                                        Defaults to "Service" when not specified.
+
+                                        ExternalName services can refer to CNAME DNS records that may live
+                                        outside of the cluster and as such are difficult to reason about in
+                                        terms of conformance. They also may not be safe to forward to (see
+                                        CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                        support ExternalName Services.
+
+                                        Support: Core (Services with a type other than ExternalName)
+
+                                        Support: Implementation-specific (Services with type ExternalName)
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                      type: string
+                                    name:
+                                      description: Name is the name of the referent.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace is the namespace of the backend. When unspecified, the local
+                                        namespace is inferred.
+
+                                        Note that when a namespace different than the local namespace is specified,
+                                        a ReferenceGrant object is required in the referent namespace to allow that
+                                        namespace's owner to accept the reference. See the ReferenceGrant
+                                        documentation for details.
+
+                                        Support: Core
+                                      maxLength: 63
+                                      minLength: 1
+                                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                      type: string
+                                    port:
+                                      description: |-
+                                        Port specifies the destination port number to use for this resource.
+                                        Port is required when the referent is a Kubernetes Service. In this
+                                        case, the port number is the service port number, not the target port.
+                                        For other resources, destination port might be derived from the referent
+                                        resource or this field.
+                                      format: int32
+                                      maximum: 65535
+                                      minimum: 1
+                                      type: integer
+                                  required:
+                                    - name
+                                  type: object
+                                  x-kubernetes-validations:
+                                    - message: Must have port for Service reference
+                                      rule: '(size(self.group) == 0 && self.kind == ''Service'') ? has(self.port) : true'
+                                forwardBody:
+                                  description: |-
+                                    ForwardBody controls if requests to the authorization server should include
+                                    the body of the client request; and if so, how big that body is allowed
+                                    to be.
+
+                                    It is expected that implementations will buffer the request body up to
+                                    `forwardBody.maxSize` bytes. Bodies over that size must be rejected with a
+                                    4xx series error (413 or 403 are common examples), and fail processing
+                                    of the filter.
+
+                                    If unset, or `forwardBody.maxSize` is set to `0`, then the body will not
+                                    be forwarded.
+
+                                    Feature Name: HTTPRouteExternalAuthForwardBody
+                                  properties:
+                                    maxSize:
+                                      description: |-
+                                        MaxSize specifies how large in bytes the largest body that will be buffered
+                                        and sent to the authorization server. If the body size is larger than
+                                        `maxSize`, then the body sent to the authorization server must be
+                                        truncated to `maxSize` bytes.
+
+                                        Experimental note: This behavior needs to be checked against
+                                        various dataplanes; it may need to be changed.
+                                        See https://github.com/kubernetes-sigs/gateway-api/pull/4001#discussion_r2291405746
+                                        for more.
+
+                                        If 0, the body will not be sent to the authorization server.
+                                      type: integer
+                                  type: object
+                                grpc:
+                                  description: |-
+                                    GRPCAuthConfig contains configuration for communication with ext_authz
+                                    protocol-speaking backends.
+
+                                    If unset, implementations must assume the default behavior for each
+                                    included field is intended.
+                                  properties:
+                                    allowedHeaders:
+                                      description: |-
+                                        AllowedRequestHeaders specifies what headers from the client request
+                                        will be sent to the authorization server.
+
+                                        If this list is empty, then all headers must be sent.
+
+                                        If the list has entries, only those entries must be sent.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                  type: object
+                                http:
+                                  description: |-
+                                    HTTPAuthConfig contains configuration for communication with HTTP-speaking
+                                    backends.
+
+                                    If unset, implementations must assume the default behavior for each
+                                    included field is intended.
+                                  properties:
+                                    allowedHeaders:
+                                      description: |-
+                                        AllowedRequestHeaders specifies what additional headers from the client request
+                                        will be sent to the authorization server.
+
+                                        The following headers must always be sent to the authorization server,
+                                        regardless of this setting:
+
+                                        * `Host`
+                                        * `Method`
+                                        * `Path`
+                                        * `Content-Length`
+                                        * `Authorization`
+
+                                        If this list is empty, then only those headers must be sent.
+
+                                        Note that `Content-Length` has a special behavior, in that the length
+                                        sent must be correct for the actual request to the external authorization
+                                        server - that is, it must reflect the actual number of bytes sent in the
+                                        body of the request to the authorization server.
+
+                                        So if the `forwardBody` stanza is unset, or `forwardBody.maxSize` is set
+                                        to `0`, then `Content-Length` must be `0`. If `forwardBody.maxSize` is set
+                                        to anything other than `0`, then the `Content-Length` of the authorization
+                                        request must be set to the actual number of bytes forwarded.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    allowedResponseHeaders:
+                                      description: |-
+                                        AllowedResponseHeaders specifies what headers from the authorization response
+                                        will be copied into the request to the backend.
+
+                                        If this list is empty, then all headers from the authorization server
+                                        except Authority or Host must be copied.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: set
+                                    path:
+                                      description: |-
+                                        Path sets the prefix that paths from the client request will have added
+                                        when forwarded to the authorization server.
+
+                                        When empty or unspecified, no prefix is added.
+
+                                        Valid values are the same as the "value" regex for path values in the `match`
+                                        stanza, and the validation regex will screen out invalid paths in the same way.
+                                        Even with the validation, implementations MUST sanitize this input before using it
+                                        directly.
+                                      maxLength: 1024
+                                      pattern: ^(?:[-A-Za-z0-9/._~!$&'()*+,;=:@]|[%][0-9a-fA-F]{2})+$
+                                      type: string
+                                  type: object
+                                protocol:
+                                  description: |-
+                                    ExternalAuthProtocol describes which protocol to use when communicating with an
+                                    ext_authz authorization server.
+
+                                    When this is set to GRPC, each backend must use the Envoy ext_authz protocol
+                                    on the port specified in `backendRefs`. Requests and responses are defined
+                                    in the protobufs explained at:
+                                    https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto
+
+                                    When this is set to HTTP, each backend must respond with a `200` status
+                                    code in on a successful authorization. Any other code is considered
+                                    an authorization failure.
+
+                                    Feature Names:
+                                    GRPC Support - HTTPRouteExternalAuthGRPC
+                                    HTTP Support - HTTPRouteExternalAuthHTTP
+                                  enum:
+                                    - HTTP
+                                    - GRPC
+                                  type: string
+                              required:
+                                - backendRef
+                                - protocol
+                              type: object
+                              x-kubernetes-validations:
+                                - message: grpc must be specified when protocol is set to 'GRPC'
+                                  rule: 'self.protocol == ''GRPC'' ? has(self.grpc) : true'
+                                - message: protocol must be 'GRPC' when grpc is set
+                                  rule: 'has(self.grpc) ? self.protocol == ''GRPC'' : true'
+                                - message: http must be specified when protocol is set to 'HTTP'
+                                  rule: 'self.protocol == ''HTTP'' ? has(self.http) : true'
+                                - message: protocol must be 'HTTP' when http is set
+                                  rule: 'has(self.http) ? self.protocol == ''HTTP'' : true'
                             requestHeaderModifier:
                               description: |-
                                 RequestHeaderModifier defines a schema for a filter that modifies request
@@ -4522,6 +6933,8 @@ spec:
                                 - RequestRedirect
                                 - URLRewrite
                                 - ExtensionRef
+                                - CORS
+                                - ExternalAuth
                               type: string
                             urlRewrite:
                               description: |-
@@ -4627,6 +7040,14 @@ spec:
                               rule: '!(has(self.extensionRef) && self.type != ''ExtensionRef'')'
                             - message: filter.extensionRef must be specified for ExtensionRef filter.type
                               rule: '!(!has(self.extensionRef) && self.type == ''ExtensionRef'')'
+                            - message: filter.cors must be nil if the filter.type is not CORS
+                              rule: '!(has(self.cors) && self.type != ''CORS'')'
+                            - message: filter.cors must be specified for CORS filter.type
+                              rule: '!(!has(self.cors) && self.type == ''CORS'')'
+                            - message: filter.externalAuth must be nil if the filter.type is not ExternalAuth
+                              rule: '!(has(self.externalAuth) && self.type != ''ExternalAuth'')'
+                            - message: filter.externalAuth must be specified for ExternalAuth filter.type
+                              rule: '!(!has(self.externalAuth) && self.type == ''ExternalAuth'')'
                         maxItems: 16
                         type: array
                         x-kubernetes-list-type: atomic
@@ -4931,6 +7352,181 @@ spec:
                         minLength: 1
                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                         type: string
+                      retry:
+                        description: |-
+                          Retry defines the configuration for when to retry an HTTP request.
+
+                          Support: Extended
+                        properties:
+                          attempts:
+                            description: |-
+                              Attempts specifies the maximum number of times an individual request
+                              from the gateway to a backend should be retried.
+
+                              If the maximum number of retries has been attempted without a successful
+                              response from the backend, the Gateway MUST return an error.
+
+                              When this field is unspecified, the number of times to attempt to retry
+                              a backend request is implementation-specific.
+
+                              Support: Extended
+                            type: integer
+                          backoff:
+                            description: |-
+                              Backoff specifies the minimum duration a Gateway should wait between
+                              retry attempts and is represented in Gateway API Duration formatting.
+
+                              For example, setting the `rules[].retry.backoff` field to the value
+                              `100ms` will cause a backend request to first be retried approximately
+                              100 milliseconds after timing out or receiving a response code configured
+                              to be retryable.
+
+                              An implementation MAY use an exponential or alternative backoff strategy
+                              for subsequent retry attempts, MAY cap the maximum backoff duration to
+                              some amount greater than the specified minimum, and MAY add arbitrary
+                              jitter to stagger requests, as long as unsuccessful backend requests are
+                              not retried before the configured minimum duration.
+
+                              If a Request timeout (`rules[].timeouts.request`) is configured on the
+                              route, the entire duration of the initial request and any retry attempts
+                              MUST not exceed the Request timeout duration. If any retry attempts are
+                              still in progress when the Request timeout duration has been reached,
+                              these SHOULD be canceled if possible and the Gateway MUST immediately
+                              return a timeout error.
+
+                              If a BackendRequest timeout (`rules[].timeouts.backendRequest`) is
+                              configured on the route, any retry attempts which reach the configured
+                              BackendRequest timeout duration without a response SHOULD be canceled if
+                              possible and the Gateway should wait for at least the specified backoff
+                              duration before attempting to retry the backend request again.
+
+                              If a BackendRequest timeout is _not_ configured on the route, retry
+                              attempts MAY time out after an implementation default duration, or MAY
+                              remain pending until a configured Request timeout or implementation
+                              default duration for total request time is reached.
+
+                              When this field is unspecified, the time to wait between retry attempts
+                              is implementation-specific.
+
+                              Support: Extended
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                          codes:
+                            description: |-
+                              Codes defines the HTTP response status codes for which a backend request
+                              should be retried.
+
+                              Support: Extended
+                            items:
+                              description: |-
+                                HTTPRouteRetryStatusCode defines an HTTP response status code for
+                                which a backend request should be retried.
+
+                                Implementations MUST support the following status codes as retryable:
+
+                                * 500
+                                * 502
+                                * 503
+                                * 504
+
+                                Implementations MAY support specifying additional discrete values in the
+                                500-599 range.
+
+                                Implementations MAY support specifying discrete values in the 400-499 range,
+                                which are often inadvisable to retry.
+                              maximum: 599
+                              minimum: 400
+                              type: integer
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      sessionPersistence:
+                        description: |-
+                          SessionPersistence defines and configures session persistence
+                          for the route rule.
+
+                          Support: Extended
+                        properties:
+                          absoluteTimeout:
+                            description: |-
+                              AbsoluteTimeout defines the absolute timeout of the persistent
+                              session. Once the AbsoluteTimeout duration has elapsed, the
+                              session becomes invalid.
+
+                              Support: Extended
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                          cookieConfig:
+                            description: |-
+                              CookieConfig provides configuration settings that are specific
+                              to cookie-based session persistence.
+
+                              Support: Core
+                            properties:
+                              lifetimeType:
+                                default: Session
+                                description: |-
+                                  LifetimeType specifies whether the cookie has a permanent or
+                                  session-based lifetime. A permanent cookie persists until its
+                                  specified expiry time, defined by the Expires or Max-Age cookie
+                                  attributes, while a session cookie is deleted when the current
+                                  session ends.
+
+                                  When set to "Permanent", AbsoluteTimeout indicates the
+                                  cookie's lifetime via the Expires or Max-Age cookie attributes
+                                  and is required.
+
+                                  When set to "Session", AbsoluteTimeout indicates the
+                                  absolute lifetime of the cookie tracked by the gateway and
+                                  is optional.
+
+                                  Defaults to "Session".
+
+                                  Support: Core for "Session" type
+
+                                  Support: Extended for "Permanent" type
+                                enum:
+                                  - Permanent
+                                  - Session
+                                type: string
+                            type: object
+                          idleTimeout:
+                            description: |-
+                              IdleTimeout defines the idle timeout of the persistent session.
+                              Once the session has been idle for more than the specified
+                              IdleTimeout duration, the session becomes invalid.
+
+                              Support: Extended
+                            pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                            type: string
+                          sessionName:
+                            description: |-
+                              SessionName defines the name of the persistent session token
+                              which may be reflected in the cookie or the header. Users
+                              should avoid reusing session names to prevent unintended
+                              consequences, such as rejection or unpredictable behavior.
+
+                              Support: Implementation-specific
+                            maxLength: 128
+                            type: string
+                          type:
+                            default: Cookie
+                            description: |-
+                              Type defines the type of session persistence such as through
+                              the use a header or cookie. Defaults to cookie based session
+                              persistence.
+
+                              Support: Core for "Cookie" type
+
+                              Support: Extended for "Header" type
+                            enum:
+                              - Cookie
+                              - Header
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                          - message: AbsoluteTimeout must be specified when cookie lifetimeType is Permanent
+                            rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
                       timeouts:
                         description: |-
                           Timeouts defines the timeouts that can be configured for an HTTP request.
@@ -5008,6 +7604,26 @@ spec:
                   x-kubernetes-validations:
                     - message: While 16 rules and 64 matches per rule are allowed, the total number of matches across all rules in a route must be less than 128
                       rule: '(self.size() > 0 ? self[0].matches.size() : 0) + (self.size() > 1 ? self[1].matches.size() : 0) + (self.size() > 2 ? self[2].matches.size() : 0) + (self.size() > 3 ? self[3].matches.size() : 0) + (self.size() > 4 ? self[4].matches.size() : 0) + (self.size() > 5 ? self[5].matches.size() : 0) + (self.size() > 6 ? self[6].matches.size() : 0) + (self.size() > 7 ? self[7].matches.size() : 0) + (self.size() > 8 ? self[8].matches.size() : 0) + (self.size() > 9 ? self[9].matches.size() : 0) + (self.size() > 10 ? self[10].matches.size() : 0) + (self.size() > 11 ? self[11].matches.size() : 0) + (self.size() > 12 ? self[12].matches.size() : 0) + (self.size() > 13 ? self[13].matches.size() : 0) + (self.size() > 14 ? self[14].matches.size() : 0) + (self.size() > 15 ? self[15].matches.size() : 0) <= 128'
+                    - message: Rule name must be unique within the route
+                      rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name) && l1.name == l2.name))
+                useDefaultGateways:
+                  description: |-
+                    UseDefaultGateways indicates the default Gateway scope to use for this
+                    Route. If unset (the default) or set to None, the Route will not be
+                    attached to any default Gateway; if set, it will be attached to any
+                    default Gateway supporting the named scope, subject to the usual rules
+                    about which Routes a Gateway is allowed to claim.
+
+                    Think carefully before using this functionality! The set of default
+                    Gateways supporting the requested scope can change over time without
+                    any notice to the Route author, and in many situations it will not be
+                    appropriate to request a default Gateway for a given Route -- for
+                    example, a Route with specific security requirements should almost
+                    certainly not use a default Gateway.
+                  enum:
+                    - All
+                    - None
+                  type: string
               type: object
             status:
               description: Status defines the current state of HTTPRoute.
@@ -5183,6 +7799,18 @@ spec:
                               Gateway has the AllowedRoutes field, and ReferenceGrant provides a
                               generic way to enable any other kind of cross-namespace reference.
 
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
                               Support: Core
                             maxLength: 63
                             minLength: 1
@@ -5200,6 +7828,12 @@ spec:
                               as opposed to a listener(s) whose port(s) may be changed. When both Port
                               and SectionName are specified, the name and port of the selected listener
                               must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
 
                               Implementations MAY choose to support other parent resources.
                               Implementations supporting other types of parent resources MUST clearly

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-referencegrants-gateway-networking-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-referencegrants-gateway-networking-k8s-io.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
     gateway.networking.k8s.io/bundle-version: v1.4.1
-    gateway.networking.k8s.io/channel: standard
+    gateway.networking.k8s.io/channel: experimental
   name: referencegrants.gateway.networking.k8s.io
 spec:
   group: gateway.networking.k8s.io

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-tcproutes-gateway-networking-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-tcproutes-gateway-networking-k8s-io.yaml
@@ -1,0 +1,732 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.4.1
+    gateway.networking.k8s.io/channel: experimental
+  name: tcproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+      - gateway-api
+    kind: TCPRoute
+    listKind: TCPRouteList
+    plural: tcproutes
+    singular: tcproute
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: |-
+            TCPRoute provides a way to route TCP requests. When combined with a Gateway
+            listener, it can be used to forward connections on the port specified by the
+            listener to a set of backends specified by the TCPRoute.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of TCPRoute.
+              properties:
+                parentRefs:
+                  description: |-
+                    ParentRefs references the resources (usually Gateways) that a Route wants
+                    to be attached to. Note that the referenced parent resource needs to
+                    allow this for the attachment to be complete. For Gateways, that means
+                    the Gateway needs to allow attachment from Routes of this kind and
+                    namespace. For Services, that means the Service must either be in the same
+                    namespace for a "producer" route, or the mesh implementation must support
+                    and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                    not applicable for governing ParentRefs to Services - it is not possible to
+                    create a "producer" route for a Service in a different namespace from the
+                    Route.
+
+                    There are two kinds of parent resources with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    ParentRefs must be _distinct_. This means either that:
+
+                    * They select different objects.  If this is the case, then parentRef
+                      entries are distinct. In terms of fields, this means that the
+                      multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                      be unique across all parentRef entries in the Route.
+                    * They do not select different objects, but for each optional field used,
+                      each ParentRef that selects the same object must set the same set of
+                      optional fields to different values. If one ParentRef sets a
+                      combination of optional fields, all must set the same combination.
+
+                    Some examples:
+
+                    * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                      same object must also set `sectionName`.
+                    * If one ParentRef sets `port`, all ParentRefs referencing the same
+                      object must also set `port`.
+                    * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                      referencing the same object must also set `sectionName` and `port`.
+
+                    It is possible to separately reference multiple distinct objects that may
+                    be collapsed by an implementation. For example, some implementations may
+                    choose to merge compatible Gateway Listeners together. If that is the
+                    case, the list of routes attached to those resources should also be
+                    merged.
+
+                    Note that for ParentRefs that cross namespace boundaries, there are specific
+                    rules. Cross-namespace references are only valid if they are explicitly
+                    allowed by something in the namespace they are referring to. For example,
+                    Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                    generic way to enable other kinds of cross-namespace reference.
+
+
+                    ParentRefs from a Route to a Service in the same namespace are "producer"
+                    routes, which apply default routing rules to inbound connections from
+                    any namespace to the Service.
+
+                    ParentRefs from a Route to a Service in a different namespace are
+                    "consumer" routes, and these routing rules are only applied to outbound
+                    connections originating from the same namespace as the Route, for which
+                    the intended destination of the connections are a Service targeted as a
+                    ParentRef of the Route.
+                  items:
+                    description: |-
+                      ParentReference identifies an API object (usually a Gateway) that can be considered
+                      a parent of this resource (usually a route). There are two kinds of parent resources
+                      with "Core" support:
+
+                      * Gateway (Gateway conformance profile)
+                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+                      This API may be extended in the future to support additional kinds of parent
+                      resources.
+
+                      The API object must be valid in the cluster; the Group and Kind must
+                      be registered in the cluster for this reference to be valid.
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: |-
+                          Group is the group of the referent.
+                          When unspecified, "gateway.networking.k8s.io" is inferred.
+                          To set the core API group (such as for a "Service" kind referent),
+                          Group must be explicitly set to "" (empty string).
+
+                          Support: Core
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Gateway
+                        description: |-
+                          Kind is kind of the referent.
+
+                          There are two kinds of parent resources with "Core" support:
+
+                          * Gateway (Gateway conformance profile)
+                          * Service (Mesh conformance profile, ClusterIP Services only)
+
+                          Support for other resources is Implementation-Specific.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referent.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referent. When unspecified, this refers
+                          to the local namespace of the Route.
+
+                          Note that there are specific rules for ParentRefs which cross namespace
+                          boundaries. Cross-namespace references are only valid if they are explicitly
+                          allowed by something in the namespace they are referring to. For example:
+                          Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                          generic way to enable any other kind of cross-namespace reference.
+
+
+                          ParentRefs from a Route to a Service in the same namespace are "producer"
+                          routes, which apply default routing rules to inbound connections from
+                          any namespace to the Service.
+
+                          ParentRefs from a Route to a Service in a different namespace are
+                          "consumer" routes, and these routing rules are only applied to outbound
+                          connections originating from the same namespace as the Route, for which
+                          the intended destination of the connections are a Service targeted as a
+                          ParentRef of the Route.
+
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      port:
+                        description: |-
+                          Port is the network port this Route targets. It can be interpreted
+                          differently based on the type of parent resource.
+
+                          When the parent resource is a Gateway, this targets all listeners
+                          listening on the specified port that also support this kind of Route(and
+                          select this Route). It's not recommended to set `Port` unless the
+                          networking behaviors specified in a Route must apply to a specific port
+                          as opposed to a listener(s) whose port(s) may be changed. When both Port
+                          and SectionName are specified, the name and port of the selected listener
+                          must match both specified values.
+
+
+                          When the parent resource is a Service, this targets a specific port in the
+                          Service spec. When both Port (experimental) and SectionName are specified,
+                          the name and port of the selected port must match both specified values.
+
+
+                          Implementations MAY choose to support other parent resources.
+                          Implementations supporting other types of parent resources MUST clearly
+                          document how/if Port is interpreted.
+
+                          For the purpose of status, an attachment is considered successful as
+                          long as the parent resource accepts it partially. For example, Gateway
+                          listeners can restrict which Routes can attach to them by Route kind,
+                          namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                          from the referencing Route, the Route MUST be considered successfully
+                          attached. If no Gateway listeners accept attachment from this Route,
+                          the Route MUST be considered detached from the Gateway.
+
+                          Support: Extended
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      sectionName:
+                        description: |-
+                          SectionName is the name of a section within the target resource. In the
+                          following resources, SectionName is interpreted as the following:
+
+                          * Gateway: Listener name. When both Port (experimental) and SectionName
+                          are specified, the name and port of the selected listener must match
+                          both specified values.
+                          * Service: Port name. When both Port (experimental) and SectionName
+                          are specified, the name and port of the selected listener must match
+                          both specified values.
+
+                          Implementations MAY choose to support attaching Routes to other resources.
+                          If that is the case, they MUST clearly document how SectionName is
+                          interpreted.
+
+                          When unspecified (empty string), this will reference the entire resource.
+                          For the purpose of status, an attachment is considered successful if at
+                          least one section in the parent resource accepts it. For example, Gateway
+                          listeners can restrict which Routes can attach to them by Route kind,
+                          namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                          the referencing Route, the Route MUST be considered successfully
+                          attached. If no Gateway listeners accept attachment from this Route, the
+                          Route MUST be considered detached from the Gateway.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                    - message: sectionName or port must be specified when parentRefs includes 2 or more references to the same parent
+                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port) || p2.port == 0)): true))'
+                    - message: sectionName or port must be unique when parentRefs includes 2 or more references to the same parent
+                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port) || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port == p2.port))))
+                rules:
+                  description: Rules are a list of TCP matchers and actions.
+                  items:
+                    description: TCPRouteRule is the configuration for a given rule.
+                    properties:
+                      backendRefs:
+                        description: |-
+                          BackendRefs defines the backend(s) where matching requests should be
+                          sent. If unspecified or invalid (refers to a nonexistent resource or a
+                          Service with no endpoints), the underlying implementation MUST actively
+                          reject connection attempts to this backend. Connection rejections must
+                          respect weight; if an invalid backend is requested to have 80% of
+                          connections, then 80% of connections must be rejected instead.
+
+                          Support: Core for Kubernetes Service
+
+                          Support: Extended for Kubernetes ServiceImport
+
+                          Support: Implementation-specific for any other resource
+
+                          Support for weight: Extended
+                        items:
+                          description: |-
+                            BackendRef defines how a Route should forward a request to a Kubernetes
+                            resource.
+
+                            Note that when a namespace different than the local namespace is specified, a
+                            ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                            honor the appProtocol field if it is set for the target Service Port.
+
+                            Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                            Standard Application Protocols defined in KEP-3726.
+
+                            If a Service appProtocol isn't specified, an implementation MAY infer the
+                            backend protocol through its own means. Implementations MAY infer the
+                            protocol from the Route type referring to the backend Service.
+
+                            If a Route is not able to send traffic to the backend using the specified
+                            protocol then the backend is considered invalid. Implementations MUST set the
+                            "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                            Note that when the BackendTLSPolicy object is enabled by the implementation,
+                            there are some extra rules about validity to consider here. See the fields
+                            where this struct is used for more information about the exact behavior.
+                          properties:
+                            group:
+                              default: ""
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Service
+                              description: |-
+                                Kind is the Kubernetes resource kind of the referent. For example
+                                "Service".
+
+                                Defaults to "Service" when not specified.
+
+                                ExternalName services can refer to CNAME DNS records that may live
+                                outside of the cluster and as such are difficult to reason about in
+                                terms of conformance. They also may not be safe to forward to (see
+                                CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                support ExternalName Services.
+
+                                Support: Core (Services with a type other than ExternalName)
+
+                                Support: Implementation-specific (Services with type ExternalName)
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the backend. When unspecified, the local
+                                namespace is inferred.
+
+                                Note that when a namespace different than the local namespace is specified,
+                                a ReferenceGrant object is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the ReferenceGrant
+                                documentation for details.
+
+                                Support: Core
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            port:
+                              description: |-
+                                Port specifies the destination port number to use for this resource.
+                                Port is required when the referent is a Kubernetes Service. In this
+                                case, the port number is the service port number, not the target port.
+                                For other resources, destination port might be derived from the referent
+                                resource or this field.
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            weight:
+                              default: 1
+                              description: |-
+                                Weight specifies the proportion of requests forwarded to the referenced
+                                backend. This is computed as weight/(sum of all weights in this
+                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                the exact proportion defined here depending on the precision an
+                                implementation supports. Weight is not a percentage and the sum of
+                                weights does not need to equal 100.
+
+                                If only one backend is specified and it has a weight greater than 0, 100%
+                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                traffic should be forwarded for this entry. If unspecified, weight
+                                defaults to 1.
+
+                                Support for this field varies based on the context where used.
+                              format: int32
+                              maximum: 1000000
+                              minimum: 0
+                              type: integer
+                          required:
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Must have port for Service reference
+                              rule: '(size(self.group) == 0 && self.kind == ''Service'') ? has(self.port) : true'
+                        maxItems: 16
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      name:
+                        description: |-
+                          Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                          Support: Extended
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - backendRefs
+                    type: object
+                  maxItems: 16
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                    - message: Rule name must be unique within the route
+                      rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name) && l1.name == l2.name))
+                useDefaultGateways:
+                  description: |-
+                    UseDefaultGateways indicates the default Gateway scope to use for this
+                    Route. If unset (the default) or set to None, the Route will not be
+                    attached to any default Gateway; if set, it will be attached to any
+                    default Gateway supporting the named scope, subject to the usual rules
+                    about which Routes a Gateway is allowed to claim.
+
+                    Think carefully before using this functionality! The set of default
+                    Gateways supporting the requested scope can change over time without
+                    any notice to the Route author, and in many situations it will not be
+                    appropriate to request a default Gateway for a given Route -- for
+                    example, a Route with specific security requirements should almost
+                    certainly not use a default Gateway.
+                  enum:
+                    - All
+                    - None
+                  type: string
+              required:
+                - rules
+              type: object
+            status:
+              description: Status defines the current state of TCPRoute.
+              properties:
+                parents:
+                  description: |-
+                    Parents is a list of parent resources (usually Gateways) that are
+                    associated with the route, and the status of the route with respect to
+                    each parent. When this route attaches to a parent, the controller that
+                    manages the parent must add an entry to this list when the controller
+                    first sees the route and should update the entry as appropriate when the
+                    route or gateway is modified.
+
+                    Note that parent references that cannot be resolved by an implementation
+                    of this API will not be added to this list. Implementations of this API
+                    can only populate Route status for the Gateways/parent resources they are
+                    responsible for.
+
+                    A maximum of 32 Gateways will be represented in this list. An empty list
+                    means the route has not been attached to any Gateway.
+                  items:
+                    description: |-
+                      RouteParentStatus describes the status of a route with respect to an
+                      associated Parent.
+                    properties:
+                      conditions:
+                        description: |-
+                          Conditions describes the status of the route with respect to the Gateway.
+                          Note that the route's availability is also subject to the Gateway's own
+                          status conditions and listener status.
+
+                          If the Route's ParentRef specifies an existing Gateway that supports
+                          Routes of this kind AND that Gateway's controller has sufficient access,
+                          then that Gateway's controller MUST set the "Accepted" condition on the
+                          Route, to indicate whether the route has been accepted or rejected by the
+                          Gateway, and why.
+
+                          A Route MUST be considered "Accepted" if at least one of the Route's
+                          rules is implemented by the Gateway.
+
+                          There are a number of cases where the "Accepted" condition may not be set
+                          due to lack of controller visibility, that includes when:
+
+                          * The Route refers to a nonexistent parent.
+                          * The Route is of a type that the controller does not support.
+                          * The Route is in a namespace the controller does not have access to.
+                        items:
+                          description: Condition contains details for one aspect of the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      controllerName:
+                        description: |-
+                          ControllerName is a domain/path string that indicates the name of the
+                          controller that wrote this status. This corresponds with the
+                          controllerName field on GatewayClass.
+
+                          Example: "example.net/gateway-controller".
+
+                          The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                          valid Kubernetes names
+                          (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                          Controllers MUST populate this field when writing status. Controllers should ensure that
+                          entries to status populated with their ControllerName are cleaned up when they are no
+                          longer necessary.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                      parentRef:
+                        description: |-
+                          ParentRef corresponds with a ParentRef in the spec that this
+                          RouteParentStatus struct describes the status of.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: |-
+                              Group is the group of the referent.
+                              When unspecified, "gateway.networking.k8s.io" is inferred.
+                              To set the core API group (such as for a "Service" kind referent),
+                              Group must be explicitly set to "" (empty string).
+
+                              Support: Core
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: |-
+                              Kind is kind of the referent.
+
+                              There are two kinds of parent resources with "Core" support:
+
+                              * Gateway (Gateway conformance profile)
+                              * Service (Mesh conformance profile, ClusterIP Services only)
+
+                              Support for other resources is Implementation-Specific.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the referent.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referent. When unspecified, this refers
+                              to the local namespace of the Route.
+
+                              Note that there are specific rules for ParentRefs which cross namespace
+                              boundaries. Cross-namespace references are only valid if they are explicitly
+                              allowed by something in the namespace they are referring to. For example:
+                              Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                              generic way to enable any other kind of cross-namespace reference.
+
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port is the network port this Route targets. It can be interpreted
+                              differently based on the type of parent resource.
+
+                              When the parent resource is a Gateway, this targets all listeners
+                              listening on the specified port that also support this kind of Route(and
+                              select this Route). It's not recommended to set `Port` unless the
+                              networking behaviors specified in a Route must apply to a specific port
+                              as opposed to a listener(s) whose port(s) may be changed. When both Port
+                              and SectionName are specified, the name and port of the selected listener
+                              must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
+
+                              Implementations MAY choose to support other parent resources.
+                              Implementations supporting other types of parent resources MUST clearly
+                              document how/if Port is interpreted.
+
+                              For the purpose of status, an attachment is considered successful as
+                              long as the parent resource accepts it partially. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                              from the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route,
+                              the Route MUST be considered detached from the Gateway.
+
+                              Support: Extended
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          sectionName:
+                            description: |-
+                              SectionName is the name of a section within the target resource. In the
+                              following resources, SectionName is interpreted as the following:
+
+                              * Gateway: Listener name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+                              * Service: Port name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+
+                              Implementations MAY choose to support attaching Routes to other resources.
+                              If that is the case, they MUST clearly document how SectionName is
+                              interpreted.
+
+                              When unspecified (empty string), this will reference the entire resource.
+                              For the purpose of status, an attachment is considered successful if at
+                              least one section in the parent resource accepts it. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                              the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route, the
+                              Route MUST be considered detached from the Gateway.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                    required:
+                      - conditions
+                      - controllerName
+                      - parentRef
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+              required:
+                - parents
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-tlsroutes-gateway-networking-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-tlsroutes-gateway-networking-k8s-io.yaml
@@ -1,0 +1,1571 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.4.1
+    gateway.networking.k8s.io/channel: experimental
+  name: tlsroutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+      - gateway-api
+    kind: TLSRoute
+    listKind: TLSRouteList
+    plural: tlsroutes
+    singular: tlsroute
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: |-
+            The TLSRoute resource is similar to TCPRoute, but can be configured
+            to match against TLS-specific metadata. This allows more flexibility
+            in matching streams for a given TLS listener.
+
+            If you need to forward traffic to a single target for a TLS listener, you
+            could choose to use a TCPRoute with a TLS listener.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of TLSRoute.
+              properties:
+                hostnames:
+                  description: |-
+                    Hostnames defines a set of SNI names that should match against the
+                    SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                    1. IPs are not allowed in SNI names per RFC 6066.
+                    2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                       label must appear by itself as the first label.
+
+                    If a hostname is specified by both the Listener and TLSRoute, there
+                    must be at least one intersecting hostname for the TLSRoute to be
+                    attached to the Listener. For example:
+
+                    * A Listener with `test.example.com` as the hostname matches TLSRoutes
+                      that have either not specified any hostnames, or have specified at
+                      least one of `test.example.com` or `*.example.com`.
+                    * A Listener with `*.example.com` as the hostname matches TLSRoutes
+                      that have either not specified any hostnames or have specified at least
+                      one hostname that matches the Listener hostname. For example,
+                      `test.example.com` and `*.example.com` would both match. On the other
+                      hand, `example.com` and `test.example.net` would not match.
+
+                    If both the Listener and TLSRoute have specified hostnames, any
+                    TLSRoute hostnames that do not match the Listener hostname MUST be
+                    ignored. For example, if a Listener specified `*.example.com`, and the
+                    TLSRoute specified `test.example.com` and `test.example.net`,
+                    `test.example.net` must not be considered for a match.
+
+                    If both the Listener and TLSRoute have specified hostnames, and none
+                    match with the criteria above, then the TLSRoute is not accepted. The
+                    implementation must raise an 'Accepted' Condition with a status of
+                    `False` in the corresponding RouteParentStatus.
+
+                    Support: Core
+                  items:
+                    description: |-
+                      Hostname is the fully qualified domain name of a network host. This matches
+                      the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                       1. IPs are not allowed.
+                       2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                          label must appear by itself as the first label.
+
+                      Hostname can be "precise" which is a domain name without the terminating
+                      dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                      domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                      Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                      alphanumeric characters or '-', and must start and end with an alphanumeric
+                      character. No other punctuation is allowed.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  maxItems: 16
+                  type: array
+                  x-kubernetes-list-type: atomic
+                parentRefs:
+                  description: |-
+                    ParentRefs references the resources (usually Gateways) that a Route wants
+                    to be attached to. Note that the referenced parent resource needs to
+                    allow this for the attachment to be complete. For Gateways, that means
+                    the Gateway needs to allow attachment from Routes of this kind and
+                    namespace. For Services, that means the Service must either be in the same
+                    namespace for a "producer" route, or the mesh implementation must support
+                    and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                    not applicable for governing ParentRefs to Services - it is not possible to
+                    create a "producer" route for a Service in a different namespace from the
+                    Route.
+
+                    There are two kinds of parent resources with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    ParentRefs must be _distinct_. This means either that:
+
+                    * They select different objects.  If this is the case, then parentRef
+                      entries are distinct. In terms of fields, this means that the
+                      multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                      be unique across all parentRef entries in the Route.
+                    * They do not select different objects, but for each optional field used,
+                      each ParentRef that selects the same object must set the same set of
+                      optional fields to different values. If one ParentRef sets a
+                      combination of optional fields, all must set the same combination.
+
+                    Some examples:
+
+                    * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                      same object must also set `sectionName`.
+                    * If one ParentRef sets `port`, all ParentRefs referencing the same
+                      object must also set `port`.
+                    * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                      referencing the same object must also set `sectionName` and `port`.
+
+                    It is possible to separately reference multiple distinct objects that may
+                    be collapsed by an implementation. For example, some implementations may
+                    choose to merge compatible Gateway Listeners together. If that is the
+                    case, the list of routes attached to those resources should also be
+                    merged.
+
+                    Note that for ParentRefs that cross namespace boundaries, there are specific
+                    rules. Cross-namespace references are only valid if they are explicitly
+                    allowed by something in the namespace they are referring to. For example,
+                    Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                    generic way to enable other kinds of cross-namespace reference.
+
+
+                    ParentRefs from a Route to a Service in the same namespace are "producer"
+                    routes, which apply default routing rules to inbound connections from
+                    any namespace to the Service.
+
+                    ParentRefs from a Route to a Service in a different namespace are
+                    "consumer" routes, and these routing rules are only applied to outbound
+                    connections originating from the same namespace as the Route, for which
+                    the intended destination of the connections are a Service targeted as a
+                    ParentRef of the Route.
+                  items:
+                    description: |-
+                      ParentReference identifies an API object (usually a Gateway) that can be considered
+                      a parent of this resource (usually a route). There are two kinds of parent resources
+                      with "Core" support:
+
+                      * Gateway (Gateway conformance profile)
+                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+                      This API may be extended in the future to support additional kinds of parent
+                      resources.
+
+                      The API object must be valid in the cluster; the Group and Kind must
+                      be registered in the cluster for this reference to be valid.
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: |-
+                          Group is the group of the referent.
+                          When unspecified, "gateway.networking.k8s.io" is inferred.
+                          To set the core API group (such as for a "Service" kind referent),
+                          Group must be explicitly set to "" (empty string).
+
+                          Support: Core
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Gateway
+                        description: |-
+                          Kind is kind of the referent.
+
+                          There are two kinds of parent resources with "Core" support:
+
+                          * Gateway (Gateway conformance profile)
+                          * Service (Mesh conformance profile, ClusterIP Services only)
+
+                          Support for other resources is Implementation-Specific.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referent.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referent. When unspecified, this refers
+                          to the local namespace of the Route.
+
+                          Note that there are specific rules for ParentRefs which cross namespace
+                          boundaries. Cross-namespace references are only valid if they are explicitly
+                          allowed by something in the namespace they are referring to. For example:
+                          Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                          generic way to enable any other kind of cross-namespace reference.
+
+
+                          ParentRefs from a Route to a Service in the same namespace are "producer"
+                          routes, which apply default routing rules to inbound connections from
+                          any namespace to the Service.
+
+                          ParentRefs from a Route to a Service in a different namespace are
+                          "consumer" routes, and these routing rules are only applied to outbound
+                          connections originating from the same namespace as the Route, for which
+                          the intended destination of the connections are a Service targeted as a
+                          ParentRef of the Route.
+
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      port:
+                        description: |-
+                          Port is the network port this Route targets. It can be interpreted
+                          differently based on the type of parent resource.
+
+                          When the parent resource is a Gateway, this targets all listeners
+                          listening on the specified port that also support this kind of Route(and
+                          select this Route). It's not recommended to set `Port` unless the
+                          networking behaviors specified in a Route must apply to a specific port
+                          as opposed to a listener(s) whose port(s) may be changed. When both Port
+                          and SectionName are specified, the name and port of the selected listener
+                          must match both specified values.
+
+
+                          When the parent resource is a Service, this targets a specific port in the
+                          Service spec. When both Port (experimental) and SectionName are specified,
+                          the name and port of the selected port must match both specified values.
+
+
+                          Implementations MAY choose to support other parent resources.
+                          Implementations supporting other types of parent resources MUST clearly
+                          document how/if Port is interpreted.
+
+                          For the purpose of status, an attachment is considered successful as
+                          long as the parent resource accepts it partially. For example, Gateway
+                          listeners can restrict which Routes can attach to them by Route kind,
+                          namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                          from the referencing Route, the Route MUST be considered successfully
+                          attached. If no Gateway listeners accept attachment from this Route,
+                          the Route MUST be considered detached from the Gateway.
+
+                          Support: Extended
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      sectionName:
+                        description: |-
+                          SectionName is the name of a section within the target resource. In the
+                          following resources, SectionName is interpreted as the following:
+
+                          * Gateway: Listener name. When both Port (experimental) and SectionName
+                          are specified, the name and port of the selected listener must match
+                          both specified values.
+                          * Service: Port name. When both Port (experimental) and SectionName
+                          are specified, the name and port of the selected listener must match
+                          both specified values.
+
+                          Implementations MAY choose to support attaching Routes to other resources.
+                          If that is the case, they MUST clearly document how SectionName is
+                          interpreted.
+
+                          When unspecified (empty string), this will reference the entire resource.
+                          For the purpose of status, an attachment is considered successful if at
+                          least one section in the parent resource accepts it. For example, Gateway
+                          listeners can restrict which Routes can attach to them by Route kind,
+                          namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                          the referencing Route, the Route MUST be considered successfully
+                          attached. If no Gateway listeners accept attachment from this Route, the
+                          Route MUST be considered detached from the Gateway.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                    - message: sectionName or port must be specified when parentRefs includes 2 or more references to the same parent
+                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port) || p2.port == 0)): true))'
+                    - message: sectionName or port must be unique when parentRefs includes 2 or more references to the same parent
+                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port) || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port == p2.port))))
+                rules:
+                  description: Rules are a list of TLS matchers and actions.
+                  items:
+                    description: TLSRouteRule is the configuration for a given rule.
+                    properties:
+                      backendRefs:
+                        description: |-
+                          BackendRefs defines the backend(s) where matching requests should be
+                          sent. If unspecified or invalid (refers to a nonexistent resource or
+                          a Service with no endpoints), the rule performs no forwarding; if no
+                          filters are specified that would result in a response being sent, the
+                          underlying implementation must actively reject request attempts to this
+                          backend, by rejecting the connection or returning a 500 status code.
+                          Request rejections must respect weight; if an invalid backend is
+                          requested to have 80% of requests, then 80% of requests must be rejected
+                          instead.
+
+                          Support: Core for Kubernetes Service
+
+                          Support: Extended for Kubernetes ServiceImport
+
+                          Support: Implementation-specific for any other resource
+
+                          Support for weight: Extended
+                        items:
+                          description: |-
+                            BackendRef defines how a Route should forward a request to a Kubernetes
+                            resource.
+
+                            Note that when a namespace different than the local namespace is specified, a
+                            ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                            honor the appProtocol field if it is set for the target Service Port.
+
+                            Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                            Standard Application Protocols defined in KEP-3726.
+
+                            If a Service appProtocol isn't specified, an implementation MAY infer the
+                            backend protocol through its own means. Implementations MAY infer the
+                            protocol from the Route type referring to the backend Service.
+
+                            If a Route is not able to send traffic to the backend using the specified
+                            protocol then the backend is considered invalid. Implementations MUST set the
+                            "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                            Note that when the BackendTLSPolicy object is enabled by the implementation,
+                            there are some extra rules about validity to consider here. See the fields
+                            where this struct is used for more information about the exact behavior.
+                          properties:
+                            group:
+                              default: ""
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Service
+                              description: |-
+                                Kind is the Kubernetes resource kind of the referent. For example
+                                "Service".
+
+                                Defaults to "Service" when not specified.
+
+                                ExternalName services can refer to CNAME DNS records that may live
+                                outside of the cluster and as such are difficult to reason about in
+                                terms of conformance. They also may not be safe to forward to (see
+                                CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                support ExternalName Services.
+
+                                Support: Core (Services with a type other than ExternalName)
+
+                                Support: Implementation-specific (Services with type ExternalName)
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the backend. When unspecified, the local
+                                namespace is inferred.
+
+                                Note that when a namespace different than the local namespace is specified,
+                                a ReferenceGrant object is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the ReferenceGrant
+                                documentation for details.
+
+                                Support: Core
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            port:
+                              description: |-
+                                Port specifies the destination port number to use for this resource.
+                                Port is required when the referent is a Kubernetes Service. In this
+                                case, the port number is the service port number, not the target port.
+                                For other resources, destination port might be derived from the referent
+                                resource or this field.
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            weight:
+                              default: 1
+                              description: |-
+                                Weight specifies the proportion of requests forwarded to the referenced
+                                backend. This is computed as weight/(sum of all weights in this
+                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                the exact proportion defined here depending on the precision an
+                                implementation supports. Weight is not a percentage and the sum of
+                                weights does not need to equal 100.
+
+                                If only one backend is specified and it has a weight greater than 0, 100%
+                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                traffic should be forwarded for this entry. If unspecified, weight
+                                defaults to 1.
+
+                                Support for this field varies based on the context where used.
+                              format: int32
+                              maximum: 1000000
+                              minimum: 0
+                              type: integer
+                          required:
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Must have port for Service reference
+                              rule: '(size(self.group) == 0 && self.kind == ''Service'') ? has(self.port) : true'
+                        maxItems: 16
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      name:
+                        description: |-
+                          Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                          Support: Extended
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - backendRefs
+                    type: object
+                  maxItems: 16
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                    - message: Rule name must be unique within the route
+                      rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name) && l1.name == l2.name))
+                useDefaultGateways:
+                  description: |-
+                    UseDefaultGateways indicates the default Gateway scope to use for this
+                    Route. If unset (the default) or set to None, the Route will not be
+                    attached to any default Gateway; if set, it will be attached to any
+                    default Gateway supporting the named scope, subject to the usual rules
+                    about which Routes a Gateway is allowed to claim.
+
+                    Think carefully before using this functionality! The set of default
+                    Gateways supporting the requested scope can change over time without
+                    any notice to the Route author, and in many situations it will not be
+                    appropriate to request a default Gateway for a given Route -- for
+                    example, a Route with specific security requirements should almost
+                    certainly not use a default Gateway.
+                  enum:
+                    - All
+                    - None
+                  type: string
+              required:
+                - rules
+              type: object
+            status:
+              description: Status defines the current state of TLSRoute.
+              properties:
+                parents:
+                  description: |-
+                    Parents is a list of parent resources (usually Gateways) that are
+                    associated with the route, and the status of the route with respect to
+                    each parent. When this route attaches to a parent, the controller that
+                    manages the parent must add an entry to this list when the controller
+                    first sees the route and should update the entry as appropriate when the
+                    route or gateway is modified.
+
+                    Note that parent references that cannot be resolved by an implementation
+                    of this API will not be added to this list. Implementations of this API
+                    can only populate Route status for the Gateways/parent resources they are
+                    responsible for.
+
+                    A maximum of 32 Gateways will be represented in this list. An empty list
+                    means the route has not been attached to any Gateway.
+                  items:
+                    description: |-
+                      RouteParentStatus describes the status of a route with respect to an
+                      associated Parent.
+                    properties:
+                      conditions:
+                        description: |-
+                          Conditions describes the status of the route with respect to the Gateway.
+                          Note that the route's availability is also subject to the Gateway's own
+                          status conditions and listener status.
+
+                          If the Route's ParentRef specifies an existing Gateway that supports
+                          Routes of this kind AND that Gateway's controller has sufficient access,
+                          then that Gateway's controller MUST set the "Accepted" condition on the
+                          Route, to indicate whether the route has been accepted or rejected by the
+                          Gateway, and why.
+
+                          A Route MUST be considered "Accepted" if at least one of the Route's
+                          rules is implemented by the Gateway.
+
+                          There are a number of cases where the "Accepted" condition may not be set
+                          due to lack of controller visibility, that includes when:
+
+                          * The Route refers to a nonexistent parent.
+                          * The Route is of a type that the controller does not support.
+                          * The Route is in a namespace the controller does not have access to.
+                        items:
+                          description: Condition contains details for one aspect of the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      controllerName:
+                        description: |-
+                          ControllerName is a domain/path string that indicates the name of the
+                          controller that wrote this status. This corresponds with the
+                          controllerName field on GatewayClass.
+
+                          Example: "example.net/gateway-controller".
+
+                          The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                          valid Kubernetes names
+                          (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                          Controllers MUST populate this field when writing status. Controllers should ensure that
+                          entries to status populated with their ControllerName are cleaned up when they are no
+                          longer necessary.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                      parentRef:
+                        description: |-
+                          ParentRef corresponds with a ParentRef in the spec that this
+                          RouteParentStatus struct describes the status of.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: |-
+                              Group is the group of the referent.
+                              When unspecified, "gateway.networking.k8s.io" is inferred.
+                              To set the core API group (such as for a "Service" kind referent),
+                              Group must be explicitly set to "" (empty string).
+
+                              Support: Core
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: |-
+                              Kind is kind of the referent.
+
+                              There are two kinds of parent resources with "Core" support:
+
+                              * Gateway (Gateway conformance profile)
+                              * Service (Mesh conformance profile, ClusterIP Services only)
+
+                              Support for other resources is Implementation-Specific.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the referent.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referent. When unspecified, this refers
+                              to the local namespace of the Route.
+
+                              Note that there are specific rules for ParentRefs which cross namespace
+                              boundaries. Cross-namespace references are only valid if they are explicitly
+                              allowed by something in the namespace they are referring to. For example:
+                              Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                              generic way to enable any other kind of cross-namespace reference.
+
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port is the network port this Route targets. It can be interpreted
+                              differently based on the type of parent resource.
+
+                              When the parent resource is a Gateway, this targets all listeners
+                              listening on the specified port that also support this kind of Route(and
+                              select this Route). It's not recommended to set `Port` unless the
+                              networking behaviors specified in a Route must apply to a specific port
+                              as opposed to a listener(s) whose port(s) may be changed. When both Port
+                              and SectionName are specified, the name and port of the selected listener
+                              must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
+
+                              Implementations MAY choose to support other parent resources.
+                              Implementations supporting other types of parent resources MUST clearly
+                              document how/if Port is interpreted.
+
+                              For the purpose of status, an attachment is considered successful as
+                              long as the parent resource accepts it partially. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                              from the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route,
+                              the Route MUST be considered detached from the Gateway.
+
+                              Support: Extended
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          sectionName:
+                            description: |-
+                              SectionName is the name of a section within the target resource. In the
+                              following resources, SectionName is interpreted as the following:
+
+                              * Gateway: Listener name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+                              * Service: Port name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+
+                              Implementations MAY choose to support attaching Routes to other resources.
+                              If that is the case, they MUST clearly document how SectionName is
+                              interpreted.
+
+                              When unspecified (empty string), this will reference the entire resource.
+                              For the purpose of status, an attachment is considered successful if at
+                              least one section in the parent resource accepts it. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                              the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route, the
+                              Route MUST be considered detached from the Gateway.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                    required:
+                      - conditions
+                      - controllerName
+                      - parentRef
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+              required:
+                - parents
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha3
+      schema:
+        openAPIV3Schema:
+          description: |-
+            The TLSRoute resource is similar to TCPRoute, but can be configured
+            to match against TLS-specific metadata. This allows more flexibility
+            in matching streams for a given TLS listener.
+
+            If you need to forward traffic to a single target for a TLS listener, you
+            could choose to use a TCPRoute with a TLS listener.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of TLSRoute.
+              properties:
+                hostnames:
+                  description: |-
+                    Hostnames defines a set of SNI hostnames that should match against the
+                    SNI attribute of TLS ClientHello message in TLS handshake. This matches
+                    the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                    1. IPs are not allowed in SNI hostnames per RFC 6066.
+                    2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                       label must appear by itself as the first label.
+
+                    If a hostname is specified by both the Listener and TLSRoute, there
+                    must be at least one intersecting hostname for the TLSRoute to be
+                    attached to the Listener. For example:
+
+                    * A Listener with `test.example.com` as the hostname matches TLSRoutes
+                      that have specified at least one of `test.example.com` or
+                      `*.example.com`.
+                    * A Listener with `*.example.com` as the hostname matches TLSRoutes
+                      that have specified at least one hostname that matches the Listener
+                      hostname. For example, `test.example.com` and `*.example.com` would both
+                      match. On the other hand, `example.com` and `test.example.net` would not
+                      match.
+
+                    If both the Listener and TLSRoute have specified hostnames, any
+                    TLSRoute hostnames that do not match the Listener hostname MUST be
+                    ignored. For example, if a Listener specified `*.example.com`, and the
+                    TLSRoute specified `test.example.com` and `test.example.net`,
+                    `test.example.net` must not be considered for a match.
+
+                    If both the Listener and TLSRoute have specified hostnames, and none
+                    match with the criteria above, then the TLSRoute is not accepted. The
+                    implementation must raise an 'Accepted' Condition with a status of
+                    `False` in the corresponding RouteParentStatus.
+
+                    Support: Core
+                  items:
+                    description: |-
+                      Hostname is the fully qualified domain name of a network host. This matches
+                      the RFC 1123 definition of a hostname with 2 notable exceptions:
+
+                       1. IPs are not allowed.
+                       2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+                          label must appear by itself as the first label.
+
+                      Hostname can be "precise" which is a domain name without the terminating
+                      dot of a network host (e.g. "foo.example.com") or "wildcard", which is a
+                      domain name prefixed with a single wildcard label (e.g. `*.example.com`).
+
+                      Note that as per RFC1035 and RFC1123, a *label* must consist of lower case
+                      alphanumeric characters or '-', and must start and end with an alphanumeric
+                      character. No other punctuation is allowed.
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  maxItems: 16
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                parentRefs:
+                  description: |-
+                    ParentRefs references the resources (usually Gateways) that a Route wants
+                    to be attached to. Note that the referenced parent resource needs to
+                    allow this for the attachment to be complete. For Gateways, that means
+                    the Gateway needs to allow attachment from Routes of this kind and
+                    namespace. For Services, that means the Service must either be in the same
+                    namespace for a "producer" route, or the mesh implementation must support
+                    and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                    not applicable for governing ParentRefs to Services - it is not possible to
+                    create a "producer" route for a Service in a different namespace from the
+                    Route.
+
+                    There are two kinds of parent resources with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    ParentRefs must be _distinct_. This means either that:
+
+                    * They select different objects.  If this is the case, then parentRef
+                      entries are distinct. In terms of fields, this means that the
+                      multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                      be unique across all parentRef entries in the Route.
+                    * They do not select different objects, but for each optional field used,
+                      each ParentRef that selects the same object must set the same set of
+                      optional fields to different values. If one ParentRef sets a
+                      combination of optional fields, all must set the same combination.
+
+                    Some examples:
+
+                    * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                      same object must also set `sectionName`.
+                    * If one ParentRef sets `port`, all ParentRefs referencing the same
+                      object must also set `port`.
+                    * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                      referencing the same object must also set `sectionName` and `port`.
+
+                    It is possible to separately reference multiple distinct objects that may
+                    be collapsed by an implementation. For example, some implementations may
+                    choose to merge compatible Gateway Listeners together. If that is the
+                    case, the list of routes attached to those resources should also be
+                    merged.
+
+                    Note that for ParentRefs that cross namespace boundaries, there are specific
+                    rules. Cross-namespace references are only valid if they are explicitly
+                    allowed by something in the namespace they are referring to. For example,
+                    Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                    generic way to enable other kinds of cross-namespace reference.
+
+
+                    ParentRefs from a Route to a Service in the same namespace are "producer"
+                    routes, which apply default routing rules to inbound connections from
+                    any namespace to the Service.
+
+                    ParentRefs from a Route to a Service in a different namespace are
+                    "consumer" routes, and these routing rules are only applied to outbound
+                    connections originating from the same namespace as the Route, for which
+                    the intended destination of the connections are a Service targeted as a
+                    ParentRef of the Route.
+                  items:
+                    description: |-
+                      ParentReference identifies an API object (usually a Gateway) that can be considered
+                      a parent of this resource (usually a route). There are two kinds of parent resources
+                      with "Core" support:
+
+                      * Gateway (Gateway conformance profile)
+                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+                      This API may be extended in the future to support additional kinds of parent
+                      resources.
+
+                      The API object must be valid in the cluster; the Group and Kind must
+                      be registered in the cluster for this reference to be valid.
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: |-
+                          Group is the group of the referent.
+                          When unspecified, "gateway.networking.k8s.io" is inferred.
+                          To set the core API group (such as for a "Service" kind referent),
+                          Group must be explicitly set to "" (empty string).
+
+                          Support: Core
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Gateway
+                        description: |-
+                          Kind is kind of the referent.
+
+                          There are two kinds of parent resources with "Core" support:
+
+                          * Gateway (Gateway conformance profile)
+                          * Service (Mesh conformance profile, ClusterIP Services only)
+
+                          Support for other resources is Implementation-Specific.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referent.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referent. When unspecified, this refers
+                          to the local namespace of the Route.
+
+                          Note that there are specific rules for ParentRefs which cross namespace
+                          boundaries. Cross-namespace references are only valid if they are explicitly
+                          allowed by something in the namespace they are referring to. For example:
+                          Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                          generic way to enable any other kind of cross-namespace reference.
+
+
+                          ParentRefs from a Route to a Service in the same namespace are "producer"
+                          routes, which apply default routing rules to inbound connections from
+                          any namespace to the Service.
+
+                          ParentRefs from a Route to a Service in a different namespace are
+                          "consumer" routes, and these routing rules are only applied to outbound
+                          connections originating from the same namespace as the Route, for which
+                          the intended destination of the connections are a Service targeted as a
+                          ParentRef of the Route.
+
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      port:
+                        description: |-
+                          Port is the network port this Route targets. It can be interpreted
+                          differently based on the type of parent resource.
+
+                          When the parent resource is a Gateway, this targets all listeners
+                          listening on the specified port that also support this kind of Route(and
+                          select this Route). It's not recommended to set `Port` unless the
+                          networking behaviors specified in a Route must apply to a specific port
+                          as opposed to a listener(s) whose port(s) may be changed. When both Port
+                          and SectionName are specified, the name and port of the selected listener
+                          must match both specified values.
+
+
+                          When the parent resource is a Service, this targets a specific port in the
+                          Service spec. When both Port (experimental) and SectionName are specified,
+                          the name and port of the selected port must match both specified values.
+
+
+                          Implementations MAY choose to support other parent resources.
+                          Implementations supporting other types of parent resources MUST clearly
+                          document how/if Port is interpreted.
+
+                          For the purpose of status, an attachment is considered successful as
+                          long as the parent resource accepts it partially. For example, Gateway
+                          listeners can restrict which Routes can attach to them by Route kind,
+                          namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                          from the referencing Route, the Route MUST be considered successfully
+                          attached. If no Gateway listeners accept attachment from this Route,
+                          the Route MUST be considered detached from the Gateway.
+
+                          Support: Extended
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      sectionName:
+                        description: |-
+                          SectionName is the name of a section within the target resource. In the
+                          following resources, SectionName is interpreted as the following:
+
+                          * Gateway: Listener name. When both Port (experimental) and SectionName
+                          are specified, the name and port of the selected listener must match
+                          both specified values.
+                          * Service: Port name. When both Port (experimental) and SectionName
+                          are specified, the name and port of the selected listener must match
+                          both specified values.
+
+                          Implementations MAY choose to support attaching Routes to other resources.
+                          If that is the case, they MUST clearly document how SectionName is
+                          interpreted.
+
+                          When unspecified (empty string), this will reference the entire resource.
+                          For the purpose of status, an attachment is considered successful if at
+                          least one section in the parent resource accepts it. For example, Gateway
+                          listeners can restrict which Routes can attach to them by Route kind,
+                          namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                          the referencing Route, the Route MUST be considered successfully
+                          attached. If no Gateway listeners accept attachment from this Route, the
+                          Route MUST be considered detached from the Gateway.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                    - message: sectionName or port must be specified when parentRefs includes 2 or more references to the same parent
+                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port) || p2.port == 0)): true))'
+                    - message: sectionName or port must be unique when parentRefs includes 2 or more references to the same parent
+                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port) || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port == p2.port))))
+                rules:
+                  description: Rules are a list of actions.
+                  items:
+                    description: TLSRouteRule is the configuration for a given rule.
+                    properties:
+                      backendRefs:
+                        description: |-
+                          BackendRefs defines the backend(s) where matching requests should be
+                          sent. If unspecified or invalid (refers to a nonexistent resource or
+                          a Service with no endpoints), the rule performs no forwarding; if no
+                          filters are specified that would result in a response being sent, the
+                          underlying implementation must actively reject request attempts to this
+                          backend, by rejecting the connection or returning a 500 status code.
+                          Request rejections must respect weight; if an invalid backend is
+                          requested to have 80% of requests, then 80% of requests must be rejected
+                          instead.
+
+                          Support: Core for Kubernetes Service
+
+                          Support: Extended for Kubernetes ServiceImport
+
+                          Support: Implementation-specific for any other resource
+
+                          Support for weight: Extended
+                        items:
+                          description: |-
+                            BackendRef defines how a Route should forward a request to a Kubernetes
+                            resource.
+
+                            Note that when a namespace different than the local namespace is specified, a
+                            ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                            honor the appProtocol field if it is set for the target Service Port.
+
+                            Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                            Standard Application Protocols defined in KEP-3726.
+
+                            If a Service appProtocol isn't specified, an implementation MAY infer the
+                            backend protocol through its own means. Implementations MAY infer the
+                            protocol from the Route type referring to the backend Service.
+
+                            If a Route is not able to send traffic to the backend using the specified
+                            protocol then the backend is considered invalid. Implementations MUST set the
+                            "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                            Note that when the BackendTLSPolicy object is enabled by the implementation,
+                            there are some extra rules about validity to consider here. See the fields
+                            where this struct is used for more information about the exact behavior.
+                          properties:
+                            group:
+                              default: ""
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Service
+                              description: |-
+                                Kind is the Kubernetes resource kind of the referent. For example
+                                "Service".
+
+                                Defaults to "Service" when not specified.
+
+                                ExternalName services can refer to CNAME DNS records that may live
+                                outside of the cluster and as such are difficult to reason about in
+                                terms of conformance. They also may not be safe to forward to (see
+                                CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                support ExternalName Services.
+
+                                Support: Core (Services with a type other than ExternalName)
+
+                                Support: Implementation-specific (Services with type ExternalName)
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the backend. When unspecified, the local
+                                namespace is inferred.
+
+                                Note that when a namespace different than the local namespace is specified,
+                                a ReferenceGrant object is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the ReferenceGrant
+                                documentation for details.
+
+                                Support: Core
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            port:
+                              description: |-
+                                Port specifies the destination port number to use for this resource.
+                                Port is required when the referent is a Kubernetes Service. In this
+                                case, the port number is the service port number, not the target port.
+                                For other resources, destination port might be derived from the referent
+                                resource or this field.
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            weight:
+                              default: 1
+                              description: |-
+                                Weight specifies the proportion of requests forwarded to the referenced
+                                backend. This is computed as weight/(sum of all weights in this
+                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                the exact proportion defined here depending on the precision an
+                                implementation supports. Weight is not a percentage and the sum of
+                                weights does not need to equal 100.
+
+                                If only one backend is specified and it has a weight greater than 0, 100%
+                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                traffic should be forwarded for this entry. If unspecified, weight
+                                defaults to 1.
+
+                                Support for this field varies based on the context where used.
+                              format: int32
+                              maximum: 1000000
+                              minimum: 0
+                              type: integer
+                          required:
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Must have port for Service reference
+                              rule: '(size(self.group) == 0 && self.kind == ''Service'') ? has(self.port) : true'
+                        maxItems: 16
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      name:
+                        description: |-
+                          Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                          Support: Extended
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - backendRefs
+                    type: object
+                  maxItems: 1
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                    - message: Rule name must be unique within the route
+                      rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name) && l1.name == l2.name))
+                useDefaultGateways:
+                  description: |-
+                    UseDefaultGateways indicates the default Gateway scope to use for this
+                    Route. If unset (the default) or set to None, the Route will not be
+                    attached to any default Gateway; if set, it will be attached to any
+                    default Gateway supporting the named scope, subject to the usual rules
+                    about which Routes a Gateway is allowed to claim.
+
+                    Think carefully before using this functionality! The set of default
+                    Gateways supporting the requested scope can change over time without
+                    any notice to the Route author, and in many situations it will not be
+                    appropriate to request a default Gateway for a given Route -- for
+                    example, a Route with specific security requirements should almost
+                    certainly not use a default Gateway.
+                  enum:
+                    - All
+                    - None
+                  type: string
+              required:
+                - hostnames
+                - rules
+              type: object
+            status:
+              description: Status defines the current state of TLSRoute.
+              properties:
+                parents:
+                  description: |-
+                    Parents is a list of parent resources (usually Gateways) that are
+                    associated with the route, and the status of the route with respect to
+                    each parent. When this route attaches to a parent, the controller that
+                    manages the parent must add an entry to this list when the controller
+                    first sees the route and should update the entry as appropriate when the
+                    route or gateway is modified.
+
+                    Note that parent references that cannot be resolved by an implementation
+                    of this API will not be added to this list. Implementations of this API
+                    can only populate Route status for the Gateways/parent resources they are
+                    responsible for.
+
+                    A maximum of 32 Gateways will be represented in this list. An empty list
+                    means the route has not been attached to any Gateway.
+                  items:
+                    description: |-
+                      RouteParentStatus describes the status of a route with respect to an
+                      associated Parent.
+                    properties:
+                      conditions:
+                        description: |-
+                          Conditions describes the status of the route with respect to the Gateway.
+                          Note that the route's availability is also subject to the Gateway's own
+                          status conditions and listener status.
+
+                          If the Route's ParentRef specifies an existing Gateway that supports
+                          Routes of this kind AND that Gateway's controller has sufficient access,
+                          then that Gateway's controller MUST set the "Accepted" condition on the
+                          Route, to indicate whether the route has been accepted or rejected by the
+                          Gateway, and why.
+
+                          A Route MUST be considered "Accepted" if at least one of the Route's
+                          rules is implemented by the Gateway.
+
+                          There are a number of cases where the "Accepted" condition may not be set
+                          due to lack of controller visibility, that includes when:
+
+                          * The Route refers to a nonexistent parent.
+                          * The Route is of a type that the controller does not support.
+                          * The Route is in a namespace the controller does not have access to.
+                        items:
+                          description: Condition contains details for one aspect of the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      controllerName:
+                        description: |-
+                          ControllerName is a domain/path string that indicates the name of the
+                          controller that wrote this status. This corresponds with the
+                          controllerName field on GatewayClass.
+
+                          Example: "example.net/gateway-controller".
+
+                          The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                          valid Kubernetes names
+                          (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                          Controllers MUST populate this field when writing status. Controllers should ensure that
+                          entries to status populated with their ControllerName are cleaned up when they are no
+                          longer necessary.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                      parentRef:
+                        description: |-
+                          ParentRef corresponds with a ParentRef in the spec that this
+                          RouteParentStatus struct describes the status of.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: |-
+                              Group is the group of the referent.
+                              When unspecified, "gateway.networking.k8s.io" is inferred.
+                              To set the core API group (such as for a "Service" kind referent),
+                              Group must be explicitly set to "" (empty string).
+
+                              Support: Core
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: |-
+                              Kind is kind of the referent.
+
+                              There are two kinds of parent resources with "Core" support:
+
+                              * Gateway (Gateway conformance profile)
+                              * Service (Mesh conformance profile, ClusterIP Services only)
+
+                              Support for other resources is Implementation-Specific.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the referent.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referent. When unspecified, this refers
+                              to the local namespace of the Route.
+
+                              Note that there are specific rules for ParentRefs which cross namespace
+                              boundaries. Cross-namespace references are only valid if they are explicitly
+                              allowed by something in the namespace they are referring to. For example:
+                              Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                              generic way to enable any other kind of cross-namespace reference.
+
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port is the network port this Route targets. It can be interpreted
+                              differently based on the type of parent resource.
+
+                              When the parent resource is a Gateway, this targets all listeners
+                              listening on the specified port that also support this kind of Route(and
+                              select this Route). It's not recommended to set `Port` unless the
+                              networking behaviors specified in a Route must apply to a specific port
+                              as opposed to a listener(s) whose port(s) may be changed. When both Port
+                              and SectionName are specified, the name and port of the selected listener
+                              must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
+
+                              Implementations MAY choose to support other parent resources.
+                              Implementations supporting other types of parent resources MUST clearly
+                              document how/if Port is interpreted.
+
+                              For the purpose of status, an attachment is considered successful as
+                              long as the parent resource accepts it partially. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                              from the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route,
+                              the Route MUST be considered detached from the Gateway.
+
+                              Support: Extended
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          sectionName:
+                            description: |-
+                              SectionName is the name of a section within the target resource. In the
+                              following resources, SectionName is interpreted as the following:
+
+                              * Gateway: Listener name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+                              * Service: Port name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+
+                              Implementations MAY choose to support attaching Routes to other resources.
+                              If that is the case, they MUST clearly document how SectionName is
+                              interpreted.
+
+                              When unspecified (empty string), this will reference the entire resource.
+                              For the purpose of status, an attachment is considered successful if at
+                              least one section in the parent resource accepts it. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                              the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route, the
+                              Route MUST be considered detached from the Gateway.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                    required:
+                      - conditions
+                      - controllerName
+                      - parentRef
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+              required:
+                - parents
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-udproutes-gateway-networking-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-udproutes-gateway-networking-k8s-io.yaml
@@ -1,0 +1,732 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.4.1
+    gateway.networking.k8s.io/channel: experimental
+  name: udproutes.gateway.networking.k8s.io
+spec:
+  group: gateway.networking.k8s.io
+  names:
+    categories:
+      - gateway-api
+    kind: UDPRoute
+    listKind: UDPRouteList
+    plural: udproutes
+    singular: udproute
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          description: |-
+            UDPRoute provides a way to route UDP traffic. When combined with a Gateway
+            listener, it can be used to forward traffic on the port specified by the
+            listener to a set of backends specified by the UDPRoute.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of UDPRoute.
+              properties:
+                parentRefs:
+                  description: |-
+                    ParentRefs references the resources (usually Gateways) that a Route wants
+                    to be attached to. Note that the referenced parent resource needs to
+                    allow this for the attachment to be complete. For Gateways, that means
+                    the Gateway needs to allow attachment from Routes of this kind and
+                    namespace. For Services, that means the Service must either be in the same
+                    namespace for a "producer" route, or the mesh implementation must support
+                    and allow "consumer" routes for the referenced Service. ReferenceGrant is
+                    not applicable for governing ParentRefs to Services - it is not possible to
+                    create a "producer" route for a Service in a different namespace from the
+                    Route.
+
+                    There are two kinds of parent resources with "Core" support:
+
+                    * Gateway (Gateway conformance profile)
+                    * Service (Mesh conformance profile, ClusterIP Services only)
+
+                    This API may be extended in the future to support additional kinds of parent
+                    resources.
+
+                    ParentRefs must be _distinct_. This means either that:
+
+                    * They select different objects.  If this is the case, then parentRef
+                      entries are distinct. In terms of fields, this means that the
+                      multi-part key defined by `group`, `kind`, `namespace`, and `name` must
+                      be unique across all parentRef entries in the Route.
+                    * They do not select different objects, but for each optional field used,
+                      each ParentRef that selects the same object must set the same set of
+                      optional fields to different values. If one ParentRef sets a
+                      combination of optional fields, all must set the same combination.
+
+                    Some examples:
+
+                    * If one ParentRef sets `sectionName`, all ParentRefs referencing the
+                      same object must also set `sectionName`.
+                    * If one ParentRef sets `port`, all ParentRefs referencing the same
+                      object must also set `port`.
+                    * If one ParentRef sets `sectionName` and `port`, all ParentRefs
+                      referencing the same object must also set `sectionName` and `port`.
+
+                    It is possible to separately reference multiple distinct objects that may
+                    be collapsed by an implementation. For example, some implementations may
+                    choose to merge compatible Gateway Listeners together. If that is the
+                    case, the list of routes attached to those resources should also be
+                    merged.
+
+                    Note that for ParentRefs that cross namespace boundaries, there are specific
+                    rules. Cross-namespace references are only valid if they are explicitly
+                    allowed by something in the namespace they are referring to. For example,
+                    Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                    generic way to enable other kinds of cross-namespace reference.
+
+
+                    ParentRefs from a Route to a Service in the same namespace are "producer"
+                    routes, which apply default routing rules to inbound connections from
+                    any namespace to the Service.
+
+                    ParentRefs from a Route to a Service in a different namespace are
+                    "consumer" routes, and these routing rules are only applied to outbound
+                    connections originating from the same namespace as the Route, for which
+                    the intended destination of the connections are a Service targeted as a
+                    ParentRef of the Route.
+                  items:
+                    description: |-
+                      ParentReference identifies an API object (usually a Gateway) that can be considered
+                      a parent of this resource (usually a route). There are two kinds of parent resources
+                      with "Core" support:
+
+                      * Gateway (Gateway conformance profile)
+                      * Service (Mesh conformance profile, ClusterIP Services only)
+
+                      This API may be extended in the future to support additional kinds of parent
+                      resources.
+
+                      The API object must be valid in the cluster; the Group and Kind must
+                      be registered in the cluster for this reference to be valid.
+                    properties:
+                      group:
+                        default: gateway.networking.k8s.io
+                        description: |-
+                          Group is the group of the referent.
+                          When unspecified, "gateway.networking.k8s.io" is inferred.
+                          To set the core API group (such as for a "Service" kind referent),
+                          Group must be explicitly set to "" (empty string).
+
+                          Support: Core
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        default: Gateway
+                        description: |-
+                          Kind is kind of the referent.
+
+                          There are two kinds of parent resources with "Core" support:
+
+                          * Gateway (Gateway conformance profile)
+                          * Service (Mesh conformance profile, ClusterIP Services only)
+
+                          Support for other resources is Implementation-Specific.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the referent.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace is the namespace of the referent. When unspecified, this refers
+                          to the local namespace of the Route.
+
+                          Note that there are specific rules for ParentRefs which cross namespace
+                          boundaries. Cross-namespace references are only valid if they are explicitly
+                          allowed by something in the namespace they are referring to. For example:
+                          Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                          generic way to enable any other kind of cross-namespace reference.
+
+
+                          ParentRefs from a Route to a Service in the same namespace are "producer"
+                          routes, which apply default routing rules to inbound connections from
+                          any namespace to the Service.
+
+                          ParentRefs from a Route to a Service in a different namespace are
+                          "consumer" routes, and these routing rules are only applied to outbound
+                          connections originating from the same namespace as the Route, for which
+                          the intended destination of the connections are a Service targeted as a
+                          ParentRef of the Route.
+
+
+                          Support: Core
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                        type: string
+                      port:
+                        description: |-
+                          Port is the network port this Route targets. It can be interpreted
+                          differently based on the type of parent resource.
+
+                          When the parent resource is a Gateway, this targets all listeners
+                          listening on the specified port that also support this kind of Route(and
+                          select this Route). It's not recommended to set `Port` unless the
+                          networking behaviors specified in a Route must apply to a specific port
+                          as opposed to a listener(s) whose port(s) may be changed. When both Port
+                          and SectionName are specified, the name and port of the selected listener
+                          must match both specified values.
+
+
+                          When the parent resource is a Service, this targets a specific port in the
+                          Service spec. When both Port (experimental) and SectionName are specified,
+                          the name and port of the selected port must match both specified values.
+
+
+                          Implementations MAY choose to support other parent resources.
+                          Implementations supporting other types of parent resources MUST clearly
+                          document how/if Port is interpreted.
+
+                          For the purpose of status, an attachment is considered successful as
+                          long as the parent resource accepts it partially. For example, Gateway
+                          listeners can restrict which Routes can attach to them by Route kind,
+                          namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                          from the referencing Route, the Route MUST be considered successfully
+                          attached. If no Gateway listeners accept attachment from this Route,
+                          the Route MUST be considered detached from the Gateway.
+
+                          Support: Extended
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      sectionName:
+                        description: |-
+                          SectionName is the name of a section within the target resource. In the
+                          following resources, SectionName is interpreted as the following:
+
+                          * Gateway: Listener name. When both Port (experimental) and SectionName
+                          are specified, the name and port of the selected listener must match
+                          both specified values.
+                          * Service: Port name. When both Port (experimental) and SectionName
+                          are specified, the name and port of the selected listener must match
+                          both specified values.
+
+                          Implementations MAY choose to support attaching Routes to other resources.
+                          If that is the case, they MUST clearly document how SectionName is
+                          interpreted.
+
+                          When unspecified (empty string), this will reference the entire resource.
+                          For the purpose of status, an attachment is considered successful if at
+                          least one section in the parent resource accepts it. For example, Gateway
+                          listeners can restrict which Routes can attach to them by Route kind,
+                          namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                          the referencing Route, the Route MUST be considered successfully
+                          attached. If no Gateway listeners accept attachment from this Route, the
+                          Route MUST be considered detached from the Gateway.
+
+                          Support: Core
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - name
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                    - message: sectionName or port must be specified when parentRefs includes 2 or more references to the same parent
+                      rule: 'self.all(p1, self.all(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '''') && (!has(p2.__namespace__) || p2.__namespace__ == '''')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__)) ? ((!has(p1.sectionName) || p1.sectionName == '''') == (!has(p2.sectionName) || p2.sectionName == '''') && (!has(p1.port) || p1.port == 0) == (!has(p2.port) || p2.port == 0)): true))'
+                    - message: sectionName or port must be unique when parentRefs includes 2 or more references to the same parent
+                      rule: self.all(p1, self.exists_one(p2, p1.group == p2.group && p1.kind == p2.kind && p1.name == p2.name && (((!has(p1.__namespace__) || p1.__namespace__ == '') && (!has(p2.__namespace__) || p2.__namespace__ == '')) || (has(p1.__namespace__) && has(p2.__namespace__) && p1.__namespace__ == p2.__namespace__ )) && (((!has(p1.sectionName) || p1.sectionName == '') && (!has(p2.sectionName) || p2.sectionName == '')) || ( has(p1.sectionName) && has(p2.sectionName) && p1.sectionName == p2.sectionName)) && (((!has(p1.port) || p1.port == 0) && (!has(p2.port) || p2.port == 0)) || (has(p1.port) && has(p2.port) && p1.port == p2.port))))
+                rules:
+                  description: Rules are a list of UDP matchers and actions.
+                  items:
+                    description: UDPRouteRule is the configuration for a given rule.
+                    properties:
+                      backendRefs:
+                        description: |-
+                          BackendRefs defines the backend(s) where matching requests should be
+                          sent. If unspecified or invalid (refers to a nonexistent resource or a
+                          Service with no endpoints), the underlying implementation MUST actively
+                          reject connection attempts to this backend. Packet drops must
+                          respect weight; if an invalid backend is requested to have 80% of
+                          the packets, then 80% of packets must be dropped instead.
+
+                          Support: Core for Kubernetes Service
+
+                          Support: Extended for Kubernetes ServiceImport
+
+                          Support: Implementation-specific for any other resource
+
+                          Support for weight: Extended
+                        items:
+                          description: |-
+                            BackendRef defines how a Route should forward a request to a Kubernetes
+                            resource.
+
+                            Note that when a namespace different than the local namespace is specified, a
+                            ReferenceGrant object is required in the referent namespace to allow that
+                            namespace's owner to accept the reference. See the ReferenceGrant
+                            documentation for details.
+
+
+                            When the BackendRef points to a Kubernetes Service, implementations SHOULD
+                            honor the appProtocol field if it is set for the target Service Port.
+
+                            Implementations supporting appProtocol SHOULD recognize the Kubernetes
+                            Standard Application Protocols defined in KEP-3726.
+
+                            If a Service appProtocol isn't specified, an implementation MAY infer the
+                            backend protocol through its own means. Implementations MAY infer the
+                            protocol from the Route type referring to the backend Service.
+
+                            If a Route is not able to send traffic to the backend using the specified
+                            protocol then the backend is considered invalid. Implementations MUST set the
+                            "ResolvedRefs" condition to "False" with the "UnsupportedProtocol" reason.
+
+
+                            Note that when the BackendTLSPolicy object is enabled by the implementation,
+                            there are some extra rules about validity to consider here. See the fields
+                            where this struct is used for more information about the exact behavior.
+                          properties:
+                            group:
+                              default: ""
+                              description: |-
+                                Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                When unspecified or empty string, core API group is inferred.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              default: Service
+                              description: |-
+                                Kind is the Kubernetes resource kind of the referent. For example
+                                "Service".
+
+                                Defaults to "Service" when not specified.
+
+                                ExternalName services can refer to CNAME DNS records that may live
+                                outside of the cluster and as such are difficult to reason about in
+                                terms of conformance. They also may not be safe to forward to (see
+                                CVE-2021-25740 for more information). Implementations SHOULD NOT
+                                support ExternalName Services.
+
+                                Support: Core (Services with a type other than ExternalName)
+
+                                Support: Implementation-specific (Services with type ExternalName)
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                            name:
+                              description: Name is the name of the referent.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            namespace:
+                              description: |-
+                                Namespace is the namespace of the backend. When unspecified, the local
+                                namespace is inferred.
+
+                                Note that when a namespace different than the local namespace is specified,
+                                a ReferenceGrant object is required in the referent namespace to allow that
+                                namespace's owner to accept the reference. See the ReferenceGrant
+                                documentation for details.
+
+                                Support: Core
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                              type: string
+                            port:
+                              description: |-
+                                Port specifies the destination port number to use for this resource.
+                                Port is required when the referent is a Kubernetes Service. In this
+                                case, the port number is the service port number, not the target port.
+                                For other resources, destination port might be derived from the referent
+                                resource or this field.
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            weight:
+                              default: 1
+                              description: |-
+                                Weight specifies the proportion of requests forwarded to the referenced
+                                backend. This is computed as weight/(sum of all weights in this
+                                BackendRefs list). For non-zero values, there may be some epsilon from
+                                the exact proportion defined here depending on the precision an
+                                implementation supports. Weight is not a percentage and the sum of
+                                weights does not need to equal 100.
+
+                                If only one backend is specified and it has a weight greater than 0, 100%
+                                of the traffic is forwarded to that backend. If weight is set to 0, no
+                                traffic should be forwarded for this entry. If unspecified, weight
+                                defaults to 1.
+
+                                Support for this field varies based on the context where used.
+                              format: int32
+                              maximum: 1000000
+                              minimum: 0
+                              type: integer
+                          required:
+                            - name
+                          type: object
+                          x-kubernetes-validations:
+                            - message: Must have port for Service reference
+                              rule: '(size(self.group) == 0 && self.kind == ''Service'') ? has(self.port) : true'
+                        maxItems: 16
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      name:
+                        description: |-
+                          Name is the name of the route rule. This name MUST be unique within a Route if it is set.
+
+                          Support: Extended
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                    required:
+                      - backendRefs
+                    type: object
+                  maxItems: 16
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                  x-kubernetes-validations:
+                    - message: Rule name must be unique within the route
+                      rule: self.all(l1, !has(l1.name) || self.exists_one(l2, has(l2.name) && l1.name == l2.name))
+                useDefaultGateways:
+                  description: |-
+                    UseDefaultGateways indicates the default Gateway scope to use for this
+                    Route. If unset (the default) or set to None, the Route will not be
+                    attached to any default Gateway; if set, it will be attached to any
+                    default Gateway supporting the named scope, subject to the usual rules
+                    about which Routes a Gateway is allowed to claim.
+
+                    Think carefully before using this functionality! The set of default
+                    Gateways supporting the requested scope can change over time without
+                    any notice to the Route author, and in many situations it will not be
+                    appropriate to request a default Gateway for a given Route -- for
+                    example, a Route with specific security requirements should almost
+                    certainly not use a default Gateway.
+                  enum:
+                    - All
+                    - None
+                  type: string
+              required:
+                - rules
+              type: object
+            status:
+              description: Status defines the current state of UDPRoute.
+              properties:
+                parents:
+                  description: |-
+                    Parents is a list of parent resources (usually Gateways) that are
+                    associated with the route, and the status of the route with respect to
+                    each parent. When this route attaches to a parent, the controller that
+                    manages the parent must add an entry to this list when the controller
+                    first sees the route and should update the entry as appropriate when the
+                    route or gateway is modified.
+
+                    Note that parent references that cannot be resolved by an implementation
+                    of this API will not be added to this list. Implementations of this API
+                    can only populate Route status for the Gateways/parent resources they are
+                    responsible for.
+
+                    A maximum of 32 Gateways will be represented in this list. An empty list
+                    means the route has not been attached to any Gateway.
+                  items:
+                    description: |-
+                      RouteParentStatus describes the status of a route with respect to an
+                      associated Parent.
+                    properties:
+                      conditions:
+                        description: |-
+                          Conditions describes the status of the route with respect to the Gateway.
+                          Note that the route's availability is also subject to the Gateway's own
+                          status conditions and listener status.
+
+                          If the Route's ParentRef specifies an existing Gateway that supports
+                          Routes of this kind AND that Gateway's controller has sufficient access,
+                          then that Gateway's controller MUST set the "Accepted" condition on the
+                          Route, to indicate whether the route has been accepted or rejected by the
+                          Gateway, and why.
+
+                          A Route MUST be considered "Accepted" if at least one of the Route's
+                          rules is implemented by the Gateway.
+
+                          There are a number of cases where the "Accepted" condition may not be set
+                          due to lack of controller visibility, that includes when:
+
+                          * The Route refers to a nonexistent parent.
+                          * The Route is of a type that the controller does not support.
+                          * The Route is in a namespace the controller does not have access to.
+                        items:
+                          description: Condition contains details for one aspect of the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      controllerName:
+                        description: |-
+                          ControllerName is a domain/path string that indicates the name of the
+                          controller that wrote this status. This corresponds with the
+                          controllerName field on GatewayClass.
+
+                          Example: "example.net/gateway-controller".
+
+                          The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                          valid Kubernetes names
+                          (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                          Controllers MUST populate this field when writing status. Controllers should ensure that
+                          entries to status populated with their ControllerName are cleaned up when they are no
+                          longer necessary.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                      parentRef:
+                        description: |-
+                          ParentRef corresponds with a ParentRef in the spec that this
+                          RouteParentStatus struct describes the status of.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: |-
+                              Group is the group of the referent.
+                              When unspecified, "gateway.networking.k8s.io" is inferred.
+                              To set the core API group (such as for a "Service" kind referent),
+                              Group must be explicitly set to "" (empty string).
+
+                              Support: Core
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: |-
+                              Kind is kind of the referent.
+
+                              There are two kinds of parent resources with "Core" support:
+
+                              * Gateway (Gateway conformance profile)
+                              * Service (Mesh conformance profile, ClusterIP Services only)
+
+                              Support for other resources is Implementation-Specific.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the referent.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referent. When unspecified, this refers
+                              to the local namespace of the Route.
+
+                              Note that there are specific rules for ParentRefs which cross namespace
+                              boundaries. Cross-namespace references are only valid if they are explicitly
+                              allowed by something in the namespace they are referring to. For example:
+                              Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                              generic way to enable any other kind of cross-namespace reference.
+
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port is the network port this Route targets. It can be interpreted
+                              differently based on the type of parent resource.
+
+                              When the parent resource is a Gateway, this targets all listeners
+                              listening on the specified port that also support this kind of Route(and
+                              select this Route). It's not recommended to set `Port` unless the
+                              networking behaviors specified in a Route must apply to a specific port
+                              as opposed to a listener(s) whose port(s) may be changed. When both Port
+                              and SectionName are specified, the name and port of the selected listener
+                              must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
+
+                              Implementations MAY choose to support other parent resources.
+                              Implementations supporting other types of parent resources MUST clearly
+                              document how/if Port is interpreted.
+
+                              For the purpose of status, an attachment is considered successful as
+                              long as the parent resource accepts it partially. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                              from the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route,
+                              the Route MUST be considered detached from the Gateway.
+
+                              Support: Extended
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          sectionName:
+                            description: |-
+                              SectionName is the name of a section within the target resource. In the
+                              following resources, SectionName is interpreted as the following:
+
+                              * Gateway: Listener name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+                              * Service: Port name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+
+                              Implementations MAY choose to support attaching Routes to other resources.
+                              If that is the case, they MUST clearly document how SectionName is
+                              interpreted.
+
+                              When unspecified (empty string), this will reference the entire resource.
+                              For the purpose of status, an attachment is considered successful if at
+                              least one section in the parent resource accepts it. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                              the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route, the
+                              Route MUST be considered detached from the Gateway.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                    required:
+                      - conditions
+                      - controllerName
+                      - parentRef
+                    type: object
+                  maxItems: 32
+                  type: array
+                  x-kubernetes-list-type: atomic
+              required:
+                - parents
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-xbackendtrafficpolicies-gateway-networking-x-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-xbackendtrafficpolicies-gateway-networking-x-k8s-io.yaml
@@ -1,0 +1,596 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.4.1
+    gateway.networking.k8s.io/channel: experimental
+  labels:
+    gateway.networking.k8s.io/policy: Direct
+  name: xbackendtrafficpolicies.gateway.networking.x-k8s.io
+spec:
+  group: gateway.networking.x-k8s.io
+  names:
+    categories:
+      - gateway-api
+    kind: XBackendTrafficPolicy
+    listKind: XBackendTrafficPolicyList
+    plural: xbackendtrafficpolicies
+    shortNames:
+      - xbtrafficpolicy
+    singular: xbackendtrafficpolicy
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            XBackendTrafficPolicy defines the configuration for how traffic to a
+            target backend should be handled.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of BackendTrafficPolicy.
+              properties:
+                retryConstraint:
+                  description: |-
+                    RetryConstraint defines the configuration for when to allow or prevent
+                    further retries to a target backend, by dynamically calculating a 'retry
+                    budget'. This budget is calculated based on the percentage of incoming
+                    traffic composed of retries over a given time interval. Once the budget
+                    is exceeded, additional retries will be rejected.
+
+                    For example, if the retry budget interval is 10 seconds, there have been
+                    1000 active requests in the past 10 seconds, and the allowed percentage
+                    of requests that can be retried is 20% (the default), then 200 of those
+                    requests may be composed of retries. Active requests will only be
+                    considered for the duration of the interval when calculating the retry
+                    budget. Retrying the same original request multiple times within the
+                    retry budget interval will lead to each retry being counted towards
+                    calculating the budget.
+
+                    Configuring a RetryConstraint in BackendTrafficPolicy is compatible with
+                    HTTPRoute Retry settings for each HTTPRouteRule that targets the same
+                    backend. While the HTTPRouteRule Retry stanza can specify whether a
+                    request will be retried, and the number of retry attempts each client
+                    may perform, RetryConstraint helps prevent cascading failures such as
+                    retry storms during periods of consistent failures.
+
+                    After the retry budget has been exceeded, additional retries to the
+                    backend MUST return a 503 response to the client.
+
+                    Additional configurations for defining a constraint on retries MAY be
+                    defined in the future.
+
+                    Support: Extended
+                  properties:
+                    budget:
+                      default:
+                        interval: 10s
+                        percent: 20
+                      description: Budget holds the details of the retry budget configuration.
+                      properties:
+                        interval:
+                          default: 10s
+                          description: |-
+                            Interval defines the duration in which requests will be considered
+                            for calculating the budget for retries.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                          x-kubernetes-validations:
+                            - message: interval can not be greater than one hour or less than one second
+                              rule: '!(duration(self) < duration(''1s'') || duration(self) > duration(''1h''))'
+                        percent:
+                          default: 20
+                          description: |-
+                            Percent defines the maximum percentage of active requests that may
+                            be made up of retries.
+
+                            Support: Extended
+                          maximum: 100
+                          minimum: 0
+                          type: integer
+                      type: object
+                    minRetryRate:
+                      default:
+                        count: 10
+                        interval: 1s
+                      description: |-
+                        MinRetryRate defines the minimum rate of retries that will be allowable
+                        over a specified duration of time.
+
+                        The effective overall minimum rate of retries targeting the backend
+                        service may be much higher, as there can be any number of clients which
+                        are applying this setting locally.
+
+                        This ensures that requests can still be retried during periods of low
+                        traffic, where the budget for retries may be calculated as a very low
+                        value.
+
+                        Support: Extended
+                      properties:
+                        count:
+                          description: |-
+                            Count specifies the number of requests per time interval.
+
+                            Support: Extended
+                          maximum: 1000000
+                          minimum: 1
+                          type: integer
+                        interval:
+                          description: |-
+                            Interval specifies the divisor of the rate of requests, the amount of
+                            time during which the given count of requests occur.
+
+                            Support: Extended
+                          pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                          type: string
+                          x-kubernetes-validations:
+                            - message: interval can not be greater than one hour
+                              rule: '!(duration(self) == duration(''0s'') || duration(self) > duration(''1h''))'
+                      type: object
+                  type: object
+                sessionPersistence:
+                  description: |-
+                    SessionPersistence defines and configures session persistence
+                    for the backend.
+
+                    Support: Extended
+                  properties:
+                    absoluteTimeout:
+                      description: |-
+                        AbsoluteTimeout defines the absolute timeout of the persistent
+                        session. Once the AbsoluteTimeout duration has elapsed, the
+                        session becomes invalid.
+
+                        Support: Extended
+                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                      type: string
+                    cookieConfig:
+                      description: |-
+                        CookieConfig provides configuration settings that are specific
+                        to cookie-based session persistence.
+
+                        Support: Core
+                      properties:
+                        lifetimeType:
+                          default: Session
+                          description: |-
+                            LifetimeType specifies whether the cookie has a permanent or
+                            session-based lifetime. A permanent cookie persists until its
+                            specified expiry time, defined by the Expires or Max-Age cookie
+                            attributes, while a session cookie is deleted when the current
+                            session ends.
+
+                            When set to "Permanent", AbsoluteTimeout indicates the
+                            cookie's lifetime via the Expires or Max-Age cookie attributes
+                            and is required.
+
+                            When set to "Session", AbsoluteTimeout indicates the
+                            absolute lifetime of the cookie tracked by the gateway and
+                            is optional.
+
+                            Defaults to "Session".
+
+                            Support: Core for "Session" type
+
+                            Support: Extended for "Permanent" type
+                          enum:
+                            - Permanent
+                            - Session
+                          type: string
+                      type: object
+                    idleTimeout:
+                      description: |-
+                        IdleTimeout defines the idle timeout of the persistent session.
+                        Once the session has been idle for more than the specified
+                        IdleTimeout duration, the session becomes invalid.
+
+                        Support: Extended
+                      pattern: ^([0-9]{1,5}(h|m|s|ms)){1,4}$
+                      type: string
+                    sessionName:
+                      description: |-
+                        SessionName defines the name of the persistent session token
+                        which may be reflected in the cookie or the header. Users
+                        should avoid reusing session names to prevent unintended
+                        consequences, such as rejection or unpredictable behavior.
+
+                        Support: Implementation-specific
+                      maxLength: 128
+                      type: string
+                    type:
+                      default: Cookie
+                      description: |-
+                        Type defines the type of session persistence such as through
+                        the use a header or cookie. Defaults to cookie based session
+                        persistence.
+
+                        Support: Core for "Cookie" type
+
+                        Support: Extended for "Header" type
+                      enum:
+                        - Cookie
+                        - Header
+                      type: string
+                  type: object
+                  x-kubernetes-validations:
+                    - message: AbsoluteTimeout must be specified when cookie lifetimeType is Permanent
+                      rule: '!has(self.cookieConfig) || !has(self.cookieConfig.lifetimeType) || self.cookieConfig.lifetimeType != ''Permanent'' || has(self.absoluteTimeout)'
+                targetRefs:
+                  description: |-
+                    TargetRefs identifies API object(s) to apply this policy to.
+                    Currently, Backends (A grouping of like endpoints such as Service,
+                    ServiceImport, or any implementation-specific backendRef) are the only
+                    valid API target references.
+
+                    Currently, a TargetRef can not be scoped to a specific port on a
+                    Service.
+                  items:
+                    description: |-
+                      LocalPolicyTargetReference identifies an API object to apply a direct or
+                      inherited policy to. This should be used as part of Policy resources
+                      that can target Gateway API resources. For more information on how this
+                      policy attachment model works, and a sample Policy resource, refer to
+                      the policy attachment documentation for Gateway API.
+                    properties:
+                      group:
+                        description: Group is the group of the target resource.
+                        maxLength: 253
+                        pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      kind:
+                        description: Kind is kind of the target resource.
+                        maxLength: 63
+                        minLength: 1
+                        pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                        type: string
+                      name:
+                        description: Name is the name of the target resource.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                    required:
+                      - group
+                      - kind
+                      - name
+                    type: object
+                  maxItems: 16
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - group
+                    - kind
+                    - name
+                  x-kubernetes-list-type: map
+              required:
+                - targetRefs
+              type: object
+            status:
+              description: Status defines the current state of BackendTrafficPolicy.
+              properties:
+                ancestors:
+                  description: |-
+                    Ancestors is a list of ancestor resources (usually Gateways) that are
+                    associated with the policy, and the status of the policy with respect to
+                    each ancestor. When this policy attaches to a parent, the controller that
+                    manages the parent and the ancestors MUST add an entry to this list when
+                    the controller first sees the policy and SHOULD update the entry as
+                    appropriate when the relevant ancestor is modified.
+
+                    Note that choosing the relevant ancestor is left to the Policy designers;
+                    an important part of Policy design is designing the right object level at
+                    which to namespace this status.
+
+                    Note also that implementations MUST ONLY populate ancestor status for
+                    the Ancestor resources they are responsible for. Implementations MUST
+                    use the ControllerName field to uniquely identify the entries in this list
+                    that they are responsible for.
+
+                    Note that to achieve this, the list of PolicyAncestorStatus structs
+                    MUST be treated as a map with a composite key, made up of the AncestorRef
+                    and ControllerName fields combined.
+
+                    A maximum of 16 ancestors will be represented in this list. An empty list
+                    means the Policy is not relevant for any ancestors.
+
+                    If this slice is full, implementations MUST NOT add further entries.
+                    Instead they MUST consider the policy unimplementable and signal that
+                    on any related resources such as the ancestor that would be referenced
+                    here. For example, if this list was full on BackendTLSPolicy, no
+                    additional Gateways would be able to reference the Service targeted by
+                    the BackendTLSPolicy.
+                  items:
+                    description: |-
+                      PolicyAncestorStatus describes the status of a route with respect to an
+                      associated Ancestor.
+
+                      Ancestors refer to objects that are either the Target of a policy or above it
+                      in terms of object hierarchy. For example, if a policy targets a Service, the
+                      Policy's Ancestors are, in order, the Service, the HTTPRoute, the Gateway, and
+                      the GatewayClass. Almost always, in this hierarchy, the Gateway will be the most
+                      useful object to place Policy status on, so we recommend that implementations
+                      SHOULD use Gateway as the PolicyAncestorStatus object unless the designers
+                      have a _very_ good reason otherwise.
+
+                      In the context of policy attachment, the Ancestor is used to distinguish which
+                      resource results in a distinct application of this policy. For example, if a policy
+                      targets a Service, it may have a distinct result per attached Gateway.
+
+                      Policies targeting the same resource may have different effects depending on the
+                      ancestors of those resources. For example, different Gateways targeting the same
+                      Service may have different capabilities, especially if they have different underlying
+                      implementations.
+
+                      For example, in BackendTLSPolicy, the Policy attaches to a Service that is
+                      used as a backend in a HTTPRoute that is itself attached to a Gateway.
+                      In this case, the relevant object for status is the Gateway, and that is the
+                      ancestor object referred to in this status.
+
+                      Note that a parent is also an ancestor, so for objects where the parent is the
+                      relevant object for status, this struct SHOULD still be used.
+
+                      This struct is intended to be used in a slice that's effectively a map,
+                      with a composite key made up of the AncestorRef and the ControllerName.
+                    properties:
+                      ancestorRef:
+                        description: |-
+                          AncestorRef corresponds with a ParentRef in the spec that this
+                          PolicyAncestorStatus struct describes the status of.
+                        properties:
+                          group:
+                            default: gateway.networking.k8s.io
+                            description: |-
+                              Group is the group of the referent.
+                              When unspecified, "gateway.networking.k8s.io" is inferred.
+                              To set the core API group (such as for a "Service" kind referent),
+                              Group must be explicitly set to "" (empty string).
+
+                              Support: Core
+                            maxLength: 253
+                            pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          kind:
+                            default: Gateway
+                            description: |-
+                              Kind is kind of the referent.
+
+                              There are two kinds of parent resources with "Core" support:
+
+                              * Gateway (Gateway conformance profile)
+                              * Service (Mesh conformance profile, ClusterIP Services only)
+
+                              Support for other resources is Implementation-Specific.
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the referent.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace is the namespace of the referent. When unspecified, this refers
+                              to the local namespace of the Route.
+
+                              Note that there are specific rules for ParentRefs which cross namespace
+                              boundaries. Cross-namespace references are only valid if they are explicitly
+                              allowed by something in the namespace they are referring to. For example:
+                              Gateway has the AllowedRoutes field, and ReferenceGrant provides a
+                              generic way to enable any other kind of cross-namespace reference.
+
+
+                              ParentRefs from a Route to a Service in the same namespace are "producer"
+                              routes, which apply default routing rules to inbound connections from
+                              any namespace to the Service.
+
+                              ParentRefs from a Route to a Service in a different namespace are
+                              "consumer" routes, and these routing rules are only applied to outbound
+                              connections originating from the same namespace as the Route, for which
+                              the intended destination of the connections are a Service targeted as a
+                              ParentRef of the Route.
+
+
+                              Support: Core
+                            maxLength: 63
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                            type: string
+                          port:
+                            description: |-
+                              Port is the network port this Route targets. It can be interpreted
+                              differently based on the type of parent resource.
+
+                              When the parent resource is a Gateway, this targets all listeners
+                              listening on the specified port that also support this kind of Route(and
+                              select this Route). It's not recommended to set `Port` unless the
+                              networking behaviors specified in a Route must apply to a specific port
+                              as opposed to a listener(s) whose port(s) may be changed. When both Port
+                              and SectionName are specified, the name and port of the selected listener
+                              must match both specified values.
+
+
+                              When the parent resource is a Service, this targets a specific port in the
+                              Service spec. When both Port (experimental) and SectionName are specified,
+                              the name and port of the selected port must match both specified values.
+
+
+                              Implementations MAY choose to support other parent resources.
+                              Implementations supporting other types of parent resources MUST clearly
+                              document how/if Port is interpreted.
+
+                              For the purpose of status, an attachment is considered successful as
+                              long as the parent resource accepts it partially. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment
+                              from the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route,
+                              the Route MUST be considered detached from the Gateway.
+
+                              Support: Extended
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
+                          sectionName:
+                            description: |-
+                              SectionName is the name of a section within the target resource. In the
+                              following resources, SectionName is interpreted as the following:
+
+                              * Gateway: Listener name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+                              * Service: Port name. When both Port (experimental) and SectionName
+                              are specified, the name and port of the selected listener must match
+                              both specified values.
+
+                              Implementations MAY choose to support attaching Routes to other resources.
+                              If that is the case, they MUST clearly document how SectionName is
+                              interpreted.
+
+                              When unspecified (empty string), this will reference the entire resource.
+                              For the purpose of status, an attachment is considered successful if at
+                              least one section in the parent resource accepts it. For example, Gateway
+                              listeners can restrict which Routes can attach to them by Route kind,
+                              namespace, or hostname. If 1 of 2 Gateway listeners accept attachment from
+                              the referencing Route, the Route MUST be considered successfully
+                              attached. If no Gateway listeners accept attachment from this Route, the
+                              Route MUST be considered detached from the Gateway.
+
+                              Support: Core
+                            maxLength: 253
+                            minLength: 1
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      conditions:
+                        description: Conditions describes the status of the Policy with respect to the given Ancestor.
+                        items:
+                          description: Condition contains details for one aspect of the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        maxItems: 8
+                        minItems: 1
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      controllerName:
+                        description: |-
+                          ControllerName is a domain/path string that indicates the name of the
+                          controller that wrote this status. This corresponds with the
+                          controllerName field on GatewayClass.
+
+                          Example: "example.net/gateway-controller".
+
+                          The format of this field is DOMAIN "/" PATH, where DOMAIN and PATH are
+                          valid Kubernetes names
+                          (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+
+                          Controllers MUST populate this field when writing status. Controllers should ensure that
+                          entries to status populated with their ControllerName are cleaned up when they are no
+                          longer necessary.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9\/\-._~%!$&'()*+,;=:]+$
+                        type: string
+                    required:
+                      - ancestorRef
+                      - conditions
+                      - controllerName
+                    type: object
+                  maxItems: 16
+                  type: array
+                  x-kubernetes-list-type: atomic
+              required:
+                - ancestors
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""

--- a/manifests/prd/gateway-api-crds/CustomResourceDefinition-xlistenersets-gateway-networking-x-k8s-io.yaml
+++ b/manifests/prd/gateway-api-crds/CustomResourceDefinition-xlistenersets-gateway-networking-x-k8s-io.yaml
@@ -1,0 +1,761 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
+    gateway.networking.k8s.io/bundle-version: v1.4.1
+    gateway.networking.k8s.io/channel: experimental
+  name: xlistenersets.gateway.networking.x-k8s.io
+spec:
+  group: gateway.networking.x-k8s.io
+  names:
+    categories:
+      - gateway-api
+    kind: XListenerSet
+    listKind: XListenerSetList
+    plural: xlistenersets
+    shortNames:
+      - lset
+    singular: xlistenerset
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .status.conditions[?(@.type=="Accepted")].status
+          name: Accepted
+          type: string
+        - jsonPath: .status.conditions[?(@.type=="Programmed")].status
+          name: Programmed
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: |-
+            XListenerSet defines a set of additional listeners to attach to an existing Gateway.
+            This resource provides a mechanism to merge multiple listeners into a single Gateway.
+
+            The parent Gateway must explicitly allow ListenerSet attachment through its
+            AllowedListeners configuration. By default, Gateways do not allow ListenerSet
+            attachment.
+
+            Routes can attach to a ListenerSet by specifying it as a parentRef, and can
+            optionally target specific listeners using the sectionName field.
+
+            Policy Attachment:
+            - Policies that attach to a ListenerSet apply to all listeners defined in that resource
+            - Policies do not impact listeners in the parent Gateway
+            - Different ListenerSets attached to the same Gateway can have different policies
+            - If an implementation cannot apply a policy to specific listeners, it should reject the policy
+
+            ReferenceGrant Semantics:
+            - ReferenceGrants applied to a Gateway are not inherited by child ListenerSets
+            - ReferenceGrants applied to a ListenerSet do not grant permission to the parent Gateway's listeners
+            - A ListenerSet can reference secrets/backends in its own namespace without a ReferenceGrant
+
+            Gateway Integration:
+            - The parent Gateway's status will include an "AttachedListenerSets" condition
+            - This condition will be:
+              - True: when AllowedListeners is set and at least one child ListenerSet is attached
+              - False: when AllowedListeners is set but no valid listeners are attached, or when AllowedListeners is not set or false
+              - Unknown: when no AllowedListeners config is present
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the desired state of ListenerSet.
+              properties:
+                listeners:
+                  description: |-
+                    Listeners associated with this ListenerSet. Listeners define
+                    logical endpoints that are bound on this referenced parent Gateway's addresses.
+
+                    Listeners in a `Gateway` and their attached `ListenerSets` are concatenated
+                    as a list when programming the underlying infrastructure. Each listener
+                    name does not need to be unique across the Gateway and ListenerSets.
+                    See ListenerEntry.Name for more details.
+
+                    Implementations MUST treat the parent Gateway as having the merged
+                    list of all listeners from itself and attached ListenerSets using
+                    the following precedence:
+
+                    1. "parent" Gateway
+                    2. ListenerSet ordered by creation time (oldest first)
+                    3. ListenerSet ordered alphabetically by "{namespace}/{name}".
+
+                    An implementation MAY reject listeners by setting the ListenerEntryStatus
+                    `Accepted` condition to False with the Reason `TooManyListeners`
+
+                    If a listener has a conflict, this will be reported in the
+                    Status.ListenerEntryStatus setting the `Conflicted` condition to True.
+
+                    Implementations SHOULD be cautious about what information from the
+                    parent or siblings are reported to avoid accidentally leaking
+                    sensitive information that the child would not otherwise have access
+                    to. This can include contents of secrets etc.
+                  items:
+                    properties:
+                      allowedRoutes:
+                        default:
+                          namespaces:
+                            from: Same
+                        description: |-
+                          AllowedRoutes defines the types of routes that MAY be attached to a
+                          Listener and the trusted namespaces where those Route resources MAY be
+                          present.
+
+                          Although a client request may match multiple route rules, only one rule
+                          may ultimately receive the request. Matching precedence MUST be
+                          determined in order of the following criteria:
+
+                          * The most specific match as defined by the Route type.
+                          * The oldest Route based on creation timestamp. For example, a Route with
+                            a creation timestamp of "2020-09-08 01:02:03" is given precedence over
+                            a Route with a creation timestamp of "2020-09-08 01:02:04".
+                          * If everything else is equivalent, the Route appearing first in
+                            alphabetical order (namespace/name) should be given precedence. For
+                            example, foo/bar is given precedence over foo/baz.
+
+                          All valid rules within a Route attached to this Listener should be
+                          implemented. Invalid Route rules can be ignored (sometimes that will mean
+                          the full Route). If a Route rule transitions from valid to invalid,
+                          support for that Route rule should be dropped to ensure consistency. For
+                          example, even if a filter specified by a Route rule is invalid, the rest
+                          of the rules within that Route should still be supported.
+                        properties:
+                          kinds:
+                            description: |-
+                              Kinds specifies the groups and kinds of Routes that are allowed to bind
+                              to this Gateway Listener. When unspecified or empty, the kinds of Routes
+                              selected are determined using the Listener protocol.
+
+                              A RouteGroupKind MUST correspond to kinds of Routes that are compatible
+                              with the application protocol specified in the Listener's Protocol field.
+                              If an implementation does not support or recognize this resource type, it
+                              MUST set the "ResolvedRefs" condition to False for this Listener with the
+                              "InvalidRouteKinds" reason.
+
+                              Support: Core
+                            items:
+                              description: RouteGroupKind indicates the group and kind of a Route resource.
+                              properties:
+                                group:
+                                  default: gateway.networking.k8s.io
+                                  description: Group is the group of the Route.
+                                  maxLength: 253
+                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                kind:
+                                  description: Kind is the kind of the Route.
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  type: string
+                              required:
+                                - kind
+                              type: object
+                            maxItems: 8
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          namespaces:
+                            default:
+                              from: Same
+                            description: |-
+                              Namespaces indicates namespaces from which Routes may be attached to this
+                              Listener. This is restricted to the namespace of this Gateway by default.
+
+                              Support: Core
+                            properties:
+                              from:
+                                default: Same
+                                description: |-
+                                  From indicates where Routes will be selected for this Gateway. Possible
+                                  values are:
+
+                                  * All: Routes in all namespaces may be used by this Gateway.
+                                  * Selector: Routes in namespaces selected by the selector may be used by
+                                    this Gateway.
+                                  * Same: Only Routes in the same namespace may be used by this Gateway.
+
+                                  Support: Core
+                                enum:
+                                  - All
+                                  - Selector
+                                  - Same
+                                type: string
+                              selector:
+                                description: |-
+                                  Selector must be specified when From is set to "Selector". In that case,
+                                  only Routes in Namespaces matching this Selector will be selected by this
+                                  Gateway. This field is ignored for other values of "From".
+
+                                  Support: Core
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        type: object
+                      hostname:
+                        description: |-
+                          Hostname specifies the virtual hostname to match for protocol types that
+                          define this concept. When unspecified, all hostnames are matched. This
+                          field is ignored for protocols that don't require hostname based
+                          matching.
+
+                          Implementations MUST apply Hostname matching appropriately for each of
+                          the following protocols:
+
+                          * TLS: The Listener Hostname MUST match the SNI.
+                          * HTTP: The Listener Hostname MUST match the Host header of the request.
+                          * HTTPS: The Listener Hostname SHOULD match at both the TLS and HTTP
+                            protocol layers as described above. If an implementation does not
+                            ensure that both the SNI and Host header match the Listener hostname,
+                            it MUST clearly document that.
+
+                          For HTTPRoute and TLSRoute resources, there is an interaction with the
+                          `spec.hostnames` array. When both listener and route specify hostnames,
+                          there MUST be an intersection between the values for a Route to be
+                          accepted. For more information, refer to the Route specific Hostnames
+                          documentation.
+
+                          Hostnames that are prefixed with a wildcard label (`*.`) are interpreted
+                          as a suffix match. That means that a match for `*.example.com` would match
+                          both `test.example.com`, and `foo.test.example.com`, but not `example.com`.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      name:
+                        description: |-
+                          Name is the name of the Listener. This name MUST be unique within a
+                          ListenerSet.
+
+                          Name is not required to be unique across a Gateway and ListenerSets.
+                          Routes can attach to a Listener by having a ListenerSet as a parentRef
+                          and setting the SectionName
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      port:
+                        default: 0
+                        description: |-
+                          Port is the network port. Multiple listeners may use the
+                          same port, subject to the Listener compatibility rules.
+
+                          If the port is not set or specified as zero, the implementation will assign
+                          a unique port. If the implementation does not support dynamic port
+                          assignment, it MUST set `Accepted` condition to `False` with the
+                          `UnsupportedPort` reason.
+                        format: int32
+                        maximum: 65535
+                        minimum: 0
+                        type: integer
+                      protocol:
+                        description: Protocol specifies the network protocol this listener expects to receive.
+                        maxLength: 255
+                        minLength: 1
+                        pattern: ^[a-zA-Z0-9]([-a-zA-Z0-9]*[a-zA-Z0-9])?$|[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*\/[A-Za-z0-9]+$
+                        type: string
+                      tls:
+                        description: |-
+                          TLS is the TLS configuration for the Listener. This field is required if
+                          the Protocol field is "HTTPS" or "TLS". It is invalid to set this field
+                          if the Protocol field is "HTTP", "TCP", or "UDP".
+
+                          The association of SNIs to Certificate defined in ListenerTLSConfig is
+                          defined based on the Hostname field for this listener.
+
+                          The GatewayClass MUST use the longest matching SNI out of all
+                          available certificates for any TLS handshake.
+                        properties:
+                          certificateRefs:
+                            description: |-
+                              CertificateRefs contains a series of references to Kubernetes objects that
+                              contains TLS certificates and private keys. These certificates are used to
+                              establish a TLS handshake for requests that match the hostname of the
+                              associated listener.
+
+                              A single CertificateRef to a Kubernetes Secret has "Core" support.
+                              Implementations MAY choose to support attaching multiple certificates to
+                              a Listener, but this behavior is implementation-specific.
+
+                              References to a resource in different namespace are invalid UNLESS there
+                              is a ReferenceGrant in the target namespace that allows the certificate
+                              to be attached. If a ReferenceGrant does not allow this reference, the
+                              "ResolvedRefs" condition MUST be set to False for this listener with the
+                              "RefNotPermitted" reason.
+
+                              This field is required to have at least one element when the mode is set
+                              to "Terminate" (default) and is optional otherwise.
+
+                              CertificateRefs can reference to standard Kubernetes resources, i.e.
+                              Secret, or implementation-specific custom resources.
+
+                              Support: Core - A single reference to a Kubernetes Secret of type kubernetes.io/tls
+
+                              Support: Implementation-specific (More than one reference or other resource types)
+                            items:
+                              description: |-
+                                SecretObjectReference identifies an API object including its namespace,
+                                defaulting to Secret.
+
+                                The API object must be valid in the cluster; the Group and Kind must
+                                be registered in the cluster for this reference to be valid.
+
+                                References to objects with invalid Group and Kind are not valid, and must
+                                be rejected by the implementation, with appropriate Conditions set
+                                on the containing object.
+                              properties:
+                                group:
+                                  default: ""
+                                  description: |-
+                                    Group is the group of the referent. For example, "gateway.networking.k8s.io".
+                                    When unspecified or empty string, core API group is inferred.
+                                  maxLength: 253
+                                  pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                                  type: string
+                                kind:
+                                  default: Secret
+                                  description: Kind is kind of the referent. For example "Secret".
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                                  type: string
+                                name:
+                                  description: Name is the name of the referent.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace is the namespace of the referenced object. When unspecified, the local
+                                    namespace is inferred.
+
+                                    Note that when a namespace different than the local namespace is specified,
+                                    a ReferenceGrant object is required in the referent namespace to allow that
+                                    namespace's owner to accept the reference. See the ReferenceGrant
+                                    documentation for details.
+
+                                    Support: Core
+                                  maxLength: 63
+                                  minLength: 1
+                                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                                  type: string
+                              required:
+                                - name
+                              type: object
+                            maxItems: 64
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          mode:
+                            default: Terminate
+                            description: |-
+                              Mode defines the TLS behavior for the TLS session initiated by the client.
+                              There are two possible modes:
+
+                              - Terminate: The TLS session between the downstream client and the
+                                Gateway is terminated at the Gateway. This mode requires certificates
+                                to be specified in some way, such as populating the certificateRefs
+                                field.
+                              - Passthrough: The TLS session is NOT terminated by the Gateway. This
+                                implies that the Gateway can't decipher the TLS stream except for
+                                the ClientHello message of the TLS protocol. The certificateRefs field
+                                is ignored in this mode.
+
+                              Support: Core
+                            enum:
+                              - Terminate
+                              - Passthrough
+                            type: string
+                          options:
+                            additionalProperties:
+                              description: |-
+                                AnnotationValue is the value of an annotation in Gateway API. This is used
+                                for validation of maps such as TLS options. This roughly matches Kubernetes
+                                annotation validation, although the length validation in that case is based
+                                on the entire size of the annotations struct.
+                              maxLength: 4096
+                              minLength: 0
+                              type: string
+                            description: |-
+                              Options are a list of key/value pairs to enable extended TLS
+                              configuration for each implementation. For example, configuring the
+                              minimum TLS version or supported cipher suites.
+
+                              A set of common keys MAY be defined by the API in the future. To avoid
+                              any ambiguity, implementation-specific definitions MUST use
+                              domain-prefixed names, such as `example.com/my-custom-option`.
+                              Un-prefixed names are reserved for key names defined by Gateway API.
+
+                              Support: Implementation-specific
+                            maxProperties: 16
+                            type: object
+                        type: object
+                        x-kubernetes-validations:
+                          - message: certificateRefs or options must be specified when mode is Terminate
+                            rule: 'self.mode == ''Terminate'' ? size(self.certificateRefs) > 0 || size(self.options) > 0 : true'
+                    required:
+                      - name
+                      - protocol
+                    type: object
+                  maxItems: 64
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+                  x-kubernetes-validations:
+                    - message: tls must not be specified for protocols ['HTTP', 'TCP', 'UDP']
+                      rule: 'self.all(l, l.protocol in [''HTTP'', ''TCP'', ''UDP''] ? !has(l.tls) : true)'
+                    - message: tls mode must be Terminate for protocol HTTPS
+                      rule: 'self.all(l, (l.protocol == ''HTTPS'' && has(l.tls)) ? (l.tls.mode == '''' || l.tls.mode == ''Terminate'') : true)'
+                    - message: hostname must not be specified for protocols ['TCP', 'UDP']
+                      rule: 'self.all(l, l.protocol in [''TCP'', ''UDP'']  ? (!has(l.hostname) || l.hostname == '''') : true)'
+                    - message: Listener name must be unique within the Gateway
+                      rule: self.all(l1, self.exists_one(l2, l1.name == l2.name))
+                    - message: Combination of port, protocol and hostname must be unique for each listener
+                      rule: 'self.all(l1, !has(l1.port) || self.exists_one(l2, has(l2.port) && l1.port == l2.port && l1.protocol == l2.protocol && (has(l1.hostname) && has(l2.hostname) ? l1.hostname == l2.hostname : !has(l1.hostname) && !has(l2.hostname))))'
+                parentRef:
+                  description: ParentRef references the Gateway that the listeners are attached to.
+                  properties:
+                    group:
+                      default: gateway.networking.k8s.io
+                      description: Group is the group of the referent.
+                      maxLength: 253
+                      pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    kind:
+                      default: Gateway
+                      description: Kind is kind of the referent. For example "Gateway".
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                      type: string
+                    name:
+                      description: Name is the name of the referent.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace is the namespace of the referent.  If not present,
+                        the namespace of the referent is assumed to be the same as
+                        the namespace of the referring object.
+                      maxLength: 63
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                  required:
+                    - name
+                  type: object
+              required:
+                - listeners
+                - parentRef
+              type: object
+            status:
+              default:
+                conditions:
+                  - lastTransitionTime: "1970-01-01T00:00:00Z"
+                    message: Waiting for controller
+                    reason: Pending
+                    status: Unknown
+                    type: Accepted
+                  - lastTransitionTime: "1970-01-01T00:00:00Z"
+                    message: Waiting for controller
+                    reason: Pending
+                    status: Unknown
+                    type: Programmed
+              description: Status defines the current state of ListenerSet.
+              properties:
+                conditions:
+                  default:
+                    - lastTransitionTime: "1970-01-01T00:00:00Z"
+                      message: Waiting for controller
+                      reason: Pending
+                      status: Unknown
+                      type: Accepted
+                    - lastTransitionTime: "1970-01-01T00:00:00Z"
+                      message: Waiting for controller
+                      reason: Pending
+                      status: Unknown
+                      type: Programmed
+                  description: |-
+                    Conditions describe the current conditions of the ListenerSet.
+
+                    Implementations MUST express ListenerSet conditions using the
+                    `ListenerSetConditionType` and `ListenerSetConditionReason`
+                    constants so that operators and tools can converge on a common
+                    vocabulary to describe ListenerSet state.
+
+                    Known condition types are:
+
+                    * "Accepted"
+                    * "Programmed"
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 8
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                listeners:
+                  description: Listeners provide status for each unique listener port defined in the Spec.
+                  items:
+                    description: ListenerStatus is the status associated with a Listener.
+                    properties:
+                      attachedRoutes:
+                        description: |-
+                          AttachedRoutes represents the total number of Routes that have been
+                          successfully attached to this Listener.
+
+                          Successful attachment of a Route to a Listener is based solely on the
+                          combination of the AllowedRoutes field on the corresponding Listener
+                          and the Route's ParentRefs field. A Route is successfully attached to
+                          a Listener when it is selected by the Listener's AllowedRoutes field
+                          AND the Route has a valid ParentRef selecting the whole Gateway
+                          resource or a specific Listener as a parent resource (more detail on
+                          attachment semantics can be found in the documentation on the various
+                          Route kinds ParentRefs fields). Listener or Route status does not impact
+                          successful attachment, i.e. the AttachedRoutes field count MUST be set
+                          for Listeners with condition Accepted: false and MUST count successfully
+                          attached Routes that may themselves have Accepted: false conditions.
+
+                          Uses for this field include troubleshooting Route attachment and
+                          measuring blast radius/impact of changes to a Listener.
+                        format: int32
+                        type: integer
+                      conditions:
+                        description: Conditions describe the current condition of this listener.
+                        items:
+                          description: Condition contains details for one aspect of the current state of this API Resource.
+                          properties:
+                            lastTransitionTime:
+                              description: |-
+                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                              format: date-time
+                              type: string
+                            message:
+                              description: |-
+                                message is a human readable message indicating details about the transition.
+                                This may be an empty string.
+                              maxLength: 32768
+                              type: string
+                            observedGeneration:
+                              description: |-
+                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                with respect to the current state of the instance.
+                              format: int64
+                              minimum: 0
+                              type: integer
+                            reason:
+                              description: |-
+                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                Producers of specific condition types may define expected values and meanings for this field,
+                                and whether the values are considered a guaranteed API.
+                                The value should be a CamelCase string.
+                                This field may not be empty.
+                              maxLength: 1024
+                              minLength: 1
+                              pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                              type: string
+                            status:
+                              description: status of the condition, one of True, False, Unknown.
+                              enum:
+                                - "True"
+                                - "False"
+                                - Unknown
+                              type: string
+                            type:
+                              description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                              maxLength: 316
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                          required:
+                            - lastTransitionTime
+                            - message
+                            - reason
+                            - status
+                            - type
+                          type: object
+                        maxItems: 8
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - type
+                        x-kubernetes-list-type: map
+                      name:
+                        description: Name is the name of the Listener that this status corresponds to.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      port:
+                        description: Port is the network port the listener is configured to listen on.
+                        format: int32
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      supportedKinds:
+                        description: |-
+                          SupportedKinds is the list indicating the Kinds supported by this
+                          listener. This MUST represent the kinds an implementation supports for
+                          that Listener configuration.
+
+                          If kinds are specified in Spec that are not supported, they MUST NOT
+                          appear in this list and an implementation MUST set the "ResolvedRefs"
+                          condition to "False" with the "InvalidRouteKinds" reason. If both valid
+                          and invalid Route kinds are specified, the implementation MUST
+                          reference the valid Route kinds that have been specified.
+                        items:
+                          description: RouteGroupKind indicates the group and kind of a Route resource.
+                          properties:
+                            group:
+                              default: gateway.networking.k8s.io
+                              description: Group is the group of the Route.
+                              maxLength: 253
+                              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                              type: string
+                            kind:
+                              description: Kind is the kind of the Route.
+                              maxLength: 63
+                              minLength: 1
+                              pattern: ^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$
+                              type: string
+                          required:
+                            - kind
+                          type: object
+                        maxItems: 8
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    required:
+                      - attachedRoutes
+                      - conditions
+                      - name
+                      - port
+                      - supportedKinds
+                    type: object
+                  maxItems: 64
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""

--- a/modules/kubernetes/cilium/gateway-api-crds.nix
+++ b/modules/kubernetes/cilium/gateway-api-crds.nix
@@ -1,9 +1,16 @@
-# Upstream gateway-api standard-channel CRDs — Cilium's chart doesn't
-# install them, and gatewayAPI.enabled (cilium/default.nix) silently no-ops
-# without them. Own applications.gateway-api-crds entry, not folded into
+# Upstream gateway-api CRDs — Cilium's chart doesn't install them, and
+# gatewayAPI.enabled (cilium/default.nix) silently no-ops without them.
+# Own applications.gateway-api-crds entry, not folded into
 # applications.cilium, so bumping this doesn't couple to the Cilium chart.
-# v1.4.1 matches what Cilium 1.19.6 (charts.cilium.cilium) requires. `config/crd`, not `config/crd/standard`: the latter has no
-# kustomization.yaml of its own.
+#
+# config/crd/experimental, not config/crd (the standard channel): Cilium
+# 1.19.6's operator unconditionally sets up a controller-runtime field
+# indexer for TLSRoute whenever gatewayAPI.enabled is true, even though it
+# lists TLSRoute as merely "optional" in its own resource-availability
+# check — so it hard-crashes at startup ("no matches for kind \"TLSRoute\"
+# in version \"gateway.networking.k8s.io/v1alpha2\"") without it, standard
+# channel alone isn't enough. experimental is a superset of standard (see
+# its own kustomization.yaml), not an add-on to it.
 #
 # The Renovate annotation below tracks this independently of Cilium's own
 # version — check the Cilium release notes for its required Gateway API
@@ -20,7 +27,7 @@ _: {
           rev = "v1.4.1";
           hash = "sha256-/GHyikcC2QGDN0ndpY6/xvSEEnpSsLrNU+lFElCKBs8=";
         };
-        path = "config/crd";
+        path = "config/crd/experimental";
       };
     };
 }


### PR DESCRIPTION
## Summary
- `cilium-operator` (1.19.6) unconditionally sets up a controller-runtime field indexer for the `TLSRoute` CRD whenever `gatewayAPI.enabled` is true, even though its own resource-availability check lists `TLSRoute` as merely "optional". Without the CRD it crash-loops at startup: `no matches for kind "TLSRoute" in version "gateway.networking.k8s.io/v1alpha2"`.
- `modules/kubernetes/cilium/gateway-api-crds.nix` only installed the Gateway API **standard** channel (`config/crd`), which doesn't include `TLSRoute`. Switched to `config/crd/experimental` — upstream's own superset of standard (confirmed by diffing the two kustomizations) — which does.
- Discovered after `node1` was fully rebooted (following #234) and `cilium-operator`'s pod restarted fresh for the first time since `gatewayAPI` was enabled, cascading into `cilium` itself crash-looping and most other pods stuck `Unknown` (no working CNI). This bug is unrelated to the storage/miroir change in #234 — just surfaced in the same window.

## Test plan
- [x] `nix run .#write-manifests` — regenerated CRDs now include `TLSRoute`/`TCPRoute`/`UDPRoute`/`XBackendTrafficPolicy`/`XListenerSet`; the 6 pre-existing CRDs pick up the experimental-channel annotations, nothing is removed
- [x] `nix flake check --print-build-logs` — full check passes
- [ ] `deploy node1` — the CRD bootstrap wave (`k3s-bootstrap-crds.service`) reapplies on deploy/reboot; confirm `cilium-operator` and `cilium` recover, then the rest of the cluster (`coredns`, `argocd`, etc.) follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PHp6KbkUNCtQLVUMQu8Sa