### PR TITLE
Route all pod egress via Cilium Egress Gateway; restrict node1 SSH to Servers

### DIFF
--- a/manifests/prd/cilium/CiliumEgressGatewayPolicy-egress-gateway.yaml
+++ b/manifests/prd/cilium/CiliumEgressGatewayPolicy-egress-gateway.yaml
@@ -1,0 +1,14 @@
+apiVersion: cilium.io/v2
+kind: CiliumEgressGatewayPolicy
+metadata:
+  name: egress-gateway
+spec:
+  destinationCIDRs:
+    - 0.0.0.0/0
+  egressGateway:
+    interface: k3s
+    nodeSelector:
+      matchLabels:
+        kidibox.net/egress-gateway: "true"
+  selectors:
+    - podSelector: {}

--- a/manifests/prd/cilium/ConfigMap-cilium-config.yaml
+++ b/manifests/prd/cilium/ConfigMap-cilium-config.yaml
@@ -54,6 +54,7 @@ data:
   enable-drift-checker: "true"
   enable-dynamic-config: "true"
   enable-dynamic-source-lookup-nodeport: "false"
+  enable-egress-gateway: "true"
   enable-endpoint-health-checking: "true"
   enable-endpoint-lockdown-on-policy-overflow: "false"
   enable-envoy-config: "true"

--- a/modules/clusters/prd.nix
+++ b/modules/clusters/prd.nix
@@ -88,6 +88,7 @@ in
     gateway-api-crds
     cilium
     cilium-bgp
+    cilium-egress-gateway
     cert-manager
     coredns
     argocd

--- a/modules/hosts/node1.nix
+++ b/modules/hosts/node1.nix
@@ -38,6 +38,10 @@
       boot.loader.systemd-boot.enable = true;
       boot.loader.efi.canTouchEfiVariables = true;
 
+      services.k3s.extraFlags = [
+        "--node-label=kidibox.net/egress-gateway=true"
+      ];
+
       networking.hostId = lib.mkDefault "795500d2";
 
       networking.hostName = "node1";

--- a/modules/hosts/node1.nix
+++ b/modules/hosts/node1.nix
@@ -2,6 +2,9 @@
 # NFS storage. Installs directly onto real hardware via nixos-anywhere
 # (`nix run .#nixos-anywhere-install`, modules/flake/nixos-anywhere.nix).
 { den, config, ... }:
+let
+  nodeAddress = config.den.devices.node1.address;
+in
 {
   den.hosts.x86_64-linux.node1 = {
     k3s.clusterName = "prd";
@@ -92,7 +95,15 @@
 
       users.mutableUsers = false;
 
-      services.openssh.enable = true;
+      services.openssh = {
+        enable = true;
+        listenAddresses = [
+          {
+            addr = nodeAddress;
+            port = 22;
+          }
+        ];
+      };
 
       system.stateVersion = "26.05";
 

--- a/modules/kubernetes/cilium/default.nix
+++ b/modules/kubernetes/cilium/default.nix
@@ -26,6 +26,7 @@ _: {
             };
 
             bpf.masquerade = true;
+            egressGateway.enabled = true;
 
             bgpControlPlane.enabled = true;
 

--- a/modules/kubernetes/cilium/egress-gateway.nix
+++ b/modules/kubernetes/cilium/egress-gateway.nix
@@ -1,0 +1,26 @@
+# CiliumEgressGatewayPolicy is a native Cilium CRD, installed by the
+# cilium-operator at runtime rather than bundled in the chart's own crds/
+# (Cilium ships none) — same reason bgp.nix uses raw YAML instead of
+# generators.fromChartCRDModule.
+_: {
+  den.aspects.cilium-egress-gateway.k8s-manifests = _: {
+    applications.cilium.yamls = [
+      ''
+        apiVersion: cilium.io/v2
+        kind: CiliumEgressGatewayPolicy
+        metadata:
+          name: egress-gateway
+        spec:
+          selectors:
+            - podSelector: {}
+          destinationCIDRs:
+            - "0.0.0.0/0"
+          egressGateway:
+            nodeSelector:
+              matchLabels:
+                kidibox.net/egress-gateway: "true"
+            interface: k3s
+      ''
+    ];
+  };
+}


### PR DESCRIPTION
## Summary
- **Root cause of the external-dns/MikroTik connectivity failure (#245):** `node1` is multi-homed (Servers/K3s/Storage VLANs). The kernel's own routing table sends all outbound traffic — including pod traffic — via the Servers interface regardless of the pod's originating network, so nothing from the cluster ever reached rb5009's Management API even though the firewall already allowed it on the K3s-facing chain (`input-K3s`). Confirmed directly on both `node1` (`ip route get 10.99.0.1`, plain `curl` from the host) and on rb5009 (`/ip firewall connection print` showed literally nothing arriving from node1).
- Adds a `CiliumEgressGatewayPolicy` (`modules/kubernetes/cilium/egress-gateway.nix`) that SNATs **all** pod egress traffic, any destination, through a `kidibox.net/egress-gateway: "true"`-labeled node's `k3s` interface — independent of the host's own default-route choice. Deliberately cluster-wide rather than Management-CIDR-specific, so K3s becomes the one deterministic egress path for pod traffic and any future consumer (e.g. mikrotik-exporter) needs no policy change.
- Raw YAML (`applications.cilium.yamls`), not nixidy's typed CRD generator — confirmed Cilium's chart ships no `crds/` directory (its CRDs are installed by the running `cilium-operator`), so `generators.fromChartCRDModule` can't introspect them. Matches the existing pattern already used in `modules/kubernetes/cilium/bgp.nix` for the same reason.
- `modules/hosts/node1.nix` gets the `kidibox.net/egress-gateway=true` k3s node label (generic, not hostname-pinned, so a second node just needs the same flag) and, in a **separate commit**, restricts `sshd` to node1's Servers address only (previously reachable from every VLAN node1 touches).

## Test plan
- [x] `nix run .#write-manifests` — rendered `manifests/prd/cilium/CiliumEgressGatewayPolicy-egress-gateway.yaml`
- [x] `nix flake check --print-build-logs` — all checks pass
- [x] `nix build .#nixosConfigurations.node1.config.system.build.toplevel` — builds cleanly; confirmed `--node-label=kidibox.net/egress-gateway=true` in the built k3s unit and `ListenAddress 10.0.10.10:22` in the built sshd config
- [ ] After merge: `deploy node1` (applies the node label + SSH restriction) and let ArgoCD sync (applies the Cilium Helm value + policy) — label should land before/alongside the policy sync
- [ ] `kubectl get ciliumegressgatewaypolicy egress-gateway -o yaml` — check `.status`
- [ ] Re-test the external-dns webhook pod reaches `10.99.0.1:443` and goes `Ready`
- [ ] Spot-check general pod egress (e.g. internet-bound) still works post-change
- [ ] From a Management-VLAN host, confirm SSH to node1 now fails, while `ssh kid@10.0.10.10` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CezjyaVpC3FVPTUECp7cMR