### PR TITLE
Add Let's Encrypt production ClusterIssuer for cert-manager

### DIFF
--- a/manifests/prd/cert-manager/ClusterIssuer-letsencrypt-prod.yaml
+++ b/manifests/prd/cert-manager/ClusterIssuer-letsencrypt-prod.yaml
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: arnaud.rebts@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    server: https://acme-v02.api.letsencrypt.org/directory
+    solvers:
+      - dns01:
+          cloudflare:
+            apiTokenSecretRef:
+              key: token
+              name: cloudflare-dns-api-token

--- a/manifests/prd/cert-manager/SopsSecret-cloudflare-dns-api-token.yaml
+++ b/manifests/prd/cert-manager/SopsSecret-cloudflare-dns-api-token.yaml
@@ -7,40 +7,40 @@ spec:
   secrets:
     - name: cloudflare-dns-api-token
       stringData:
-        token: ENC[AES256_GCM,data:hQzD38Hx8LeIb8zGwOpILWKFNk89o5vazC0y,iv:XVZXDEinyf484QxrBFM62yyyoBpNk30D90WhG7TKZuo=,tag:McKm0itp4fqzySNfb05ygQ==,type:str]
+        token: ENC[AES256_GCM,data:CGbhENvhemnBs2Sk88XBoMRHFGMQQPPv/vWJWavruBNiK+EWWiw/inClNzsdsnAYJ1GBE8U=,iv:K8tRm5p2u2/9s6eRecqGPzEky/8GKe28JZbBz0Le6kU=,tag:ExdSyiOGzmBh4NFT0JeNHA==,type:str]
 sops:
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IFE1WkIwUSA5WnlT
-        NUE5aE5uV2QvM2V5Q2t4bFpMMHNKL1FkcG9acUdtdjY4aHczQWhBCnZJcEZuUGVt
-        d0s3b21VNWMrWWxDbk1mZXYwVWlkOHVLa09wdDhaaVdxUmcKLS0tIGZNaFFXUE1P
-        UXIxaWtLOFJqMk5aeURJUkdBQm4yTkFINVVCRGcyOENDMU0Kcjf/yljRtARGRS2F
-        lwaFrKgBVsgXkrlELE7N/qsOm60tcxIUrNAGci2DvKTgiwbSzopxnjHp11sR9v1u
-        +yqQGg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IFE1WkIwUSAzZUJi
+        T25QQ3Awb1EyL0xZMXBxbUpRSndrV0J1QkQ0QWVtVWdUcEZ0UnpNCk9xYTZrc2oz
+        UjMzS1ltZWM3bXpMT0h6dGd3WktvRHhaQVRxazE0VlZTTEEKLS0tIDdDaHBwcGEx
+        UUVTQU5Ec0J4U29CWTlsSEhNTU14R3lnWldkcTMzWWZmamMKazxKWFTPBK9h4fwH
+        2gEnxqDRgxbCwt6Ck5XL9nUGTGU7yncnk9m6apza0E9uvsqTtZuXB1Nq6nFPCL0p
+        BlAkRg==
         -----END AGE ENCRYPTED FILE-----
       recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAcnmLrPeTJeKsasfU0qn4sP4lBNeOUgRG4iZDS8nyEo kid@vulkan
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IE1Wa1kxQSBjd01M
-        OFphdStaVGp1VzZtSi9xamFZVXJQMzZXQ2VQWEsyS0pUNEY0ZHg4CkEvUWoxeFJt
-        MmZsWC9DS28rUmMybGxVL2xaTEVtbUF5cmNGdnRHcVRCRW8KLS0tIGYrMTlFbXZr
-        YU4wMkV3dHF0SjlZZENSbXRITDh1bmVMU3ZGMFY3TERjdUEKu6DSfMkV9m/5yTq4
-        kEPklIGO9IbiPjPQDu2epK1+qmOzqvCt7WPOoafLEtahnGOElAKWYHCpbaACNLwu
-        JoAXkQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IHNzaC1lZDI1NTE5IE1Wa1kxQSBKZHhu
+        ODRpMkxtblg1b2EyU1NQQkRPdDNvOG44ZFFrc2tRS0tMUTlvL0NBCktoYVRwMmxu
+        OFpkdm9ZODNRblJsUUVuSjBHK2ZOQWxUV2E0ZVlQaDIrUDQKLS0tIEdqY1BpTzRX
+        amRqU0RSTi9iY1RHZ09LVm9YOTdRUHA3dG90alZFcnIyUncKGuh/5plELiEbRrUW
+        pO8yUXxSdxA9otN5fDi5Mj5zZRh7GAHPGtzIRrJEjN446YG4JdorAf+TJ+4Mfibj
+        zOpNdg==
         -----END AGE ENCRYPTED FILE-----
       recipient: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHIM3nsk3HxvEcplSqwynh9V2NzlYdI10mrR746SiJZb kid@fw13
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrR2crZTU2eUp6MnJLOEY0
-        ZmZNTit3dXNET2JhOHA2QzYxUTdoWnY4TFNzCjdUaitZTjZ2QWlKbWxpalJqM0pQ
-        azBCQ09SWFNGWUs0MFhKUGJhVlFNNE0KLS0tIGs3M3EzdlRJbkpiRmtQZFdINTVp
-        NHhJTTFGN2xkSTM3ZHFhL3R1dWdsUm8K2UJVwI5mfh33plbLL/AUockAkhD77Aa4
-        EiVORvGk06f3XOmaoCdXk5li3Kqzzg05XZ8CyxsAtEoLeWYocdKTLQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA0MUZqUjNkendZTjE1NWs0
+        dTFvZlVJdTlnRDNlK1EwdDhMZjhlL2l4SEZrCkU4MlNRRnhaTnhXOXZhU0p1MXJh
+        bmxGMHArZkVlSmZyS1JPUnVtYngyWFkKLS0tIEczU0hSanNVUlY3TEp5U0c5YTkw
+        R3kzaW9jRFZxR3FtL2FLdHRhSmxUUUUKrh51lq0x+hMqLrQztlgHzCL04KUxN7Nn
+        npbL2ugvGjGT3aE8FtVwURE9eJ7/tcwrz7fhX5mPfWvAM7FzfFXdrA==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1crlwx4k0eaq666fa8dqpq3k9rhkm8qvwf3ewuum8s8hmrzrm55fsl3tk8h
   encrypted_regex: ^(data|stringData)$
