### PR TITLE
Sweep all app manifests for Namespace/CRD resources in k3s bootstrap

### DIFF
--- a/modules/den/aspects/services/k3s/bootstrap.nix
+++ b/modules/den/aspects/services/k3s/bootstrap.nix
@@ -1,17 +1,21 @@
 # k3s bootstrap aspect — oneshot systemd services that apply manifests on
-# first boot, scoped to the app set in modules/clusters/prd.nix's
-# den.aspects.prd.includes (cilium + gateway-api-crds + coredns + argocd +
-# cert-manager).
+# first boot. Waves 0 and 1 sweep every app's rendered output under
+# manifests/prd/ for Namespace/CRD resources, whatever the app — cheap and
+# safe to apply early even for apps (miroir, sops-operator) whose own
+# workloads are left for ArgoCD to bring up later. Waves 2 onward apply a
+# specific, hand-picked subset of apps whose workloads the rest of the
+# chain (or the node itself) needs up before ArgoCD takes over: cilium +
+# cert-manager + coredns + argocd.
 #
 # Bakes the generated manifests into the NixOS image via `self` (the flake
 # source is a store path), so no git clone is needed on the node.
 #
 # Wave ordering:
-#   0. k3s-bootstrap-namespaces    — all Namespace resources from all apps
-#                                     (cilium, coredns, argocd, cert-manager)
-#   1. k3s-bootstrap-crds          — all CustomResourceDefinition resources from all apps
-#                                     (including the upstream Gateway API CRDs, modules/
-#                                     kubernetes/cilium/gateway-api-crds.nix), wait for
+#   0. k3s-bootstrap-namespaces    — all Namespace resources, every app
+#   1. k3s-bootstrap-crds          — all CustomResourceDefinition resources, every
+#                                     app (including the upstream Gateway API CRDs,
+#                                     modules/kubernetes/cilium/gateway-api-crds.nix),
+#                                     wait for the ones later waves need to be
 #                                     Established before proceeding
 #   2. k3s-bootstrap-cilium        — Cilium core manifests, wait for operator
 #                                     (operator registers Cilium CRDs at startup),
@@ -46,11 +50,18 @@
             name = "k3s-prd-${builtins.replaceStrings [ "/" "." ] [ "-" "-" ] name}";
           };
         ciliumDir = manifestPath "cilium";
-        gatewayApiCrdsDir = manifestPath "gateway-api-crds";
         corednsDir = manifestPath "coredns";
         argocdDir = manifestPath "argocd";
         certManagerDir = manifestPath "cert-manager";
         bootstrapFile = manifestPath "bootstrap.yaml";
+        # Every app's rendered output, namespaces and CRDs included — used by
+        # waves 0 and 1 below so a new app (e.g. miroir, sops-operator) gets
+        # its Namespace/CRD resources swept up automatically, instead of
+        # each needing its own dir added to a hand-maintained list here.
+        allManifestsDir = builtins.path {
+          path = self + "/manifests/prd";
+          name = "k3s-prd-all";
+        };
         hasCilium = host.hasAspect den.aspects.k3s-cilium;
         waitForApi = ''
           echo "Waiting for k3s API server..."
@@ -81,7 +92,7 @@
                 echo "Applying all Namespace resources..."
                 declare -a files
                 while IFS= read -r f; do files+=("-f" "$f"); done < <(
-                  find ${ciliumDir} ${corednsDir} ${argocdDir} ${certManagerDir} -name "Namespace-*.yaml" | sort
+                  find ${allManifestsDir} -name "Namespace-*.yaml" | sort
                 )
                 [[ ''${#files[@]} -gt 0 ]] && \
                   kubectl apply --server-side --force-conflicts --field-manager=argocd-controller "''${files[@]}"
@@ -117,7 +128,7 @@
                 echo "Applying all CRDs..."
                 declare -a files
                 while IFS= read -r f; do files+=("-f" "$f"); done < <(
-                  find ${ciliumDir} ${gatewayApiCrdsDir} ${argocdDir} ${certManagerDir} -name "CustomResourceDefinition-*.yaml" | sort
+                  find ${allManifestsDir} -name "CustomResourceDefinition-*.yaml" | sort
                 )
                 [[ ''${#files[@]} -gt 0 ]] && \
                   kubectl apply --server-side --force-conflicts --field-manager=argocd-controller "''${files[@]}"
@@ -147,6 +158,13 @@
                   crd/grpcroutes.gateway.networking.k8s.io \
                   crd/referencegrants.gateway.networking.k8s.io \
                   crd/backendtlspolicies.gateway.networking.k8s.io \
+                  --timeout=60s
+
+                echo "Waiting for sops-operator CRDs to be established..."
+                kubectl wait --for=condition=Established \
+                  crd/sopssecrets.addons.projectcapsule.dev \
+                  crd/globalsopssecrets.addons.projectcapsule.dev \
+                  crd/sopsproviders.addons.projectcapsule.dev \
                   --timeout=60s
 
                 echo "CRDs ready."

--- a/modules/den/aspects/services/k3s/sops-operator.nix
+++ b/modules/den/aspects/services/k3s/sops-operator.nix
@@ -11,7 +11,8 @@
 # A standalone oneshot, not joined to the k3s-bootstrap wave (modules/den/
 # aspects/services/k3s/bootstrap.nix) — sops-operator itself is an
 # ArgoCD-synced app (modules/kubernetes/sops-operator/default.nix), not
-# part of that bootstrap chain, and nothing in that chain needs a secret.
+# part of that bootstrap chain. Its CRDs are registered by that chain's own
+# wave 1 though, since cert-manager's manifests include a SopsSecret CR.
 {
   inputs,
   ...


### PR DESCRIPTION
## Summary
- `k3s-bootstrap-cert-manager` failed on node1: cert-manager's manifests include a `SopsSecret` custom resource (#240), but its CRD only exists under `manifests/prd/sops-operator/`, which wave 1 (`k3s-bootstrap-crds`) never scanned.
- Waves 0 and 1 used a hand-maintained list of app directories that predated sops-operator, and had the same gap for `miroir`'s CRDs/namespace.
- Point both waves at the whole `manifests/prd/` tree instead, so a new app's Namespace/CRD resources get picked up automatically.

## Test plan
- [x] `nix flake check --print-build-logs` passes
- [x] Built `k3s-bootstrap-namespaces`/`k3s-bootstrap-crds` ExecStart scripts locally and confirmed they now `find` across `manifests/prd/` (picking up sops-operator's and miroir's CRDs/namespaces)
- [ ] `deploy node1` and confirm `k3s-bootstrap-cert-manager`, `k3s-bootstrap-coredns`, `k3s-bootstrap-argocd` all succeed

https://claude.ai/code/session_01CezjyaVpC3FVPTUECp7cMR