### PR TITLE
Add conservative power-saving aspect for node1

### DIFF
--- a/modules/den/aspects/power-saving/power-saving.nix
+++ b/modules/den/aspects/power-saving/power-saving.nix
@@ -1,0 +1,22 @@
+# Conservative host power-saving: safe on server hardware, no forced ASPM
+# or NIC energy-efficient-ethernet (real compatibility risk on trunk NICs).
+{
+  den.aspects.power-saving.nixos =
+    { pkgs, ... }:
+    {
+      # amd_pstate's "active" driver exposes AMD's CPPC/EPP power control,
+      # more efficient than the legacy acpi-cpufreq driver on Zen2+ CPUs.
+      # Harmless no-op if the CPU/firmware doesn't support it.
+      boot.kernelParams = [ "amd_pstate=active" ];
+      powerManagement.cpuFreqGovernor = "powersave";
+
+      systemd.services.powertop-autotune = {
+        description = "Apply powertop's recommended power-saving tunables";
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = "${pkgs.powertop}/bin/powertop --auto-tune";
+        };
+      };
+    };
+}

--- a/modules/hosts/node1.nix
+++ b/modules/hosts/node1.nix
@@ -105,6 +105,7 @@
     den.aspects.k3s-bootstrap
     den.aspects.k3s-openebs
     den.aspects.k3s-miroir
+    den.aspects.power-saving
   ];
 
   # Grants kid's "admin" access-policy group (modules/users/kid.nix) onto


### PR DESCRIPTION
## Summary
- New `den.aspects.power-saving` aspect: enables AMD's `amd_pstate=active` driver, sets the `powersave` cpufreq governor, and runs `powertop --auto-tune` at boot.
- Wired onto `node1` only (its only AMD host currently in the repo).
- Deliberately excludes forced PCIe ASPM and NIC energy-efficient-ethernet — both carry real instability/link-flap risk, and node1's single NIC (`enp36s0f1`) trunks storage and k3s VLANs, so an EEE-related flap would take down the cluster network.

## Test plan
- [x] `nix flake check --print-build-logs` passes (node1 NixOS configuration evaluates, treefmt clean).
- [ ] `deploy node1` to push the change.
- [ ] Reboot node1 (kernel param only applies on next boot) and confirm:
  - `scaling_driver` shows `amd-pstate*` (not `acpi-cpufreq`)
  - `scaling_governor` shows `powersave`
  - `systemctl status powertop-autotune` ran successfully
- [ ] `kubectl get nodes` / `kubectl get pods -A` healthy after reboot.
- [ ] Compare wattmeter idle draw before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)