-  lastmodified: "2026-08-18T15:46:40Z"
-  mac: ENC[AES256_GCM,data:0IWfzMejoGR/COhBuoF6zhyQylEq+2w86HQcJaDAu8H+YFf8TKqRTGF82ImJeZT7FY5NRJyWbCZGkDxsj5e/LgB2w7neVEBel29VgPXr7KIToS/NmQpPhHn+Vp88YwdQjE8bGTFzga1oMpL+F4QAGTzIeBhEhHiwSacmefJfhwQ=,iv:ixsboKEr2miR1oOBHPwMz4mx+DjKqTsbQ5ZybxJxNIg=,tag:DpkffL2Up6J6ba6+wQEOSA==,type:str]
+  lastmodified: "2026-08-20T14:21:08Z"
+  mac: ENC[AES256_GCM,data:4bcFHuSDysWjvxXer75zbUSdv2Y5C6w+dwc8GhdjWIL4Ecr3gYYxN/vZutE0TRsMZWUdDaxyj5yUcoU+6+6nhKWm1WZok1lFlF0Da0CUdmT3xrMCpCvLuGDDrtAG850VkaFx1mtxG+BXmczh3RMN82Dr7gvH9XuK/qg4ihoeVPY=,iv:gCbqpVwYbRVzZhSnyEugmMx8hNJwy8QAWzJ0t+oyTKE=,tag:xlLzdmx7PaJHicHzeJngJw==,type:str]
   mac_only_encrypted: true
   version: 3.13.3

