### PR TITLE
Pin sops-operator's image tag+digest

### DIFF
--- a/manifests/prd/sops-operator/Deployment-sops-operator.yaml
+++ b/manifests/prd/sops-operator/Deployment-sops-operator.yaml
@@ -29,7 +29,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: ghcr.io/peak-scale/sops-operator:0.0.0
+          image: ghcr.io/peak-scale/sops-operator:0.10.1@sha256:1da9b716b79210f51b1c757b4d5c3bab57df9fdc74e67f2fa274d33603492fd4
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/modules/kubernetes/sops-operator/default.nix
+++ b/modules/kubernetes/sops-operator/default.nix
@@ -47,6 +47,8 @@ _: {
           inherit chart;
           values = {
             crds.install = true;
+            # renovate: datasource=docker depName=ghcr.io/peak-scale/sops-operator
+            image.tag = "0.10.1@sha256:1da9b716b79210f51b1c757b4d5c3bab57df9fdc74e67f2fa274d33603492fd4";
           };
         };
 


### PR DESCRIPTION
## Summary
- The `sops-operator` ArgoCD Application was `Degraded` on node1: `ImagePullBackOff` on `ghcr.io/peak-scale/sops-operator:0.0.0`.
- Root cause: the chart's `Chart.yaml` ships `appVersion: "0.0.0"` (a placeholder upstream never sets — confirmed unchanged across chart versions), and `image.tag` was never overridden in our values, so it fell back to that placeholder.
- Verified `0.10.1` (matching the chart's own pinned `rev`) is actually published on `ghcr.io` (my first check used a paginated tag-list endpoint and missed it; a direct manifest HEAD request confirmed it exists). Pinned by tag+digest.
- Tracked by Renovate going forward via the repo's existing `customManagers` convention for `modules/kubernetes/**/*.nix` pins (`# renovate: datasource=docker depName=...`).

## Test plan
- [x] `nix flake check --print-build-logs` passes
- [x] `nix run .#write-manifests` — `manifests/prd/sops-operator/Deployment-sops-operator.yaml` now references `ghcr.io/peak-scale/sops-operator:0.10.1@sha256:1da9b716b79210f51b1c757b4d5c3bab57df9fdc74e67f2fa274d33603492fd4`
- [ ] `deploy node1` and confirm the `sops-operator` pod goes `Running` and the ArgoCD Application health turns `Healthy`

https://claude.ai/code/session_01CezjyaVpC3FVPTUECp7cMR