--- a/modules/kubernetes/cert-manager/default.nix
+++ b/modules/kubernetes/cert-manager/default.nix
@@ -80,6 +80,20 @@ _: {
 
         resources.clusterIssuers.hubble-ca-issuer.spec.ca.secretName = "hubble-ca-secret";
 
+        resources.clusterIssuers.letsencrypt-prod.spec.acme = {
+          server = "https://acme-v02.api.letsencrypt.org/directory";
+          email = "arnaud.rebts@gmail.com";
+          privateKeySecretRef.name = "letsencrypt-prod-account-key";
+          solvers = [
+            {
+              dns01.cloudflare.apiTokenSecretRef = {
+                name = "cloudflare-dns-api-token";
+                key = "token";
+              };
+            }
+          ];
+        };
+
         yamls = [ cloudflareDnsApiToken ];
       };
     };

--- a/secrets/clusters/prd/cert-manager/cloudflare-dns-api-token.sops.json
+++ b/secrets/clusters/prd/cert-manager/cloudflare-dns-api-token.sops.json
@@ -1,5 +1,5 @@
 {
-	"token": "ENC[AES256_GCM,data:G7apMErKuyVoKoSS+PG1JwxJEoHfpq8NpFpV,iv:0JX5YCIT4HxO49gfvpXTanU9kI04S7uG1ZJJ/XkHEYs=,tag:DD0rzwiUaiv+ayVUYNoiAw==,type:str]",
+	"token": "ENC[AES256_GCM,data:exudFKtic5S8tF+zlM7xdjPJ9nDkyWLXepSAHmnKhj1VVMaN2aT80yjXI4cCsJ8jKGVOdns=,iv:PL4ZVvf5s/oWxh8yTQyvJF9FXHE5XC9+k8rLfCpeJOI=,tag:gR0wQwXkvGaXL1/EjSPQVA==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -19,8 +19,8 @@
 				"recipient": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILkFKxaxcAS/tQuS8Gfk8xaHSLDAm1VCPHo8M7umUdVJ root@node1"
 			}
 		],
-		"lastmodified": "2026-08-17T20:12:56Z",
-		"mac": "ENC[AES256_GCM,data:xu34v/NeHnSh9Ymk7RK7Jx+v6pqDAZ71vcewbUAkgTj71kSgBa27/YviC/+83K64OoDePMS9lJXPxlIi0//BjvNU9QuxKD5aB+4RpMb8sGftv9BWm2X+Jg/ou1nxTyKVUgNI1odmmQdn4z9mW34kKZzghQxU+rBYGhPhq3wDulU=,iv:epjvun6tu1sCB9XbHJbubWi+R3Vu2SVDyeL/FJTXVVU=,tag:et/dnKSlnMmk2sC0ES0fmA==,type:str]",
+		"lastmodified": "2026-08-18T16:32:39Z",
+		"mac": "ENC[AES256_GCM,data:qk0I5ocmLXPBpbvVB0p32230IOBGJwOJO6tD9VVs6oOKPA/y2ngzlilGRUjJT19rYoh8AOPWFK7XwkZ3cWkwjCHWfplNrU2yhY+Q4P3sw9NhqBKV6+6dT9G0h3ZC8EMIRi/YeZ4CuaHjtJp43vfRqnPySVKXshZRJ6pu2TOuQAM=,iv:rD+CgvkFfhaX1wCgMaF5w3A4Z+U25gQdhKi43X6vMOI=,tag:q/kTAIESP12eqq5qyzpdZA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.13.3"
 	}


### PR DESCRIPTION
## Summary
- Adds a `letsencrypt-prod` ClusterIssuer to cert-manager, using ACME DNS-01 validation via Cloudflare.
- Reuses the existing `cloudflare-dns-api-token` Secret for the DNS-01 solver.
- Re-encrypts the Cloudflare DNS API token secret with the updated value.

## Test plan
- [x] `nix run .#write-manifests` — regenerated `manifests/prd/cert-manager/ClusterIssuer-letsencrypt-prod.yaml`
- [x] `nix flake check --print-build-logs` — all checks pass
- [ ] Confirm a real `Certificate` resource resolves against `letsencrypt-prod` once an app references it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CezjyaVpC3FVPTUECp7cMR